### PR TITLE
Add aggregate required CI status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,60 @@ jobs:
 
       - name: Check MSRV
         run: cargo check --all-targets
+
+  zizmor:
+    name: GitHub Actions security
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color
+
+  required:
+    name: Required
+    # Stable branch-protection and automerge target. The underlying jobs can be
+    # split or renamed later without changing the single required status.
+    runs-on: ubuntu-latest
+    needs:
+      - check
+      - markdown
+      - msrv
+      - zizmor
+      - actionlint
+    if: ${{ always() }}
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+          HAS_FAILED_JOB: >-
+            ${{
+              contains(needs.*.result, 'failure')
+              || contains(needs.*.result, 'cancelled')
+              || contains(needs.*.result, 'skipped')
+            }}
+        run: |
+          echo "$NEEDS_JSON"
+          test "$HAS_FAILED_JOB" = "false"


### PR DESCRIPTION
## Summary

- add a `Required` aggregate job to CI
- add `zizmor` for GitHub Actions security checks
- add `actionlint` for workflow validation
- keep `Check`, `Markdown`, and `MSRV` as separate diagnostic jobs

## Context

Betamax, tui-widgets, and ratatui-labs use the same useful shape: individual jobs stay focused, safety checks run explicitly, and branch protection/auto-merge can depend on one stable `Required` status while the implementation jobs can split, rename, or grow independently.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'`
- `actionlint .github/workflows/ci.yml`
- `zizmor .github/workflows/ci.yml`
