### PR TITLE
Prevent release-plz stale PR race

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,7 +14,22 @@ jobs:
     # Only the canonical repository should publish crates or create releases.
     # Forks can still run CI, but release jobs would fail without trusted
     # credentials and would be surprising for contributors.
-    if: ${{ github.repository_owner == 'joshka' }}
+    #
+    # This job enters the protected `release` environment. Keep it off ordinary
+    # `main` pushes so non-release merges do not require release approval.
+    #
+    # release-plz release PRs are merged with squash commits whose subjects are
+    # `chore: release` or the older `chore(<package>): release ...` form.
+    # Manual dispatch remains available for repair.
+    if: >-
+      ${{
+        github.repository_owner == 'joshka' &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          startsWith(github.event.head_commit.message, 'chore: release') ||
+          contains(github.event.head_commit.message, '): release')
+        )
+      }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -149,9 +164,20 @@ jobs:
 
   release-pr:
     name: Release-plz PR
-    # The release PR should be maintained only from pushes to the canonical
-    # repository. Manual workflow_dispatch is for publishing/rerunning releases.
-    if: ${{ github.repository_owner == 'joshka' && github.event_name == 'push' }}
+    # release-plz's quickstart runs `release` and `release-pr` as sibling jobs
+    # on every `main` push. In this repo the release job publishes through a
+    # protected environment and then uploads binary assets in the same workflow
+    # run. If `release-pr` also runs on a release-PR merge, it can read crates.io
+    # before the sibling publish finishes and open a stale PR for the version
+    # being released. Skip release commits here; the next ordinary merge will
+    # refresh the release PR.
+    if: >-
+      ${{
+        github.repository_owner == 'joshka' &&
+        github.event_name == 'push' &&
+        !startsWith(github.event.head_commit.message, 'chore: release') &&
+        !contains(github.event.head_commit.message, '): release')
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- gate `release` so it only runs for release-merge commits or manual dispatch
- gate `release-pr` so it skips release-merge commits
- document why the guards are needed for this repo's protected release environment and asset upload flow

## Why

PR #19 was opened after PR #17 merged even though v0.2.1 was already being published. The push workflow started `release` and `release-pr` as sibling jobs. `release-pr` finished while `release` was still publishing, so it read stale registry/release state and opened a duplicate changelog-only release PR.

This matches the race fixed in Betamax and ratatui-labs: release commits should publish, ordinary commits should refresh the release PR, and those two paths should not run against each other.

## Verification

- `actionlint .github/workflows/release-plz.yml .github/workflows/ci.yml`
- `zizmor .github/workflows/release-plz.yml .github/workflows/ci.yml`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "#{p} parses" }' .github/workflows/release-plz.yml .github/workflows/ci.yml`
- `just lint-md`
