### PR TITLE
Polish diff navigation and folding

### DIFF
--- a/.plans/0006-selected-change-diff.md
+++ b/.plans/0006-selected-change-diff.md
@@ -68,6 +68,8 @@ Hunk-level collapse remains out of scope.
    shown in the status line when shifted.
 1. Hunk navigation: `{` and `}` jump to previous and next unified diff hunk headers, updating the
    current file selection when movement crosses file boundaries.
+1. Hunk folding: `-` folds the current hunk body and `+` unfolds it while keeping the hunk header
+   visible.
 
 ## Validation
 

--- a/.plans/0006-selected-change-diff.md
+++ b/.plans/0006-selected-change-diff.md
@@ -75,6 +75,8 @@ Hunk-level collapse remains out of scope.
 1. Empty and error states: an empty `jj diff` body renders an intentional no-diff message, and
    initial `jk diff REV` load failures open a retryable diff view instead of exiting before the TUI
    starts.
+1. Visual review: Betamax screenshots were inspected for the pinned file header, help overlay,
+   search status, folded file row, and horizontal-scroll behavior in a real terminal rendering.
 
 ## Validation
 

--- a/.plans/0006-selected-change-diff.md
+++ b/.plans/0006-selected-change-diff.md
@@ -58,6 +58,11 @@ Hunk-level collapse remains out of scope.
 - Collapsed file sections survive refresh when the file still exists.
 - Tests cover target selection, refresh, return navigation, and collapse state.
 
+## Follow-Up Slices
+
+1. Diff search: `/` opens a search prompt, Enter jumps to the first visible line match, and `n`/`N`
+   repeat the last search forward or backward with wrapping.
+
 ## Validation
 
 - `cargo test -p jk-cli -p jk-tui -p jk --lib --bins`

--- a/.plans/0006-selected-change-diff.md
+++ b/.plans/0006-selected-change-diff.md
@@ -64,6 +64,8 @@ Hunk-level collapse remains out of scope.
    repeat the last search forward or backward with wrapping.
 1. Current-file context: when the real file header scrolls offscreen, the pinned header includes
    the same stat suffix and a compact file index such as `[file 1/3]`.
+1. Horizontal overflow: `<` and `>` scroll wide diff content horizontally, with the current column
+   shown in the status line when shifted.
 
 ## Validation
 

--- a/.plans/0006-selected-change-diff.md
+++ b/.plans/0006-selected-change-diff.md
@@ -66,6 +66,8 @@ Hunk-level collapse remains out of scope.
    the same stat suffix and a compact file index such as `[file 1/3]`.
 1. Horizontal overflow: `<` and `>` scroll wide diff content horizontally, with the current column
    shown in the status line when shifted.
+1. Hunk navigation: `{` and `}` jump to previous and next unified diff hunk headers, updating the
+   current file selection when movement crosses file boundaries.
 
 ## Validation
 

--- a/.plans/0006-selected-change-diff.md
+++ b/.plans/0006-selected-change-diff.md
@@ -72,6 +72,9 @@ Hunk-level collapse remains out of scope.
    visible.
 1. Mode-specific help: `?` opens a compact overlay for the active log or diff mode, keeping the
    status line focused on the most common commands.
+1. Empty and error states: an empty `jj diff` body renders an intentional no-diff message, and
+   initial `jk diff REV` load failures open a retryable diff view instead of exiting before the TUI
+   starts.
 
 ## Validation
 

--- a/.plans/0006-selected-change-diff.md
+++ b/.plans/0006-selected-change-diff.md
@@ -62,6 +62,8 @@ Hunk-level collapse remains out of scope.
 
 1. Diff search: `/` opens a search prompt, Enter jumps to the first visible line match, and `n`/`N`
    repeat the last search forward or backward with wrapping.
+1. Current-file context: when the real file header scrolls offscreen, the pinned header includes
+   the same stat suffix and a compact file index such as `[file 1/3]`.
 
 ## Validation
 

--- a/.plans/0006-selected-change-diff.md
+++ b/.plans/0006-selected-change-diff.md
@@ -77,6 +77,8 @@ Hunk-level collapse remains out of scope.
    starts.
 1. Visual review: Betamax screenshots were inspected for the pinned file header, help overlay,
    search status, folded file row, and horizontal-scroll behavior in a real terminal rendering.
+1. Visual tapes: `tapes/jk-diff.tape` records opening the selected diff, help, search, hunk
+   navigation, hunk/file folding, horizontal scroll, and return-to-log behavior.
 
 ## Validation
 

--- a/.plans/0006-selected-change-diff.md
+++ b/.plans/0006-selected-change-diff.md
@@ -70,6 +70,8 @@ Hunk-level collapse remains out of scope.
    current file selection when movement crosses file boundaries.
 1. Hunk folding: `-` folds the current hunk body and `+` unfolds it while keeping the hunk header
    visible.
+1. Mode-specific help: `?` opens a compact overlay for the active log or diff mode, keeping the
+   status line focused on the most common commands.
 
 ## Validation
 

--- a/crates/jk-tui/src/chrome.rs
+++ b/crates/jk-tui/src/chrome.rs
@@ -13,7 +13,8 @@ pub const LOG_STATUS: &str =
     "H home  L log  d diff  r refresh  j/k move  space page  enter/right expand  q quit";
 
 /// Default diff-view status text shown when there is no transient error.
-pub const DIFF_STATUS: &str = "H/L log  r refresh  j/k line  space page  [/]: file  h/left fold  l/right unfold  ctrl+arrows all";
+pub const DIFF_STATUS: &str =
+    "H/L log  r refresh  j/k line  space page  [/]: file  </> hscroll  h/left fold  l/right unfold";
 
 const DEFAULT_TITLE: &str = "jj log";
 

--- a/crates/jk-tui/src/chrome.rs
+++ b/crates/jk-tui/src/chrome.rs
@@ -5,16 +5,56 @@
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::prelude::{Color, Line, Modifier, Span, Style};
-use ratatui::widgets::Paragraph;
+use ratatui::prelude::{Color, Line, Modifier, Span, Style, Text};
+use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 
 /// Default log-view status text shown when there is no transient error.
 pub const LOG_STATUS: &str =
-    "H home  L log  d diff  r refresh  j/k move  space page  enter/right expand  q quit";
+    "? help  H home  L log  d diff  r refresh  j/k move  space page  q quit";
 
 /// Default diff-view status text shown when there is no transient error.
-pub const DIFF_STATUS: &str =
-    "H/L log  r refresh  j/k line  space page  [/]: file  {/}: hunk  -/+ fold hunk  h/l fold file";
+pub const DIFF_STATUS: &str = "? help  r refresh  j/k line  space page  q quit";
+
+/// Renders a small mode-specific help overlay centered in the content area.
+pub fn render_help_overlay(frame: &mut Frame<'_>, area: Rect, title: &str, lines: &[&str]) {
+    if area.is_empty() {
+        return;
+    }
+
+    let overlay = centered_rect(area, 72, lines.len().saturating_add(4));
+    frame.render_widget(Clear, overlay);
+
+    let text = Text::from(
+        std::iter::once(Line::from(Span::styled(
+            title,
+            Style::new().add_modifier(Modifier::BOLD),
+        )))
+        .chain(std::iter::once(Line::from("")))
+        .chain(lines.iter().copied().map(Line::from))
+        .collect::<Vec<_>>(),
+    );
+    let paragraph = Paragraph::new(text)
+        .block(Block::bordered())
+        .style(Style::new().fg(Color::White).bg(Color::Black))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, overlay);
+}
+
+fn centered_rect(area: Rect, preferred_width: usize, preferred_height: usize) -> Rect {
+    let width = u16::try_from(preferred_width)
+        .unwrap_or(u16::MAX)
+        .min(area.width);
+    let height = u16::try_from(preferred_height)
+        .unwrap_or(u16::MAX)
+        .min(area.height);
+
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
 
 const DEFAULT_TITLE: &str = "jj log";
 

--- a/crates/jk-tui/src/chrome.rs
+++ b/crates/jk-tui/src/chrome.rs
@@ -14,7 +14,7 @@ pub const LOG_STATUS: &str =
 
 /// Default diff-view status text shown when there is no transient error.
 pub const DIFF_STATUS: &str =
-    "H/L log  r refresh  j/k line  space page  [/]: file  </> hscroll  h/left fold  l/right unfold";
+    "H/L log  r refresh  j/k line  space page  [/]: file  {/}: hunk  </> hscroll  h/l fold";
 
 const DEFAULT_TITLE: &str = "jj log";
 

--- a/crates/jk-tui/src/chrome.rs
+++ b/crates/jk-tui/src/chrome.rs
@@ -10,10 +10,10 @@ use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 
 /// Default log-view status text shown when there is no transient error.
 pub const LOG_STATUS: &str =
-    "? help  H home  L log  d diff  r refresh  j/k move  space page  q quit";
+    "? help  H home  L log  d diff  r refresh  j/k move  space/b page  q quit";
 
 /// Default diff-view status text shown when there is no transient error.
-pub const DIFF_STATUS: &str = "? help  r refresh  j/k line  space page  q quit";
+pub const DIFF_STATUS: &str = "? help  r refresh  j/k line  space/b page  q quit";
 
 /// Renders a small mode-specific help overlay centered in the content area.
 pub fn render_help_overlay(frame: &mut Frame<'_>, area: Rect, title: &str, lines: &[&str]) {

--- a/crates/jk-tui/src/chrome.rs
+++ b/crates/jk-tui/src/chrome.rs
@@ -14,7 +14,7 @@ pub const LOG_STATUS: &str =
 
 /// Default diff-view status text shown when there is no transient error.
 pub const DIFF_STATUS: &str =
-    "H/L log  r refresh  j/k line  space page  [/]: file  {/}: hunk  </> hscroll  h/l fold";
+    "H/L log  r refresh  j/k line  space page  [/]: file  {/}: hunk  -/+ fold hunk  h/l fold file";
 
 const DEFAULT_TITLE: &str = "jj log";
 

--- a/crates/jk-tui/src/diff_state.rs
+++ b/crates/jk-tui/src/diff_state.rs
@@ -16,6 +16,7 @@ pub struct DiffState {
     sections: Vec<FileSection>,
     selected: Option<usize>,
     collapsed_paths: BTreeSet<String>,
+    search: Option<SearchState>,
     scroll_offset: usize,
     viewport_height: usize,
 }
@@ -33,6 +34,7 @@ impl DiffState {
             sections,
             selected,
             collapsed_paths: BTreeSet::new(),
+            search: None,
             scroll_offset: 0,
             viewport_height: 10,
         }
@@ -58,6 +60,7 @@ impl DiffState {
             .or_else(|| (!self.sections.is_empty()).then_some(0));
 
         self.clamp_scroll_offset();
+        self.refresh_search_matches();
     }
 
     /// Returns the command context shown in the title bar.
@@ -255,6 +258,66 @@ impl DiffState {
             .map(ToOwned::to_owned)
     }
 
+    /// Searches visible diff lines and moves to the first match at or below the viewport.
+    pub fn search(&mut self, query: &str) {
+        if query.is_empty() {
+            self.search = None;
+            return;
+        }
+
+        let matches = matching_visible_lines(&self.visible_rendered(), query);
+        let selected = selected_match_at_or_after(&matches, self.scroll_offset);
+        self.search = Some(SearchState {
+            query: query.to_owned(),
+            matches,
+            selected,
+        });
+        self.scroll_to_selected_match();
+    }
+
+    /// Moves to the next search match, wrapping at the end of the diff.
+    pub fn search_next(&mut self) {
+        let Some(search) = &mut self.search else {
+            return;
+        };
+        if search.matches.is_empty() {
+            return;
+        }
+
+        let selected = search.selected.unwrap_or(0);
+        search.selected = Some((selected + 1) % search.matches.len());
+        self.scroll_to_selected_match();
+    }
+
+    /// Moves to the previous search match, wrapping at the beginning of the diff.
+    pub fn search_previous(&mut self) {
+        let Some(search) = &mut self.search else {
+            return;
+        };
+        if search.matches.is_empty() {
+            return;
+        }
+
+        let selected = search.selected.unwrap_or(0);
+        search.selected = Some(selected.checked_sub(1).unwrap_or(search.matches.len() - 1));
+        self.scroll_to_selected_match();
+    }
+
+    /// Returns status-line text for the current search, if any.
+    pub fn search_status(&self) -> Option<String> {
+        let search = self.search.as_ref()?;
+        let Some(selected) = search.selected else {
+            return Some(format!("/{}  no matches", search.query));
+        };
+
+        Some(format!(
+            "/{}  {}/{}  n next  N previous",
+            search.query,
+            selected + 1,
+            search.matches.len()
+        ))
+    }
+
     /// Returns whether the selected file section is collapsed.
     #[cfg(test)]
     pub fn selected_file_is_collapsed(&self) -> bool {
@@ -315,6 +378,32 @@ impl DiffState {
         }
     }
 
+    /// Recomputes search matches after the rendered visible body changes.
+    fn refresh_search_matches(&mut self) {
+        let Some(query) = self.search.as_ref().map(|search| search.query.clone()) else {
+            return;
+        };
+
+        let matches = matching_visible_lines(&self.visible_rendered(), &query);
+        let selected = selected_match_at_or_after(&matches, self.scroll_offset);
+        self.search = Some(SearchState {
+            query,
+            matches,
+            selected,
+        });
+    }
+
+    /// Scrolls to the selected search match and updates the current file from that line.
+    fn scroll_to_selected_match(&mut self) {
+        let Some(line) = self.search.as_ref().and_then(SearchState::selected_line) else {
+            return;
+        };
+
+        self.scroll_offset = line;
+        self.clamp_scroll_offset();
+        self.select_file_for_scroll_offset();
+    }
+
     /// Keeps scroll offset within the currently visible diff body.
     fn clamp_scroll_offset(&mut self) {
         let max_scroll_offset = self
@@ -349,6 +438,22 @@ impl DiffState {
             .map(|header| visible_width(header.trim_end_matches('\n')))
             .max()
             .unwrap_or_default()
+    }
+}
+
+/// State for the last submitted diff search.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SearchState {
+    query: String,
+    matches: Vec<usize>,
+    selected: Option<usize>,
+}
+
+impl SearchState {
+    /// Returns the visible line number of the selected search match.
+    fn selected_line(&self) -> Option<usize> {
+        self.selected
+            .and_then(|index| self.matches.get(index).copied())
     }
 }
 
@@ -446,6 +551,31 @@ fn file_header_path(line: &str) -> Option<String> {
 /// Returns the terminal-visible width of text after removing ANSI color escapes.
 fn visible_width(text: &str) -> usize {
     strip_ansi(text).chars().count()
+}
+
+/// Returns visible line numbers whose plain text contains `query`.
+fn matching_visible_lines(rendered: &str, query: &str) -> Vec<usize> {
+    let query = query.to_lowercase();
+    rendered
+        .lines()
+        .enumerate()
+        .filter_map(|(line, text)| {
+            let text = strip_ansi(text).to_lowercase();
+            text.contains(&query).then_some(line)
+        })
+        .collect()
+}
+
+/// Selects the first match at or below the current viewport, wrapping to the first match.
+fn selected_match_at_or_after(matches: &[usize], scroll_offset: usize) -> Option<usize> {
+    if matches.is_empty() {
+        return None;
+    }
+
+    matches
+        .iter()
+        .position(|line| *line >= scroll_offset)
+        .or(Some(0))
 }
 
 #[cfg(test)]
@@ -578,6 +708,55 @@ mod tests {
         state.select_first();
 
         assert_eq!(state.sticky_header(), None);
+    }
+
+    #[test]
+    fn search_jumps_to_matching_visible_line_and_repeats() {
+        let mut state = DiffState::new(snapshot(
+            "aaa",
+            "Modified regular file src/a.rs:\n alpha\n beta\nModified regular file src/b.rs:\n alphabet\n",
+        ));
+        state.keep_selected_in_view(2);
+
+        state.search("alpha");
+
+        assert_eq!(state.scroll_offset(), 1);
+        assert_eq!(
+            state.search_status(),
+            Some("/alpha  1/2  n next  N previous".to_owned())
+        );
+
+        state.search_next();
+
+        assert_eq!(state.scroll_offset(), 3);
+        assert_eq!(state.selected_visible_line(), Some(3));
+        assert_eq!(
+            state.search_status(),
+            Some("/alpha  2/2  n next  N previous".to_owned())
+        );
+
+        state.search_previous();
+
+        assert_eq!(state.scroll_offset(), 1);
+        assert_eq!(
+            state.search_status(),
+            Some("/alpha  1/2  n next  N previous".to_owned())
+        );
+    }
+
+    #[test]
+    fn search_reports_no_matches_without_moving_scroll() {
+        let mut state =
+            DiffState::new(snapshot("aaa", "Modified regular file src/a.rs:\n alpha\n"));
+        state.keep_selected_in_view(2);
+
+        state.search("missing");
+
+        assert_eq!(state.scroll_offset(), 0);
+        assert_eq!(
+            state.search_status(),
+            Some("/missing  no matches".to_owned())
+        );
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_state.rs
+++ b/crates/jk-tui/src/diff_state.rs
@@ -1,6 +1,7 @@
 //! State machine for selected-change diff inspection.
 
 use std::collections::BTreeSet;
+use std::fmt::Write as _;
 
 use jk_core::{DiffFileStat, DiffSnapshot};
 
@@ -252,10 +253,26 @@ impl DiffState {
             return None;
         }
 
-        self.visible_rendered()
-            .lines()
-            .nth(selected_line)
-            .map(ToOwned::to_owned)
+        let selected_index = self.selected?;
+        let selected = self.selected_section()?;
+        let lines = self.rendered.split_inclusive('\n').collect::<Vec<_>>();
+        let header = lines
+            .get(selected.start_line)?
+            .trim_end_matches('\n')
+            .to_owned();
+        let mut sticky_header = header.clone();
+        if let Some(suffix) =
+            selected.stat_suffix(self.folded_header_width(&lines), visible_width(&header))
+        {
+            sticky_header.push_str(&suffix);
+        }
+        let _ = write!(
+            sticky_header,
+            "  [file {}/{}]",
+            selected_index + 1,
+            self.sections.len()
+        );
+        Some(sticky_header)
     }
 
     /// Searches visible diff lines and moves to the first match at or below the viewport.
@@ -469,22 +486,32 @@ struct FileSection {
 impl FileSection {
     /// Returns the folded suffix appended to this file section's header.
     fn folded_suffix(&self, target_width: usize, header_width: usize) -> String {
-        let padding = " ".repeat(target_width.saturating_sub(header_width) + 1);
-        match &self.stat {
-            Some(stat) if !stat.rendered.is_empty() => {
-                let mut suffix = padding;
-                suffix.push_str(&stat.rendered);
-                suffix
-            }
-            Some(stat) => format!(
-                "{padding}| {:>3} \u{1b}[38;5;2m{}\u{1b}[38;5;1m{}\u{1b}[39m",
-                stat.added + stat.removed,
-                "+".repeat(stat.added.min(10)),
-                "-".repeat(stat.removed.min(10)),
-            ),
-            None => format!("{padding}| folded"),
-        }
+        self.stat_suffix(target_width, header_width)
+            .unwrap_or_else(|| stat_padding(target_width, header_width) + "| folded")
     }
+
+    /// Returns the stat suffix appended after a file section header.
+    fn stat_suffix(&self, target_width: usize, header_width: usize) -> Option<String> {
+        let padding = stat_padding(target_width, header_width);
+        let stat = self.stat.as_ref()?;
+        if !stat.rendered.is_empty() {
+            let mut suffix = padding;
+            suffix.push_str(&stat.rendered);
+            return Some(suffix);
+        }
+
+        Some(format!(
+            "{padding}| {:>3} \u{1b}[38;5;2m{}\u{1b}[38;5;1m{}\u{1b}[39m",
+            stat.added + stat.removed,
+            "+".repeat(stat.added.min(10)),
+            "-".repeat(stat.removed.min(10)),
+        ))
+    }
+}
+
+/// Returns the spaces between a diff file header and its stat suffix.
+fn stat_padding(target_width: usize, header_width: usize) -> String {
+    " ".repeat(target_width.saturating_sub(header_width) + 1)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -702,12 +729,36 @@ mod tests {
 
         assert_eq!(
             state.sticky_header(),
-            Some("Modified regular file src/a.rs:".to_owned())
+            Some("Modified regular file src/a.rs:  [file 1/2]".to_owned())
         );
 
         state.select_first();
 
         assert_eq!(state.sticky_header(), None);
+    }
+
+    #[test]
+    fn sticky_header_includes_stat_suffix_and_file_index() {
+        let mut state = DiffState::new(snapshot_with_stats(
+            "aaa",
+            "Modified regular file src/a.rs:\n a1\n a2\nModified regular file src/b.rs:\n b\n",
+            vec![
+                DiffFileStat::new("src/a.rs", 2, 1)
+                    .with_rendered("| 3 \u{1b}[38;5;2m++\u{1b}[38;5;1m-\u{1b}[39m"),
+                DiffFileStat::new("src/b.rs", 1, 0).with_rendered("| 1 \u{1b}[38;5;2m+\u{1b}[39m"),
+            ],
+        ));
+        state.keep_selected_in_view(2);
+
+        state.scroll_next_line();
+
+        let sticky_header = state
+            .sticky_header()
+            .map_or_else(String::new, |sticky_header| strip_ansi(&sticky_header));
+        assert_eq!(
+            sticky_header,
+            "Modified regular file src/a.rs: | 3 ++-  [file 1/2]"
+        );
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_state.rs
+++ b/crates/jk-tui/src/diff_state.rs
@@ -1,7 +1,6 @@
 //! State machine for selected-change diff inspection.
 
 use std::collections::BTreeSet;
-use std::fmt::Write as _;
 
 use jk_core::{DiffFileStat, DiffSnapshot};
 
@@ -297,9 +296,7 @@ impl DiffState {
 
     /// Returns the visible diff body after applying collapsed sections.
     pub fn visible_rendered(&self) -> String {
-        if self.sections.is_empty()
-            || (self.collapsed_paths.is_empty() && self.collapsed_hunks.is_empty())
-        {
+        if self.sections.is_empty() {
             return self.rendered.clone();
         }
 
@@ -323,19 +320,16 @@ impl DiffState {
                     .filter(|hunk| hunk.file_index == section_index)
                     .filter(|hunk| self.collapsed_hunks.contains(&hunk.key));
                 for hunk in folded_hunks {
-                    while line_index <= hunk.start_line {
-                        if let Some(line) = lines.get(line_index) {
-                            visible.push_str(line);
-                        }
+                    while line_index < hunk.start_line {
+                        self.push_visible_line(&mut visible, &lines, line_index);
                         line_index += 1;
                     }
+                    self.push_visible_line(&mut visible, &lines, hunk.start_line);
                     visible.push_str("  | folded hunk\n");
                     line_index = hunk.end_line;
                 }
                 while line_index < section.end_line {
-                    if let Some(line) = lines.get(line_index) {
-                        visible.push_str(line);
-                    }
+                    self.push_visible_line(&mut visible, &lines, line_index);
                     line_index += 1;
                 }
                 continue;
@@ -344,8 +338,11 @@ impl DiffState {
             if let Some(header) = lines.get(section.start_line) {
                 let header = header.trim_end_matches('\n');
                 visible.push_str(header);
-                visible
-                    .push_str(&section.folded_suffix(folded_header_width, visible_width(header)));
+                visible.push_str(&section.folded_suffix(
+                    folded_header_width,
+                    visible_width(header),
+                    &self.file_index_suffix(section_index),
+                ));
                 visible.push('\n');
             }
             line_index = section.end_line;
@@ -357,6 +354,34 @@ impl DiffState {
         }
 
         visible
+    }
+
+    fn push_visible_line(&self, visible: &mut String, lines: &[&str], line_index: usize) {
+        let Some(line) = lines.get(line_index) else {
+            return;
+        };
+
+        let Some(section_index) = self
+            .sections
+            .iter()
+            .position(|section| section.start_line == line_index)
+        else {
+            visible.push_str(line);
+            return;
+        };
+
+        let header = line.trim_end_matches('\n');
+        visible.push_str(header);
+        if let Some(section) = self.sections.get(section_index)
+            && self.selected == Some(section_index)
+        {
+            visible.push_str(&section.selected_suffix(
+                self.folded_header_width(lines),
+                visible_width(header),
+                &self.file_index_suffix(section_index),
+            ));
+        }
+        visible.push('\n');
     }
 
     /// Returns the visible line for the selected file header after collapse is applied.
@@ -385,12 +410,7 @@ impl DiffState {
         {
             sticky_header.push_str(&suffix);
         }
-        let _ = write!(
-            sticky_header,
-            "  [file {}/{}]",
-            selected_index + 1,
-            self.sections.len()
-        );
+        sticky_header.push_str(&self.file_index_suffix(selected_index));
         Some(sticky_header)
     }
 
@@ -646,6 +666,10 @@ impl DiffState {
             .max()
             .unwrap_or_default()
     }
+
+    fn file_index_suffix(&self, section_index: usize) -> String {
+        format!("  [file {}/{}]", section_index + 1, self.sections.len())
+    }
 }
 
 /// State for the last submitted diff search.
@@ -684,9 +708,17 @@ struct FileSection {
 
 impl FileSection {
     /// Returns the folded suffix appended to this file section's header.
-    fn folded_suffix(&self, target_width: usize, header_width: usize) -> String {
+    fn folded_suffix(&self, target_width: usize, header_width: usize, extra: &str) -> String {
         self.stat_suffix(target_width, header_width)
             .unwrap_or_else(|| stat_padding(target_width, header_width) + "| folded")
+            + extra
+    }
+
+    /// Returns the suffix appended to the selected file section's visible header.
+    fn selected_suffix(&self, target_width: usize, header_width: usize, extra: &str) -> String {
+        self.stat_suffix(target_width, header_width)
+            .unwrap_or_default()
+            + extra
     }
 
     /// Returns the stat suffix appended after a file section header.
@@ -1005,6 +1037,23 @@ mod tests {
             sticky_header,
             "Modified regular file src/a.rs: | 3 ++-  [file 1/2]"
         );
+    }
+
+    #[test]
+    fn visible_selected_file_header_includes_stat_suffix_and_file_index() {
+        let state = DiffState::new(snapshot_with_stats(
+            "aaa",
+            "Modified regular file src/a.rs:\n a1\nModified regular file src/b.rs:\n b\n",
+            vec![
+                DiffFileStat::new("src/a.rs", 1, 1)
+                    .with_rendered("| 2 \u{1b}[38;5;2m+\u{1b}[38;5;1m-\u{1b}[39m"),
+                DiffFileStat::new("src/b.rs", 1, 0).with_rendered("| 1 \u{1b}[38;5;2m+\u{1b}[39m"),
+            ],
+        ));
+
+        let rendered = strip_ansi(&state.visible_rendered());
+
+        assert!(rendered.contains("Modified regular file src/a.rs: | 2 +-  [file 1/2]"));
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_state.rs
+++ b/crates/jk-tui/src/diff_state.rs
@@ -93,6 +93,11 @@ impl DiffState {
         &self.change_id
     }
 
+    /// Returns whether `jj diff` produced no visible body.
+    pub fn is_empty_diff(&self) -> bool {
+        self.rendered.trim().is_empty()
+    }
+
     /// Returns the first rendered line currently visible in the viewport.
     pub const fn scroll_offset(&self) -> usize {
         self.scroll_offset

--- a/crates/jk-tui/src/diff_state.rs
+++ b/crates/jk-tui/src/diff_state.rs
@@ -18,7 +18,9 @@ pub struct DiffState {
     change_id: String,
     rendered: String,
     sections: Vec<FileSection>,
+    hunks: Vec<HunkSection>,
     selected: Option<usize>,
+    selected_hunk: Option<usize>,
     collapsed_paths: BTreeSet<String>,
     search: Option<SearchState>,
     scroll_offset: usize,
@@ -32,13 +34,16 @@ impl DiffState {
     pub fn new(snapshot: DiffSnapshot) -> Self {
         let (title, change_id, rendered, file_stats) = snapshot.into_parts();
         let sections = file_sections(&rendered, &file_stats);
+        let hunks = hunk_sections(&rendered, &sections);
         let selected = (!sections.is_empty()).then_some(0);
         Self {
             title: title_or_default(title),
             change_id,
             rendered,
             sections,
+            hunks,
             selected,
+            selected_hunk: None,
             collapsed_paths: BTreeSet::new(),
             search: None,
             scroll_offset: 0,
@@ -57,6 +62,8 @@ impl DiffState {
         self.change_id = change_id;
         self.rendered = rendered;
         self.sections = file_sections(&self.rendered, &file_stats);
+        self.hunks = hunk_sections(&self.rendered, &self.sections);
+        self.selected_hunk = None;
         self.collapsed_paths
             .retain(|path| self.sections.iter().any(|section| section.path == *path));
         self.selected = selected_path
@@ -99,6 +106,7 @@ impl DiffState {
         if self.scroll_offset == old_offset {
             self.select_previous_file();
         } else {
+            self.selected_hunk = None;
             self.select_file_for_scroll_offset();
         }
     }
@@ -111,6 +119,7 @@ impl DiffState {
         if self.scroll_offset == old_offset {
             self.select_next_file();
         } else {
+            self.selected_hunk = None;
             self.select_file_for_scroll_offset();
         }
     }
@@ -118,6 +127,7 @@ impl DiffState {
     /// Scrolls one viewport toward the start of the diff.
     pub fn select_page_previous(&mut self) {
         self.scroll_offset = self.scroll_offset.saturating_sub(self.viewport_height);
+        self.selected_hunk = None;
         self.select_file_for_scroll_offset();
     }
 
@@ -125,12 +135,14 @@ impl DiffState {
     pub fn select_page_next(&mut self) {
         self.scroll_offset = self.scroll_offset.saturating_add(self.viewport_height);
         self.clamp_scroll_offset();
+        self.selected_hunk = None;
         self.select_file_for_scroll_offset();
     }
 
     /// Moves to the first visible diff line.
     pub fn select_first(&mut self) {
         self.scroll_offset = 0;
+        self.selected_hunk = None;
         self.select_file_for_scroll_offset();
     }
 
@@ -138,6 +150,7 @@ impl DiffState {
     pub fn select_last(&mut self) {
         self.scroll_offset = usize::MAX;
         self.clamp_scroll_offset();
+        self.selected_hunk = None;
         self.select_file_for_scroll_offset();
     }
 
@@ -173,6 +186,24 @@ impl DiffState {
 
         let last_index = self.sections.len().saturating_sub(1);
         self.select_index((selected + 1).min(last_index));
+    }
+
+    /// Jumps to the previous hunk.
+    pub fn select_previous_hunk(&mut self) {
+        let Some(index) = self.current_hunk_index() else {
+            return;
+        };
+
+        self.select_hunk_index(index.saturating_sub(1));
+    }
+
+    /// Jumps to the next hunk.
+    pub fn select_next_hunk(&mut self) {
+        let Some(index) = self.current_hunk_index() else {
+            return;
+        };
+
+        self.select_hunk_index((index + 1).min(self.hunks.len().saturating_sub(1)));
     }
 
     /// Folds the selected file section.
@@ -398,8 +429,41 @@ impl DiffState {
         };
 
         self.selected = Some(index);
+        self.selected_hunk = None;
         self.scroll_offset = self.visible_line_for_rendered_line(section.start_line);
         self.clamp_scroll_offset();
+    }
+
+    /// Selects a hunk by index and scrolls its header to the top.
+    fn select_hunk_index(&mut self, index: usize) {
+        let Some(hunk) = self.hunks.get(index) else {
+            return;
+        };
+
+        self.selected = Some(hunk.file_index);
+        self.selected_hunk = Some(index);
+        self.scroll_offset = self.visible_line_for_rendered_line(hunk.start_line);
+        self.clamp_scroll_offset();
+    }
+
+    /// Returns the hunk containing, or nearest before, the current scroll offset.
+    fn current_hunk_index(&self) -> Option<usize> {
+        if self.hunks.is_empty() {
+            return None;
+        }
+        if let Some(selected_hunk) = self.selected_hunk {
+            return Some(selected_hunk.min(self.hunks.len() - 1));
+        }
+
+        self.hunks
+            .iter()
+            .enumerate()
+            .take_while(|(_, hunk)| {
+                self.visible_line_for_rendered_line(hunk.start_line) <= self.scroll_offset
+            })
+            .map(|(index, _)| index)
+            .last()
+            .or(Some(0))
     }
 
     /// Selects the file section containing, or nearest before, the current scroll offset.
@@ -462,6 +526,7 @@ impl DiffState {
 
         self.scroll_offset = line;
         self.clamp_scroll_offset();
+        self.selected_hunk = None;
         self.select_file_for_scroll_offset();
     }
 
@@ -528,6 +593,13 @@ impl SearchState {
         self.selected
             .and_then(|index| self.matches.get(index).copied())
     }
+}
+
+/// A diff hunk header discovered in rendered `jj diff` output.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct HunkSection {
+    file_index: usize,
+    start_line: usize,
 }
 
 /// A file section discovered in `jj diff` output.
@@ -608,6 +680,28 @@ fn file_sections(rendered: &str, file_stats: &[DiffFileStat]) -> Vec<FileSection
     sections
 }
 
+/// Finds diff hunk headers inside recognized file sections.
+fn hunk_sections(rendered: &str, file_sections: &[FileSection]) -> Vec<HunkSection> {
+    let lines = rendered.lines().collect::<Vec<_>>();
+    let mut hunks = Vec::new();
+
+    for (file_index, section) in file_sections.iter().enumerate() {
+        for line_index in (section.start_line + 1)..section.end_line {
+            let Some(line) = lines.get(line_index) else {
+                continue;
+            };
+            if hunk_header_line(line) {
+                hunks.push(HunkSection {
+                    file_index,
+                    start_line: line_index,
+                });
+            }
+        }
+    }
+
+    hunks
+}
+
 /// Extracts a stable file path from a visible `jj diff` file header line.
 fn file_header_path(line: &str) -> Option<String> {
     let line = strip_ansi(line);
@@ -629,6 +723,13 @@ fn file_header_path(line: &str) -> Option<String> {
     .find_map(|prefix| line.strip_prefix(prefix))?;
 
     path.strip_suffix(':').map(ToOwned::to_owned)
+}
+
+/// Returns whether a rendered line looks like a unified diff hunk header.
+fn hunk_header_line(line: &str) -> bool {
+    let line = strip_ansi(line);
+    let line = line.trim_start();
+    line.starts_with("@@") && line.contains("@@")
 }
 
 /// Returns the terminal-visible width of text after removing ANSI color escapes.
@@ -889,6 +990,39 @@ mod tests {
         state.scroll_left();
 
         assert_eq!(state.horizontal_offset(), 8);
+    }
+
+    #[test]
+    fn brace_movement_selects_hunk_headers_across_files() {
+        let mut state = DiffState::new(snapshot(
+            "aaa",
+            concat!(
+                "Modified regular file src/a.rs:\n",
+                "@@ -1,1 +1,1 @@\n",
+                " a1\n",
+                "@@ -8,1 +8,1 @@\n",
+                " a2\n",
+                "Modified regular file src/b.rs:\n",
+                "@@ -1,1 +1,1 @@\n",
+                " b1\n",
+            ),
+        ));
+        state.keep_selected_in_view(3);
+
+        state.select_next_hunk();
+
+        assert_eq!(state.scroll_offset(), 3);
+        assert_eq!(state.selected_visible_line(), Some(0));
+
+        state.select_next_hunk();
+
+        assert_eq!(state.scroll_offset(), 5);
+        assert_eq!(state.selected_visible_line(), Some(5));
+
+        state.select_previous_hunk();
+
+        assert_eq!(state.scroll_offset(), 3);
+        assert_eq!(state.selected_visible_line(), Some(0));
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_state.rs
+++ b/crates/jk-tui/src/diff_state.rs
@@ -22,6 +22,7 @@ pub struct DiffState {
     selected: Option<usize>,
     selected_hunk: Option<usize>,
     collapsed_paths: BTreeSet<String>,
+    collapsed_hunks: BTreeSet<String>,
     search: Option<SearchState>,
     scroll_offset: usize,
     horizontal_offset: usize,
@@ -45,6 +46,7 @@ impl DiffState {
             selected,
             selected_hunk: None,
             collapsed_paths: BTreeSet::new(),
+            collapsed_hunks: BTreeSet::new(),
             search: None,
             scroll_offset: 0,
             horizontal_offset: 0,
@@ -66,6 +68,8 @@ impl DiffState {
         self.selected_hunk = None;
         self.collapsed_paths
             .retain(|path| self.sections.iter().any(|section| section.path == *path));
+        self.collapsed_hunks
+            .retain(|key| self.hunks.iter().any(|hunk| hunk.key == *key));
         self.selected = selected_path
             .and_then(|path| {
                 self.sections
@@ -206,6 +210,34 @@ impl DiffState {
         self.select_hunk_index((index + 1).min(self.hunks.len().saturating_sub(1)));
     }
 
+    /// Folds the selected or current hunk.
+    pub fn fold_selected_hunk(&mut self) {
+        let Some(index) = self.current_hunk_index() else {
+            return;
+        };
+        let Some(hunk) = self.hunks.get(index) else {
+            return;
+        };
+
+        self.collapsed_hunks.insert(hunk.key.clone());
+        self.select_hunk_index(index);
+        self.clamp_scroll_offset();
+    }
+
+    /// Unfolds the selected or current hunk.
+    pub fn unfold_selected_hunk(&mut self) {
+        let Some(index) = self.current_hunk_index() else {
+            return;
+        };
+        let Some(hunk) = self.hunks.get(index) else {
+            return;
+        };
+
+        self.collapsed_hunks.remove(&hunk.key);
+        self.select_hunk_index(index);
+        self.clamp_scroll_offset();
+    }
+
     /// Folds the selected file section.
     pub fn fold_selected_file(&mut self) {
         let Some(path) = self.selected_section().map(|section| section.path.clone()) else {
@@ -258,9 +290,11 @@ impl DiffState {
         self.clamp_horizontal_offset();
     }
 
-    /// Returns the visible diff body after applying collapsed file sections.
+    /// Returns the visible diff body after applying collapsed sections.
     pub fn visible_rendered(&self) -> String {
-        if self.sections.is_empty() || self.collapsed_paths.is_empty() {
+        if self.sections.is_empty()
+            || (self.collapsed_paths.is_empty() && self.collapsed_hunks.is_empty())
+        {
             return self.rendered.clone();
         }
 
@@ -269,7 +303,7 @@ impl DiffState {
         let mut visible = String::new();
         let mut line_index = 0;
 
-        for section in &self.sections {
+        for (section_index, section) in self.sections.iter().enumerate() {
             while line_index < section.start_line {
                 if let Some(line) = lines.get(line_index) {
                     visible.push_str(line);
@@ -278,6 +312,21 @@ impl DiffState {
             }
 
             if !self.collapsed_paths.contains(&section.path) {
+                let folded_hunks = self
+                    .hunks
+                    .iter()
+                    .filter(|hunk| hunk.file_index == section_index)
+                    .filter(|hunk| self.collapsed_hunks.contains(&hunk.key));
+                for hunk in folded_hunks {
+                    while line_index <= hunk.start_line {
+                        if let Some(line) = lines.get(line_index) {
+                            visible.push_str(line);
+                        }
+                        line_index += 1;
+                    }
+                    visible.push_str("  | folded hunk\n");
+                    line_index = hunk.end_line;
+                }
                 while line_index < section.end_line {
                     if let Some(line) = lines.get(line_index) {
                         visible.push_str(line);
@@ -565,6 +614,21 @@ impl DiffState {
             }
         }
 
+        for hunk in self
+            .hunks
+            .iter()
+            .filter(|hunk| hunk.start_line < rendered_line)
+        {
+            let Some(section) = self.sections.get(hunk.file_index) else {
+                continue;
+            };
+            if !self.collapsed_paths.contains(&section.path)
+                && self.collapsed_hunks.contains(&hunk.key)
+            {
+                hidden_lines += hunk.end_line.saturating_sub(hunk.start_line + 1);
+            }
+        }
+
         rendered_line.saturating_sub(hidden_lines)
     }
 
@@ -600,6 +664,8 @@ impl SearchState {
 struct HunkSection {
     file_index: usize,
     start_line: usize,
+    end_line: usize,
+    key: String,
 }
 
 /// A file section discovered in `jj diff` output.
@@ -686,6 +752,7 @@ fn hunk_sections(rendered: &str, file_sections: &[FileSection]) -> Vec<HunkSecti
     let mut hunks = Vec::new();
 
     for (file_index, section) in file_sections.iter().enumerate() {
+        let hunk_start = hunks.len();
         for line_index in (section.start_line + 1)..section.end_line {
             let Some(line) = lines.get(line_index) else {
                 continue;
@@ -694,7 +761,19 @@ fn hunk_sections(rendered: &str, file_sections: &[FileSection]) -> Vec<HunkSecti
                 hunks.push(HunkSection {
                     file_index,
                     start_line: line_index,
+                    end_line: section.end_line,
+                    key: hunk_key(&section.path, line),
                 });
+            }
+        }
+
+        for index in hunk_start..hunks.len() {
+            let end_line = hunks
+                .get(index + 1)
+                .filter(|next| next.file_index == file_index)
+                .map_or(section.end_line, |next| next.start_line);
+            if let Some(hunk) = hunks.get_mut(index) {
+                hunk.end_line = end_line;
             }
         }
     }
@@ -730,6 +809,11 @@ fn hunk_header_line(line: &str) -> bool {
     let line = strip_ansi(line);
     let line = line.trim_start();
     line.starts_with("@@") && line.contains("@@")
+}
+
+/// Builds a refresh-stable identity for a hunk within one diff file.
+fn hunk_key(path: &str, header: &str) -> String {
+    format!("{}\0{}", path, strip_ansi(header).trim())
 }
 
 /// Returns the terminal-visible width of text after removing ANSI color escapes.
@@ -1023,6 +1107,31 @@ mod tests {
 
         assert_eq!(state.scroll_offset(), 3);
         assert_eq!(state.selected_visible_line(), Some(0));
+    }
+
+    #[test]
+    fn hunk_folding_hides_only_selected_hunk_body() {
+        let mut state = DiffState::new(snapshot(
+            "aaa",
+            concat!(
+                "Modified regular file src/a.rs:\n",
+                "@@ -1,1 +1,1 @@\n",
+                " hidden\n",
+                "@@ -8,1 +8,1 @@\n",
+                " visible\n",
+            ),
+        ));
+
+        state.fold_selected_hunk();
+
+        let rendered = state.visible_rendered();
+        assert!(rendered.contains("@@ -1,1 +1,1 @@\n  | folded hunk\n"));
+        assert!(!rendered.contains(" hidden"));
+        assert!(rendered.contains(" visible"));
+
+        state.unfold_selected_hunk();
+
+        assert!(state.visible_rendered().contains(" hidden"));
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_state.rs
+++ b/crates/jk-tui/src/diff_state.rs
@@ -8,6 +8,9 @@ use jk_core::{DiffFileStat, DiffSnapshot};
 use crate::ansi_text::strip_ansi;
 use crate::chrome::title_or_default;
 
+const HORIZONTAL_SCROLL_STEP: usize = 8;
+const DIFF_HORIZONTAL_STATUS: &str = "</> horizontal scroll";
+
 /// Semantic state behind a rendered selected-change diff.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DiffState {
@@ -19,7 +22,9 @@ pub struct DiffState {
     collapsed_paths: BTreeSet<String>,
     search: Option<SearchState>,
     scroll_offset: usize,
+    horizontal_offset: usize,
     viewport_height: usize,
+    viewport_width: usize,
 }
 
 impl DiffState {
@@ -37,7 +42,9 @@ impl DiffState {
             collapsed_paths: BTreeSet::new(),
             search: None,
             scroll_offset: 0,
+            horizontal_offset: 0,
             viewport_height: 10,
+            viewport_width: 80,
         }
     }
 
@@ -61,6 +68,7 @@ impl DiffState {
             .or_else(|| (!self.sections.is_empty()).then_some(0));
 
         self.clamp_scroll_offset();
+        self.clamp_horizontal_offset();
         self.refresh_search_matches();
     }
 
@@ -77,6 +85,11 @@ impl DiffState {
     /// Returns the first rendered line currently visible in the viewport.
     pub const fn scroll_offset(&self) -> usize {
         self.scroll_offset
+    }
+
+    /// Returns the first rendered column currently visible in the viewport.
+    pub const fn horizontal_offset(&self) -> usize {
+        self.horizontal_offset
     }
 
     /// Scrolls one visible line toward the start of the diff.
@@ -126,6 +139,21 @@ impl DiffState {
         self.scroll_offset = usize::MAX;
         self.clamp_scroll_offset();
         self.select_file_for_scroll_offset();
+    }
+
+    /// Scrolls wide diff lines toward the start.
+    pub const fn scroll_left(&mut self) {
+        self.horizontal_offset = self
+            .horizontal_offset
+            .saturating_sub(HORIZONTAL_SCROLL_STEP);
+    }
+
+    /// Scrolls wide diff lines toward the end.
+    pub fn scroll_right(&mut self) {
+        self.horizontal_offset = self
+            .horizontal_offset
+            .saturating_add(HORIZONTAL_SCROLL_STEP);
+        self.clamp_horizontal_offset();
     }
 
     /// Jumps to the previous file section.
@@ -191,6 +219,12 @@ impl DiffState {
     pub fn keep_selected_in_view(&mut self, height: usize) {
         self.viewport_height = height.max(1);
         self.clamp_scroll_offset();
+    }
+
+    /// Updates viewport width and clamps horizontal scrolling to visible content.
+    pub fn set_viewport_width(&mut self, width: usize) {
+        self.viewport_width = width.max(1);
+        self.clamp_horizontal_offset();
     }
 
     /// Returns the visible diff body after applying collapsed file sections.
@@ -335,6 +369,16 @@ impl DiffState {
         ))
     }
 
+    /// Returns status-line text for horizontal scroll state, if the view is shifted.
+    pub fn horizontal_status(&self) -> Option<String> {
+        (self.horizontal_offset > 0).then(|| {
+            format!(
+                "{DIFF_HORIZONTAL_STATUS}  col {}",
+                self.horizontal_offset + 1
+            )
+        })
+    }
+
     /// Returns whether the selected file section is collapsed.
     #[cfg(test)]
     pub fn selected_file_is_collapsed(&self) -> bool {
@@ -429,6 +473,18 @@ impl DiffState {
             .count()
             .saturating_sub(self.viewport_height);
         self.scroll_offset = self.scroll_offset.min(max_scroll_offset);
+    }
+
+    /// Keeps horizontal offset within the widest visible line.
+    fn clamp_horizontal_offset(&mut self) {
+        let max_horizontal_offset = self
+            .visible_rendered()
+            .lines()
+            .map(visible_width)
+            .max()
+            .unwrap_or_default()
+            .saturating_sub(self.viewport_width);
+        self.horizontal_offset = self.horizontal_offset.min(max_horizontal_offset);
     }
 
     /// Maps an original rendered line number to its line number after collapsed sections are
@@ -808,6 +864,31 @@ mod tests {
             state.search_status(),
             Some("/missing  no matches".to_owned())
         );
+    }
+
+    #[test]
+    fn horizontal_scroll_moves_by_columns_and_clamps_to_wide_content() {
+        let mut state = DiffState::new(snapshot(
+            "aaa",
+            "Modified regular file src/a.rs:\n 12345678901234567890\n",
+        ));
+        state.set_viewport_width(10);
+
+        state.scroll_right();
+
+        assert_eq!(state.horizontal_offset(), 8);
+        assert_eq!(
+            state.horizontal_status(),
+            Some("</> horizontal scroll  col 9".to_owned())
+        );
+
+        state.scroll_right();
+
+        assert_eq!(state.horizontal_offset(), 16);
+
+        state.scroll_left();
+
+        assert_eq!(state.horizontal_offset(), 8);
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_view.rs
+++ b/crates/jk-tui/src/diff_view.rs
@@ -28,7 +28,7 @@ pub enum DiffActionResult {
 }
 
 /// Input actions understood by the selected-change diff view.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum DiffAction {
     /// Leave the diff view unchanged.
@@ -69,6 +69,15 @@ pub enum DiffAction {
 
     /// Unfold every file section.
     UnfoldAll,
+
+    /// Search visible diff lines for text.
+    Search(String),
+
+    /// Jump to the next search match.
+    SearchNext,
+
+    /// Jump to the previous search match.
+    SearchPrevious,
 
     /// Refresh the diff.
     Refresh,
@@ -167,6 +176,18 @@ impl DiffView {
                 self.state.unfold_all_files();
                 DiffActionResult::Continue
             }
+            DiffAction::Search(query) => {
+                self.state.search(&query);
+                DiffActionResult::Continue
+            }
+            DiffAction::SearchNext => {
+                self.state.search_next();
+                DiffActionResult::Continue
+            }
+            DiffAction::SearchPrevious => {
+                self.state.search_previous();
+                DiffActionResult::Continue
+            }
             DiffAction::Refresh => DiffActionResult::Refresh,
             DiffAction::ReturnToLog => DiffActionResult::ReturnToLog,
             DiffAction::Quit => DiffActionResult::Quit,
@@ -176,10 +197,16 @@ impl DiffView {
     /// Renders the diff view.
     pub fn render(&mut self, frame: &mut Frame<'_>) {
         let area = frame.area();
-        self.render_area(frame, area);
+        self.render_area(frame, area, None);
     }
 
-    fn render_area(&mut self, frame: &mut Frame<'_>, area: Rect) {
+    /// Renders the diff view with a temporary status-line override.
+    pub fn render_with_status(&mut self, frame: &mut Frame<'_>, status: &str) {
+        let area = frame.area();
+        self.render_area(frame, area, Some(status));
+    }
+
+    fn render_area(&mut self, frame: &mut Frame<'_>, area: Rect, status_override: Option<&str>) {
         let areas = ViewChrome::layout(area);
         let height = usize::from(areas.content.height);
         self.state.keep_selected_in_view(height);
@@ -192,7 +219,11 @@ impl DiffView {
         self.state
             .keep_selected_in_view(usize::from(body_area.height));
 
-        let status = self.status_message.as_deref().unwrap_or(DIFF_STATUS);
+        let search_status = self.state.search_status();
+        let status = status_override
+            .or(self.status_message.as_deref())
+            .or(search_status.as_deref())
+            .unwrap_or(DIFF_STATUS);
         let chrome = ViewChrome::new(self.state.title(), status);
         chrome.render(frame, areas);
 
@@ -310,6 +341,22 @@ mod tests {
 
         let _ = view.apply(DiffAction::UnfoldAll);
         assert!(!view.state.visible_rendered().contains(" | folded"));
+    }
+
+    #[test]
+    fn search_status_replaces_default_status_after_search() {
+        let mut view = DiffView::new(snapshot("aaa", "Modified regular file src/a.rs:\n alpha\n"));
+        let _ = view.apply(DiffAction::Search("alpha".to_owned()));
+        let backend = TestBackend::new(64, 5);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        assert!(buffer_line(terminal.backend().buffer(), 4).contains("/alpha  1/1"));
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_view.rs
+++ b/crates/jk-tui/src/diff_view.rs
@@ -5,7 +5,7 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::widgets::Paragraph;
 
-use crate::chrome::{DIFF_STATUS, ViewChrome};
+use crate::chrome::{DIFF_STATUS, ViewChrome, render_help_overlay};
 use crate::diff_state::DiffState;
 use crate::rendered_log::rendered_text;
 use crate::selected_row::paint_subtle_selected_row;
@@ -91,6 +91,9 @@ pub enum DiffAction {
     /// Search visible diff lines for text.
     Search(String),
 
+    /// Toggle mode-specific help.
+    ToggleHelp,
+
     /// Jump to the next search match.
     SearchNext,
 
@@ -112,6 +115,7 @@ pub enum DiffAction {
 pub struct DiffView {
     state: DiffState,
     status_message: Option<String>,
+    help_visible: bool,
 }
 
 impl DiffView {
@@ -121,6 +125,7 @@ impl DiffView {
         Self {
             state: DiffState::new(snapshot),
             status_message: None,
+            help_visible: false,
         }
     }
 
@@ -222,6 +227,10 @@ impl DiffView {
                 self.state.search(&query);
                 DiffActionResult::Continue
             }
+            DiffAction::ToggleHelp => {
+                self.help_visible = !self.help_visible;
+                DiffActionResult::Continue
+            }
             DiffAction::SearchNext => {
                 self.state.search_next();
                 DiffActionResult::Continue
@@ -294,8 +303,29 @@ impl DiffView {
         if let Some(line) = self.state.selected_visible_line() {
             paint_subtle_selected_row(frame, body_area, line, self.state.scroll_offset());
         }
+
+        if self.help_visible {
+            render_help_overlay(frame, areas.content, "Diff keys", DIFF_HELP);
+        }
     }
 }
+
+const DIFF_HELP: &[&str] = &[
+    "j/k or arrows        scroll one line",
+    "space, Ctrl-f/b      page down/up",
+    "g/G or Home/End      jump to top/bottom",
+    "[ / ]                previous/next file",
+    "{ / }                previous/next hunk",
+    "h / l                fold/unfold current file",
+    "Ctrl-left/right      fold/unfold all files",
+    "- / +                fold/unfold current hunk",
+    "< / >                horizontal scroll",
+    "/, n, N              search, next, previous",
+    "r                    refresh",
+    "H / L                return to log",
+    "?                    close help",
+    "q or Esc             quit",
+];
 
 /// Returns the portion of a content area left after a sticky file header row.
 const fn area_below_sticky_header(area: Rect) -> Rect {
@@ -405,6 +435,25 @@ mod tests {
         assert!(draw_result.is_ok());
 
         assert!(buffer_line(terminal.backend().buffer(), 4).contains("/alpha  1/1"));
+    }
+
+    #[test]
+    fn help_action_shows_diff_specific_keys() {
+        let mut view = DiffView::new(snapshot("aaa", "Modified regular file src/a.rs:\n alpha\n"));
+        let _ = view.apply(DiffAction::ToggleHelp);
+        let backend = TestBackend::new(72, 18);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("Diff keys"));
+        assert!(rendered.contains("[ / ]                previous/next file"));
+        assert!(rendered.contains("/, n, N              search, next, previous"));
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_view.rs
+++ b/crates/jk-tui/src/diff_view.rs
@@ -254,6 +254,10 @@ impl DiffView {
             }
             DiffAction::Refresh => DiffActionResult::Refresh,
             DiffAction::ReturnToLog => DiffActionResult::ReturnToLog,
+            DiffAction::Quit if self.help_visible => {
+                self.help_visible = false;
+                DiffActionResult::Continue
+            }
             DiffAction::Quit => DiffActionResult::Quit,
         }
     }
@@ -343,7 +347,7 @@ impl DiffView {
 
 const DIFF_HELP: &[&str] = &[
     "j/k or arrows        scroll one line",
-    "space, Ctrl-f/b      page down/up",
+    "space / b, Ctrl-f/b  page down/up",
     "g/G or Home/End      jump to top/bottom",
     "[ / ]                previous/next file",
     "{ / }                previous/next hunk",
@@ -354,8 +358,7 @@ const DIFF_HELP: &[&str] = &[
     "/, n, N              search, next, previous",
     "r                    refresh",
     "H / L                return to log",
-    "?                    close help",
-    "q or Esc             quit",
+    "?, q, Esc            close help",
 ];
 
 /// Returns the portion of a content area left after a sticky file header row.
@@ -524,6 +527,15 @@ mod tests {
         assert!(rendered.contains("Diff keys"));
         assert!(rendered.contains("[ / ]                previous/next file"));
         assert!(rendered.contains("/, n, N              search, next, previous"));
+    }
+
+    #[test]
+    fn quit_closes_diff_help_before_quitting() {
+        let mut view = DiffView::new(snapshot("aaa", "Modified regular file src/a.rs:\n alpha\n"));
+        let _ = view.apply(DiffAction::ToggleHelp);
+
+        assert_eq!(view.apply(DiffAction::Quit), DiffActionResult::Continue);
+        assert_eq!(view.apply(DiffAction::Quit), DiffActionResult::Quit);
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_view.rs
+++ b/crates/jk-tui/src/diff_view.rs
@@ -129,6 +129,19 @@ impl DiffView {
         }
     }
 
+    /// Creates a diff view that starts in an error state for an unloaded target.
+    #[must_use]
+    pub fn from_error(
+        change_id: impl Into<String>,
+        title: impl Into<String>,
+        error: String,
+    ) -> Self {
+        let snapshot = DiffSnapshot::new(change_id, "").with_title(title);
+        let mut view = Self::new(snapshot);
+        view.show_error(error);
+        view
+    }
+
     /// Returns the target change identifier for refresh requests.
     #[must_use]
     pub fn change_id(&self) -> &str {
@@ -283,7 +296,7 @@ impl DiffView {
         let chrome = ViewChrome::new(self.state.title(), status);
         chrome.render(frame, areas);
 
-        let rendered = self.state.visible_rendered();
+        let rendered = self.visible_body();
         let text = rendered_text(&rendered);
         let scroll = u16::try_from(self.state.scroll_offset()).unwrap_or(u16::MAX);
         let horizontal_scroll = u16::try_from(self.state.horizontal_offset()).unwrap_or(u16::MAX);
@@ -307,6 +320,24 @@ impl DiffView {
         if self.help_visible {
             render_help_overlay(frame, areas.content, "Diff keys", DIFF_HELP);
         }
+    }
+
+    fn visible_body(&self) -> String {
+        if !self.state.is_empty_diff() {
+            return self.state.visible_rendered();
+        }
+
+        if let Some(error) = &self.status_message {
+            return format!(
+                "Unable to load diff for {}.\n\n{error}\n\nPress r to retry or H/L to return to the log.\n",
+                self.state.change_id()
+            );
+        }
+
+        format!(
+            "No diff for {}.\n\nThis change has no file content differences.\n",
+            self.state.change_id()
+        )
     }
 }
 
@@ -384,6 +415,45 @@ mod tests {
         let rendered = buffer_to_string(terminal.backend().buffer());
         assert!(rendered.contains("Modified regular file src/b.rs:"));
         assert!(buffer_line(terminal.backend().buffer(), 4).contains("r refresh"));
+    }
+
+    #[test]
+    fn empty_diff_renders_intentional_message() {
+        let mut view = DiffView::new(snapshot("aaa", ""));
+        let backend = TestBackend::new(64, 7);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("No diff for aaa."));
+        assert!(rendered.contains("This change has no file content differences."));
+    }
+
+    #[test]
+    fn initial_diff_error_renders_retryable_message() {
+        let mut view = DiffView::from_error(
+            "missing",
+            "jj diff -r missing",
+            "jj failed: Revision missing doesn't exist".to_owned(),
+        );
+        let backend = TestBackend::new(72, 8);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("Unable to load diff for missing."));
+        assert!(rendered.contains("Revision missing doesn't exist"));
+        assert!(rendered.contains("Press r to retry"));
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_view.rs
+++ b/crates/jk-tui/src/diff_view.rs
@@ -64,6 +64,12 @@ pub enum DiffAction {
     /// Jump to the next hunk.
     NextHunk,
 
+    /// Fold the selected hunk.
+    FoldHunk,
+
+    /// Unfold the selected hunk.
+    UnfoldHunk,
+
     /// Fold the selected file section.
     FoldFile,
 
@@ -178,6 +184,14 @@ impl DiffView {
             }
             DiffAction::NextHunk => {
                 self.state.select_next_hunk();
+                DiffActionResult::Continue
+            }
+            DiffAction::FoldHunk => {
+                self.state.fold_selected_hunk();
+                DiffActionResult::Continue
+            }
+            DiffAction::UnfoldHunk => {
+                self.state.unfold_selected_hunk();
                 DiffActionResult::Continue
             }
             DiffAction::FoldFile => {

--- a/crates/jk-tui/src/diff_view.rs
+++ b/crates/jk-tui/src/diff_view.rs
@@ -70,6 +70,12 @@ pub enum DiffAction {
     /// Unfold every file section.
     UnfoldAll,
 
+    /// Scroll wide diff lines toward the start.
+    ScrollLeft,
+
+    /// Scroll wide diff lines toward the end.
+    ScrollRight,
+
     /// Search visible diff lines for text.
     Search(String),
 
@@ -176,6 +182,14 @@ impl DiffView {
                 self.state.unfold_all_files();
                 DiffActionResult::Continue
             }
+            DiffAction::ScrollLeft => {
+                self.state.scroll_left();
+                DiffActionResult::Continue
+            }
+            DiffAction::ScrollRight => {
+                self.state.scroll_right();
+                DiffActionResult::Continue
+            }
             DiffAction::Search(query) => {
                 self.state.search(&query);
                 DiffActionResult::Continue
@@ -210,6 +224,8 @@ impl DiffView {
         let areas = ViewChrome::layout(area);
         let height = usize::from(areas.content.height);
         self.state.keep_selected_in_view(height);
+        self.state
+            .set_viewport_width(usize::from(areas.content.width));
         let sticky_header = self.state.sticky_header();
         let body_area = if sticky_header.is_some() {
             area_below_sticky_header(areas.content)
@@ -218,11 +234,14 @@ impl DiffView {
         };
         self.state
             .keep_selected_in_view(usize::from(body_area.height));
+        self.state.set_viewport_width(usize::from(body_area.width));
 
         let search_status = self.state.search_status();
+        let horizontal_status = self.state.horizontal_status();
         let status = status_override
             .or(self.status_message.as_deref())
             .or(search_status.as_deref())
+            .or(horizontal_status.as_deref())
             .unwrap_or(DIFF_STATUS);
         let chrome = ViewChrome::new(self.state.title(), status);
         chrome.render(frame, areas);
@@ -230,7 +249,8 @@ impl DiffView {
         let rendered = self.state.visible_rendered();
         let text = rendered_text(&rendered);
         let scroll = u16::try_from(self.state.scroll_offset()).unwrap_or(u16::MAX);
-        let paragraph = Paragraph::new(text).scroll((scroll, 0));
+        let horizontal_scroll = u16::try_from(self.state.horizontal_offset()).unwrap_or(u16::MAX);
+        let paragraph = Paragraph::new(text).scroll((scroll, horizontal_scroll));
         frame.render_widget(paragraph, body_area);
 
         if let Some(header) = sticky_header {
@@ -238,7 +258,7 @@ impl DiffView {
                 height: 1,
                 ..areas.content
             };
-            let paragraph = Paragraph::new(rendered_text(&header));
+            let paragraph = Paragraph::new(rendered_text(&header)).scroll((0, horizontal_scroll));
             frame.render_widget(paragraph, sticky_area);
             paint_subtle_selected_row(frame, sticky_area, 0, 0);
         }
@@ -357,6 +377,28 @@ mod tests {
         assert!(draw_result.is_ok());
 
         assert!(buffer_line(terminal.backend().buffer(), 4).contains("/alpha  1/1"));
+    }
+
+    #[test]
+    fn horizontal_scroll_shifts_body_and_reports_column() {
+        let mut view = DiffView::new(snapshot(
+            "aaa",
+            "Modified regular file src/a.rs:\n 1234567890123456789012345678901234567890\n",
+        ));
+        let backend = TestBackend::new(32, 5);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+        let _ = view.apply(DiffAction::ScrollRight);
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        assert_eq!(view.state.horizontal_offset(), 8);
+        assert!(buffer_line(terminal.backend().buffer(), 4).contains("col 9"));
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_view.rs
+++ b/crates/jk-tui/src/diff_view.rs
@@ -58,6 +58,12 @@ pub enum DiffAction {
     /// Jump to the next file section.
     NextFile,
 
+    /// Jump to the previous hunk.
+    PreviousHunk,
+
+    /// Jump to the next hunk.
+    NextHunk,
+
     /// Fold the selected file section.
     FoldFile,
 
@@ -164,6 +170,14 @@ impl DiffView {
             }
             DiffAction::NextFile => {
                 self.state.select_next_file();
+                DiffActionResult::Continue
+            }
+            DiffAction::PreviousHunk => {
+                self.state.select_previous_hunk();
+                DiffActionResult::Continue
+            }
+            DiffAction::NextHunk => {
+                self.state.select_next_hunk();
                 DiffActionResult::Continue
             }
             DiffAction::FoldFile => {

--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -69,6 +69,12 @@ pub enum LogAction {
     /// Move to the next file section in views that support file sections.
     NextFile,
 
+    /// Scroll horizontally toward the start in views that support wide content.
+    HorizontalPrevious,
+
+    /// Scroll horizontally toward the end in views that support wide content.
+    HorizontalNext,
+
     /// Fold all collapsible sections in views that support sections.
     FoldAll,
 
@@ -172,6 +178,8 @@ impl LogView {
             }
             LogAction::PreviousFile
             | LogAction::NextFile
+            | LogAction::HorizontalPrevious
+            | LogAction::HorizontalNext
             | LogAction::FoldAll
             | LogAction::UnfoldAll => ActionResult::Continue,
             LogAction::ToggleExpanded => {

--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -10,7 +10,7 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::widgets::Paragraph;
 
-use crate::chrome::{LOG_STATUS, ViewChrome};
+use crate::chrome::{LOG_STATUS, ViewChrome, render_help_overlay};
 use crate::log_state::LogState;
 use crate::rendered_log::{ExpandedDetails, RenderedLog, rendered_text};
 use crate::selected_row::paint_selected_row;
@@ -111,6 +111,9 @@ pub enum LogAction {
     /// Open the selected change's diff.
     OpenDiff,
 
+    /// Toggle mode-specific help.
+    ToggleHelp,
+
     /// Quit the TUI.
     Quit,
 }
@@ -124,6 +127,7 @@ pub enum LogAction {
 pub struct LogView {
     state: LogState,
     status_message: Option<String>,
+    help_visible: bool,
 }
 
 impl LogView {
@@ -133,6 +137,7 @@ impl LogView {
         Self {
             state: LogState::new(snapshot),
             status_message: None,
+            help_visible: false,
         }
     }
 
@@ -216,6 +221,10 @@ impl LogView {
                     ActionResult::Continue
                 }
             }
+            LogAction::ToggleHelp => {
+                self.help_visible = !self.help_visible;
+                ActionResult::Continue
+            }
             LogAction::Quit => ActionResult::Quit,
         }
     }
@@ -251,8 +260,25 @@ impl LogView {
         if let Some(line) = self.state.selected_rendered_line() {
             paint_selected_row(frame, areas.content, line, self.state.scroll_offset());
         }
+
+        if self.help_visible {
+            render_help_overlay(frame, areas.content, "Log keys", LOG_HELP);
+        }
     }
 }
+
+const LOG_HELP: &[&str] = &[
+    "j/k or arrows        move selection",
+    "space, Ctrl-f/b      page down/up",
+    "g/G or Home/End      jump to top/bottom",
+    "enter, right, l      expand selected change",
+    "left, h              collapse selected change",
+    "d                    open selected-change diff",
+    "r                    refresh",
+    "H / L                home command / jj log",
+    "?                    close help",
+    "q or Esc             quit",
+];
 
 #[cfg(test)]
 mod tests {
@@ -315,6 +341,25 @@ mod tests {
         let buffer = terminal.backend().buffer();
         assert!(buffer_line(buffer, 0).contains("jk jj log"));
         assert!(buffer_line(buffer, 3).contains("r refresh"));
+    }
+
+    #[test]
+    fn help_action_shows_log_specific_keys() {
+        let mut view = LogView::new(snapshot(["aaa"]));
+        let _ = view.apply(LogAction::ToggleHelp);
+        let backend = TestBackend::new(72, 16);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("Log keys"));
+        assert!(rendered.contains("d                    open selected-change diff"));
+        assert!(rendered.contains("?                    close help"));
     }
 
     #[test]

--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -225,6 +225,10 @@ impl LogView {
                 self.help_visible = !self.help_visible;
                 ActionResult::Continue
             }
+            LogAction::Quit if self.help_visible => {
+                self.help_visible = false;
+                ActionResult::Continue
+            }
             LogAction::Quit => ActionResult::Quit,
         }
     }
@@ -269,15 +273,14 @@ impl LogView {
 
 const LOG_HELP: &[&str] = &[
     "j/k or arrows        move selection",
-    "space, Ctrl-f/b      page down/up",
+    "space / b, Ctrl-f/b  page down/up",
     "g/G or Home/End      jump to top/bottom",
     "enter, right, l      expand selected change",
     "left, h              collapse selected change",
     "d                    open selected-change diff",
     "r                    refresh",
     "H / L                home command / jj log",
-    "?                    close help",
-    "q or Esc             quit",
+    "?, q, Esc            close help",
 ];
 
 #[cfg(test)]
@@ -359,7 +362,16 @@ mod tests {
         let rendered = buffer_to_string(terminal.backend().buffer());
         assert!(rendered.contains("Log keys"));
         assert!(rendered.contains("d                    open selected-change diff"));
-        assert!(rendered.contains("?                    close help"));
+        assert!(rendered.contains("?, q, Esc            close help"));
+    }
+
+    #[test]
+    fn quit_closes_log_help_before_quitting() {
+        let mut view = LogView::new(snapshot(["aaa"]));
+        let _ = view.apply(LogAction::ToggleHelp);
+
+        assert_eq!(view.apply(LogAction::Quit), ActionResult::Continue);
+        assert_eq!(view.apply(LogAction::Quit), ActionResult::Quit);
     }
 
     #[test]

--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -69,6 +69,12 @@ pub enum LogAction {
     /// Move to the next file section in views that support file sections.
     NextFile,
 
+    /// Move to the previous hunk in views that support diff hunks.
+    PreviousHunk,
+
+    /// Move to the next hunk in views that support diff hunks.
+    NextHunk,
+
     /// Scroll horizontally toward the start in views that support wide content.
     HorizontalPrevious,
 
@@ -178,6 +184,8 @@ impl LogView {
             }
             LogAction::PreviousFile
             | LogAction::NextFile
+            | LogAction::PreviousHunk
+            | LogAction::NextHunk
             | LogAction::HorizontalPrevious
             | LogAction::HorizontalNext
             | LogAction::FoldAll

--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -75,6 +75,12 @@ pub enum LogAction {
     /// Move to the next hunk in views that support diff hunks.
     NextHunk,
 
+    /// Fold the selected hunk in views that support diff hunks.
+    FoldHunk,
+
+    /// Unfold the selected hunk in views that support diff hunks.
+    UnfoldHunk,
+
     /// Scroll horizontally toward the start in views that support wide content.
     HorizontalPrevious,
 
@@ -186,6 +192,8 @@ impl LogView {
             | LogAction::NextFile
             | LogAction::PreviousHunk
             | LogAction::NextHunk
+            | LogAction::FoldHunk
+            | LogAction::UnfoldHunk
             | LogAction::HorizontalPrevious
             | LogAction::HorizontalNext
             | LogAction::FoldAll

--- a/crates/jk/src/key.rs
+++ b/crates/jk/src/key.rs
@@ -97,6 +97,7 @@ const fn action_for_character_key(character: char) -> Option<AppKey> {
         'L' => Some(AppKey::Action(LogAction::Log)),
         'l' => Some(AppKey::Action(LogAction::ToggleExpanded)),
         'd' => Some(AppKey::Action(LogAction::OpenDiff)),
+        '?' => Some(AppKey::Action(LogAction::ToggleHelp)),
         '/' => Some(AppKey::StartSearch),
         'n' => Some(AppKey::SearchNext),
         'N' => Some(AppKey::SearchPrevious),
@@ -181,6 +182,14 @@ mod tests {
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE)),
             AppKey::Action(LogAction::OpenDiff)
+        );
+    }
+
+    #[test]
+    fn question_mark_toggles_mode_help() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE)),
+            AppKey::Action(LogAction::ToggleHelp)
         );
     }
 

--- a/crates/jk/src/key.rs
+++ b/crates/jk/src/key.rs
@@ -33,53 +33,26 @@ impl AppKey {
             return action_for_control_key(key.code);
         }
 
+        if let KeyCode::Char(character) = key.code
+            && let Some(action) = action_for_character_key(character)
+        {
+            return action;
+        }
+
         match key {
             KeyEvent {
                 code: KeyCode::Char('q') | KeyCode::Esc,
                 ..
             } => Self::Action(LogAction::Quit),
             KeyEvent {
-                code: KeyCode::Char('r'),
-                ..
-            } => Self::Action(LogAction::Refresh),
-            KeyEvent {
-                code: KeyCode::Char('H'),
-                ..
-            } => Self::Action(LogAction::Home),
-            KeyEvent {
-                code: KeyCode::Char('L'),
-                ..
-            } => Self::Action(LogAction::Log),
-            KeyEvent {
-                code: KeyCode::Char('l'),
-                ..
-            }
-            | KeyEvent {
-                code: KeyCode::Enter | KeyCode::Right,
+                code: KeyCode::Right | KeyCode::Enter,
                 ..
             } => Self::Action(LogAction::ToggleExpanded),
             KeyEvent {
-                code: KeyCode::Char('d'),
-                ..
-            } => Self::Action(LogAction::OpenDiff),
-            KeyEvent {
-                code: KeyCode::Char('/'),
-                ..
-            } => Self::StartSearch,
-            KeyEvent {
-                code: KeyCode::Char('n'),
-                ..
-            } => Self::SearchNext,
-            KeyEvent {
-                code: KeyCode::Char('N'),
-                ..
-            } => Self::SearchPrevious,
-            KeyEvent {
-                code: KeyCode::Char('k') | KeyCode::Up,
-                ..
+                code: KeyCode::Up, ..
             } => Self::Action(LogAction::Previous),
             KeyEvent {
-                code: KeyCode::Char('j') | KeyCode::Down,
+                code: KeyCode::Down,
                 ..
             } => Self::Action(LogAction::Next),
             KeyEvent {
@@ -100,35 +73,45 @@ impl AppKey {
                 ..
             } => Self::Action(LogAction::PageNext),
             KeyEvent {
-                code: KeyCode::Char('g') | KeyCode::Home,
+                code: KeyCode::Home,
                 ..
             } => Self::Action(LogAction::First),
             KeyEvent {
-                code: KeyCode::Char('G') | KeyCode::End,
-                ..
+                code: KeyCode::End, ..
             } => Self::Action(LogAction::Last),
             KeyEvent {
-                code: KeyCode::Char('['),
-                ..
-            } => Self::Action(LogAction::PreviousFile),
-            KeyEvent {
-                code: KeyCode::Char(']'),
-                ..
-            } => Self::Action(LogAction::NextFile),
-            KeyEvent {
-                code: KeyCode::Char('<'),
-                ..
-            } => Self::Action(LogAction::HorizontalPrevious),
-            KeyEvent {
-                code: KeyCode::Char('>'),
-                ..
-            } => Self::Action(LogAction::HorizontalNext),
-            KeyEvent {
-                code: KeyCode::Char('h') | KeyCode::Left,
+                code: KeyCode::Left,
                 ..
             } => Self::Action(LogAction::CollapseExpanded),
             _ => Self::Ignore,
         }
+    }
+}
+
+/// Interprets unmodified character keys.
+const fn action_for_character_key(character: char) -> Option<AppKey> {
+    match character {
+        'q' => Some(AppKey::Action(LogAction::Quit)),
+        'r' => Some(AppKey::Action(LogAction::Refresh)),
+        'H' => Some(AppKey::Action(LogAction::Home)),
+        'L' => Some(AppKey::Action(LogAction::Log)),
+        'l' => Some(AppKey::Action(LogAction::ToggleExpanded)),
+        'd' => Some(AppKey::Action(LogAction::OpenDiff)),
+        '/' => Some(AppKey::StartSearch),
+        'n' => Some(AppKey::SearchNext),
+        'N' => Some(AppKey::SearchPrevious),
+        'k' => Some(AppKey::Action(LogAction::Previous)),
+        'j' => Some(AppKey::Action(LogAction::Next)),
+        'g' => Some(AppKey::Action(LogAction::First)),
+        'G' => Some(AppKey::Action(LogAction::Last)),
+        '[' => Some(AppKey::Action(LogAction::PreviousFile)),
+        ']' => Some(AppKey::Action(LogAction::NextFile)),
+        '{' => Some(AppKey::Action(LogAction::PreviousHunk)),
+        '}' => Some(AppKey::Action(LogAction::NextHunk)),
+        '<' => Some(AppKey::Action(LogAction::HorizontalPrevious)),
+        '>' => Some(AppKey::Action(LogAction::HorizontalNext)),
+        'h' => Some(AppKey::Action(LogAction::CollapseExpanded)),
+        _ => None,
     }
 }
 
@@ -236,6 +219,18 @@ mod tests {
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('>'), KeyModifiers::NONE)),
             AppKey::Action(LogAction::HorizontalNext)
+        );
+    }
+
+    #[test]
+    fn braces_jump_between_diff_hunks() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('{'), KeyModifiers::NONE)),
+            AppKey::Action(LogAction::PreviousHunk)
+        );
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('}'), KeyModifiers::NONE)),
+            AppKey::Action(LogAction::NextHunk)
         );
     }
 

--- a/crates/jk/src/key.rs
+++ b/crates/jk/src/key.rs
@@ -116,6 +116,14 @@ impl AppKey {
                 ..
             } => Self::Action(LogAction::NextFile),
             KeyEvent {
+                code: KeyCode::Char('<'),
+                ..
+            } => Self::Action(LogAction::HorizontalPrevious),
+            KeyEvent {
+                code: KeyCode::Char('>'),
+                ..
+            } => Self::Action(LogAction::HorizontalNext),
+            KeyEvent {
                 code: KeyCode::Char('h') | KeyCode::Left,
                 ..
             } => Self::Action(LogAction::CollapseExpanded),
@@ -216,6 +224,18 @@ mod tests {
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char(']'), KeyModifiers::NONE)),
             AppKey::Action(LogAction::NextFile)
+        );
+    }
+
+    #[test]
+    fn angle_brackets_scroll_horizontally() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('<'), KeyModifiers::NONE)),
+            AppKey::Action(LogAction::HorizontalPrevious)
+        );
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('>'), KeyModifiers::NONE)),
+            AppKey::Action(LogAction::HorizontalNext)
         );
     }
 

--- a/crates/jk/src/key.rs
+++ b/crates/jk/src/key.rs
@@ -13,6 +13,15 @@ pub enum AppKey {
     /// Dispatch this action to the active view.
     Action(LogAction),
 
+    /// Start a search prompt in views that support search.
+    StartSearch,
+
+    /// Jump to the next search match.
+    SearchNext,
+
+    /// Jump to the previous search match.
+    SearchPrevious,
+
     /// Leave the active view unchanged.
     Ignore,
 }
@@ -53,6 +62,18 @@ impl AppKey {
                 code: KeyCode::Char('d'),
                 ..
             } => Self::Action(LogAction::OpenDiff),
+            KeyEvent {
+                code: KeyCode::Char('/'),
+                ..
+            } => Self::StartSearch,
+            KeyEvent {
+                code: KeyCode::Char('n'),
+                ..
+            } => Self::SearchNext,
+            KeyEvent {
+                code: KeyCode::Char('N'),
+                ..
+            } => Self::SearchPrevious,
             KeyEvent {
                 code: KeyCode::Char('k') | KeyCode::Up,
                 ..
@@ -167,6 +188,22 @@ mod tests {
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE)),
             AppKey::Action(LogAction::OpenDiff)
+        );
+    }
+
+    #[test]
+    fn slash_and_navigate_search_matches() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE)),
+            AppKey::StartSearch
+        );
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
+            AppKey::SearchNext
+        );
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('N'), KeyModifiers::NONE)),
+            AppKey::SearchPrevious
         );
     }
 

--- a/crates/jk/src/key.rs
+++ b/crates/jk/src/key.rs
@@ -108,6 +108,8 @@ const fn action_for_character_key(character: char) -> Option<AppKey> {
         ']' => Some(AppKey::Action(LogAction::NextFile)),
         '{' => Some(AppKey::Action(LogAction::PreviousHunk)),
         '}' => Some(AppKey::Action(LogAction::NextHunk)),
+        '-' => Some(AppKey::Action(LogAction::FoldHunk)),
+        '+' => Some(AppKey::Action(LogAction::UnfoldHunk)),
         '<' => Some(AppKey::Action(LogAction::HorizontalPrevious)),
         '>' => Some(AppKey::Action(LogAction::HorizontalNext)),
         'h' => Some(AppKey::Action(LogAction::CollapseExpanded)),
@@ -231,6 +233,18 @@ mod tests {
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('}'), KeyModifiers::NONE)),
             AppKey::Action(LogAction::NextHunk)
+        );
+    }
+
+    #[test]
+    fn minus_and_plus_fold_and_unfold_diff_hunks() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('-'), KeyModifiers::NONE)),
+            AppKey::Action(LogAction::FoldHunk)
+        );
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('+'), KeyModifiers::NONE)),
+            AppKey::Action(LogAction::UnfoldHunk)
         );
     }
 

--- a/crates/jk/src/key.rs
+++ b/crates/jk/src/key.rs
@@ -101,6 +101,7 @@ const fn action_for_character_key(character: char) -> Option<AppKey> {
         '/' => Some(AppKey::StartSearch),
         'n' => Some(AppKey::SearchNext),
         'N' => Some(AppKey::SearchPrevious),
+        'b' => Some(AppKey::Action(LogAction::PagePrevious)),
         'k' => Some(AppKey::Action(LogAction::Previous)),
         'j' => Some(AppKey::Action(LogAction::Next)),
         'g' => Some(AppKey::Action(LogAction::First)),
@@ -281,6 +282,10 @@ mod tests {
         );
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL)),
+            AppKey::Action(LogAction::PagePrevious)
+        );
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE)),
             AppKey::Action(LogAction::PagePrevious)
         );
         assert_eq!(

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -348,6 +348,8 @@ fn apply_diff_action(
         jk_tui::log_view::LogAction::NextFile => DiffAction::NextFile,
         jk_tui::log_view::LogAction::PreviousHunk => DiffAction::PreviousHunk,
         jk_tui::log_view::LogAction::NextHunk => DiffAction::NextHunk,
+        jk_tui::log_view::LogAction::FoldHunk => DiffAction::FoldHunk,
+        jk_tui::log_view::LogAction::UnfoldHunk => DiffAction::UnfoldHunk,
         jk_tui::log_view::LogAction::HorizontalPrevious => DiffAction::ScrollLeft,
         jk_tui::log_view::LogAction::HorizontalNext => DiffAction::ScrollRight,
         jk_tui::log_view::LogAction::ToggleExpanded => DiffAction::UnfoldFile,

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -68,10 +68,18 @@ fn main() -> Result<()> {
     let source = log_source(&args);
     let diff_source = diff_source(&args);
     let app = if let Some(Command::Diff(diff_args)) = &args.command {
-        let snapshot = diff_source.load(&diff_args.revision)?;
+        let snapshot = diff_source.load(&diff_args.revision);
+        let diff = match snapshot {
+            Ok(snapshot) => DiffView::new(snapshot),
+            Err(error) => DiffView::from_error(
+                diff_args.revision.clone(),
+                format!("jj diff -r {}", diff_args.revision),
+                error.to_string(),
+            ),
+        };
         AppView::Diff {
             log: None,
-            diff: Box::new(DiffView::new(snapshot)),
+            diff: Box::new(diff),
         }
     } else {
         let entries = source.load()?;

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -346,6 +346,8 @@ fn apply_diff_action(
         jk_tui::log_view::LogAction::Last => DiffAction::Last,
         jk_tui::log_view::LogAction::PreviousFile => DiffAction::PreviousFile,
         jk_tui::log_view::LogAction::NextFile => DiffAction::NextFile,
+        jk_tui::log_view::LogAction::PreviousHunk => DiffAction::PreviousHunk,
+        jk_tui::log_view::LogAction::NextHunk => DiffAction::NextHunk,
         jk_tui::log_view::LogAction::HorizontalPrevious => DiffAction::ScrollLeft,
         jk_tui::log_view::LogAction::HorizontalNext => DiffAction::ScrollRight,
         jk_tui::log_view::LogAction::ToggleExpanded => DiffAction::UnfoldFile,

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use color_eyre::Result;
-use crossterm::event::{self, Event};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::style::force_color_output;
 use jk_cli::{JjDiff, JjLog, JjLogCommand};
 use jk_tui::diff_view::{DiffAction, DiffActionResult, DiffView};
@@ -71,7 +71,7 @@ fn main() -> Result<()> {
         let snapshot = diff_source.load(&diff_args.revision)?;
         AppView::Diff {
             log: None,
-            diff: DiffView::new(snapshot),
+            diff: Box::new(DiffView::new(snapshot)),
         }
     } else {
         let entries = source.load()?;
@@ -117,7 +117,7 @@ enum AppView {
     Log(LogView),
     Diff {
         log: Option<LogView>,
-        diff: DiffView,
+        diff: Box<DiffView>,
     },
 }
 
@@ -133,19 +133,48 @@ fn run_terminal(mut app: AppView, mut source: JjLog, diff_source: &JjDiff) -> Re
     let mut terminal = ratatui::try_init().inspect_err(|_| ratatui::restore())?;
     let _terminal_restore = TerminalRestore;
     let mut needs_redraw = true;
+    let mut input_mode = InputMode::Normal;
 
     loop {
         if needs_redraw {
             terminal.draw(|frame| match &mut app {
                 AppView::Log(log) => log.render(frame),
-                AppView::Diff { diff, .. } => diff.render(frame),
+                AppView::Diff { diff, .. } => match &input_mode {
+                    InputMode::Normal => diff.render(frame),
+                    InputMode::DiffSearch { query } => {
+                        let status = format!("/{query}");
+                        diff.render_with_status(frame, &status);
+                    }
+                },
             })?;
             needs_redraw = false;
         }
 
         match event::read()? {
             Event::Key(key) => {
+                if handle_input_mode(&mut app, &mut input_mode, key) == InputModeResult::Handled {
+                    needs_redraw = true;
+                    continue;
+                }
+
                 let AppKey::Action(action) = AppKey::from_crossterm(key) else {
+                    match AppKey::from_crossterm(key) {
+                        AppKey::StartSearch if matches!(app, AppView::Diff { .. }) => {
+                            input_mode = InputMode::DiffSearch {
+                                query: String::new(),
+                            };
+                            needs_redraw = true;
+                        }
+                        AppKey::SearchNext => {
+                            apply_diff_search_action(&mut app, DiffAction::SearchNext);
+                            needs_redraw = true;
+                        }
+                        AppKey::SearchPrevious => {
+                            apply_diff_search_action(&mut app, DiffAction::SearchPrevious);
+                            needs_redraw = true;
+                        }
+                        _ => {}
+                    }
                     continue;
                 };
 
@@ -162,6 +191,71 @@ fn run_terminal(mut app: AppView, mut source: JjLog, diff_source: &JjDiff) -> Re
     }
 
     Ok(())
+}
+
+/// Transient input modes owned by the terminal loop.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum InputMode {
+    Normal,
+    DiffSearch { query: String },
+}
+
+/// Whether an input-mode handler consumed a key event.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InputModeResult {
+    Handled,
+    Unhandled,
+}
+
+/// Handles key input while a prompt-like mode is active.
+fn handle_input_mode(
+    app: &mut AppView,
+    input_mode: &mut InputMode,
+    key: KeyEvent,
+) -> InputModeResult {
+    let InputMode::DiffSearch { query } = input_mode else {
+        return InputModeResult::Unhandled;
+    };
+
+    match key {
+        KeyEvent {
+            code: KeyCode::Esc, ..
+        } => {
+            *input_mode = InputMode::Normal;
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Enter,
+            ..
+        } => {
+            apply_diff_search_action(app, DiffAction::Search(query.clone()));
+            *input_mode = InputMode::Normal;
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Backspace,
+            ..
+        } => {
+            query.pop();
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Char(character),
+            modifiers,
+            ..
+        } if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
+            query.push(character);
+            InputModeResult::Handled
+        }
+        _ => InputModeResult::Handled,
+    }
+}
+
+/// Applies a search-only diff action when the active view supports it.
+fn apply_diff_search_action(app: &mut AppView, action: DiffAction) {
+    if let AppView::Diff { diff, .. } = app {
+        let _ = diff.apply(action);
+    }
 }
 
 /// Applies an action to the active view and performs any requested I/O.
@@ -228,7 +322,7 @@ fn apply_log_action(
         match diff_source.load(&change_id) {
             Ok(snapshot) => {
                 let diff = DiffView::new(snapshot);
-                return AppTransition::OpenDiff(diff);
+                return AppTransition::OpenDiff(Box::new(diff));
             }
             Err(error) => log.show_error(error.to_string()),
         }
@@ -283,7 +377,7 @@ enum AppLoop {
 #[derive(Debug)]
 enum AppTransition {
     Continue,
-    OpenDiff(DiffView),
+    OpenDiff(Box<DiffView>),
     ReturnToLog,
     Quit,
 }

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -346,6 +346,8 @@ fn apply_diff_action(
         jk_tui::log_view::LogAction::Last => DiffAction::Last,
         jk_tui::log_view::LogAction::PreviousFile => DiffAction::PreviousFile,
         jk_tui::log_view::LogAction::NextFile => DiffAction::NextFile,
+        jk_tui::log_view::LogAction::HorizontalPrevious => DiffAction::ScrollLeft,
+        jk_tui::log_view::LogAction::HorizontalNext => DiffAction::ScrollRight,
         jk_tui::log_view::LogAction::ToggleExpanded => DiffAction::UnfoldFile,
         jk_tui::log_view::LogAction::CollapseExpanded => DiffAction::FoldFile,
         jk_tui::log_view::LogAction::FoldAll => DiffAction::FoldAll,

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -352,6 +352,7 @@ fn apply_diff_action(
         jk_tui::log_view::LogAction::UnfoldHunk => DiffAction::UnfoldHunk,
         jk_tui::log_view::LogAction::HorizontalPrevious => DiffAction::ScrollLeft,
         jk_tui::log_view::LogAction::HorizontalNext => DiffAction::ScrollRight,
+        jk_tui::log_view::LogAction::ToggleHelp => DiffAction::ToggleHelp,
         jk_tui::log_view::LogAction::ToggleExpanded => DiffAction::UnfoldFile,
         jk_tui::log_view::LogAction::CollapseExpanded => DiffAction::FoldFile,
         jk_tui::log_view::LogAction::FoldAll => DiffAction::FoldAll,

--- a/justfile
+++ b/justfile
@@ -25,8 +25,13 @@ check:
 test:
     cargo test --workspace
 
-betamax:
-    cargo run --manifest-path ../betamax/Cargo.toml -p betamax -- run tapes/jk-log.tape
+betamax: betamax-log betamax-diff
+
+betamax-log:
+    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run tapes/jk-log.tape
+
+betamax-diff:
+    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run tapes/jk-diff.tape
 
 clippy:
     cargo clippy --workspace --all-targets -- -D warnings

--- a/tapes/jk-diff.tape
+++ b/tapes/jk-diff.tape
@@ -1,0 +1,90 @@
+Output target/betamax/jk-diff.gif
+Output target/betamax/jk-diff-final-state.json
+
+Require cargo
+Require jj
+
+Set Shell "bash"
+Set Theme "Aardvark Ink"
+Set FontSize 22
+Set Width 1200
+Set Height 720
+Set Margin 12
+Set WindowBar Colorful
+Set BorderRadius 8
+Set CursorBlink false
+Set TypingSpeed 20ms
+Set WaitTimeout 30s
+Env NO_COLOR "1"
+
+Hide
+Type "repo=${JK_REPO:-$HOME/local/jk/default}"
+Enter
+Wait
+Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && pwd"
+Enter
+Wait+Screen "/local/jk"
+Type "cargo build --manifest-path Cargo.toml -p jk >/tmp/jk-betamax-build.log 2>&1 && echo JK_BUILD_READY"
+Enter
+Wait+Screen "JK_BUILD_READY"
+Show
+
+Type "./target/debug/jk -R . -n 8"
+Enter
+Wait+Screen "jk jj"
+Sleep 500ms
+Type "d"
+Wait+Screen "jk jj diff"
+Sleep 500ms
+Screenshot target/betamax/jk-diff-open.png
+State target/betamax/jk-diff-open.json
+
+Type "?"
+Sleep 300ms
+Screenshot target/betamax/jk-diff-help.png
+State target/betamax/jk-diff-help.json
+
+Type "?"
+Sleep 300ms
+Type "/"
+Sleep 200ms
+Type "diff"
+Enter
+Sleep 300ms
+Screenshot target/betamax/jk-diff-search.png
+State target/betamax/jk-diff-search.json
+
+Type "}"
+Sleep 300ms
+Screenshot target/betamax/jk-diff-next-hunk.png
+State target/betamax/jk-diff-next-hunk.json
+
+Type "-"
+Sleep 300ms
+Screenshot target/betamax/jk-diff-fold-hunk.png
+State target/betamax/jk-diff-fold-hunk.json
+
+Type "+"
+Sleep 300ms
+Type "h"
+Sleep 300ms
+Screenshot target/betamax/jk-diff-fold-file.png
+State target/betamax/jk-diff-fold-file.json
+
+Type "l"
+Sleep 300ms
+Type ">"
+Sleep 300ms
+Screenshot target/betamax/jk-diff-horizontal.png
+State target/betamax/jk-diff-horizontal.json
+
+Type "L"
+Wait+Screen "jk jj"
+Sleep 300ms
+Screenshot target/betamax/jk-diff-return-log.png
+State target/betamax/jk-diff-return-log.json
+
+Type "q"
+Hide
+Type "exit"
+Enter

--- a/tapes/jk-log.tape
+++ b/tapes/jk-log.tape
@@ -18,7 +18,7 @@ Set WaitTimeout 30s
 Env NO_COLOR "1"
 
 Hide
-Type "repo=${JK_REPO:-$HOME/local/jk}"
+Type "repo=${JK_REPO:-$HOME/local/jk/default}"
 Enter
 Wait
 Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && pwd"


### PR DESCRIPTION
## Summary

- add diff search, sticky file context, hunk navigation, and horizontal scrolling
- add hunk/file folding with stat-style folded summaries
- add mode-specific help, empty/error states, and visual review coverage

## Stack

Depends on [#21](https://github.com/joshka/jk/pull/21).

## Validation

- `just fmt-check`
- `just check`
- `just test`
- `just clippy`
- `just lint-md`
