### PR TITLE
Start README media inside jk

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It keeps the parts of `jj` you already trust: the graph, colors, wording, revset
 diff output still come from `jj`. `jk` adds an interactive review loop around that output so you can
 keep context open while an editor, shell, or coding agent changes the repository.
 
-![jk log view](https://www.joshka.net/jk-screenshots/assets/jk-log.gif)
+![jk log view](https://www.joshka.net/jk-screenshots/assets/jk-log-v3.gif)
 
 ## What Works Today
 
@@ -40,7 +40,7 @@ TUI parses only enough structure to support navigation, search, sticky headers, 
 
 The diff view preserves `jj diff` output while adding review controls around it.
 
-![jk diff view](https://www.joshka.net/jk-screenshots/assets/jk-diff.gif)
+![jk diff view](https://www.joshka.net/jk-screenshots/assets/jk-diff-v3.gif)
 
 Useful bindings in the diff view:
 

--- a/crates/jk/README.md
+++ b/crates/jk/README.md
@@ -5,9 +5,9 @@
 It keeps a `jj` log-like view open, lets you refresh in place, and adds interactive navigation for
 reviewing change descriptions and selected-change diffs.
 
-![jk log view](https://www.joshka.net/jk-screenshots/assets/jk-log.gif)
+![jk log view](https://www.joshka.net/jk-screenshots/assets/jk-log-v3.gif)
 
-![jk diff view](https://www.joshka.net/jk-screenshots/assets/jk-diff.gif)
+![jk diff view](https://www.joshka.net/jk-screenshots/assets/jk-diff-v3.gif)
 
 ## Current Status
 

--- a/tapes/readme-diff.tape
+++ b/tapes/readme-diff.tape
@@ -1,4 +1,4 @@
-Output ../../jk-screenshots/assets/jk-diff.gif
+Output ../../jk-screenshots/assets/jk-diff-v3.gif
 Output target/betamax/readme-diff-final-state.json
 
 Require cargo
@@ -8,7 +8,7 @@ Set Shell "bash"
 Set Theme "Aardvark Ink"
 Set Width 1200
 Set Height 720
-Set Padding 8
+Set Padding 0
 Set Margin 0
 Set WindowBar Colorful
 Set BorderRadius 0
@@ -29,18 +29,18 @@ Enter
 Wait+Screen "JK_BUILD_READY"
 Ctrl+L
 Sleep 200ms
-Show
 
 Type "./target/debug/jk -R . diff @-"
 Enter
 Wait+Screen "jk jj diff"
 Sleep 1100ms
-Screenshot ../../jk-screenshots/assets/jk-diff.png
+Show
+Screenshot ../../jk-screenshots/assets/jk-diff-v3.png
 
 Hide
 Type "?"
 Sleep 500ms
-Screenshot ../../jk-screenshots/assets/jk-diff-help.png
+Screenshot ../../jk-screenshots/assets/jk-diff-help-v3.png
 
 Type "?"
 Sleep 300ms
@@ -50,13 +50,13 @@ Sleep 250ms
 Type "diff"
 Enter
 Sleep 800ms
-Screenshot ../../jk-screenshots/assets/jk-diff-search.png
+Screenshot ../../jk-screenshots/assets/jk-diff-search-v3.png
 
 Type "}"
 Sleep 700ms
 Type "-"
 Sleep 1s
-Screenshot ../../jk-screenshots/assets/jk-diff-folded-hunk.png
+Screenshot ../../jk-screenshots/assets/jk-diff-folded-hunk-v3.png
 
 Type "j"
 Sleep 180ms
@@ -74,7 +74,7 @@ Type "+"
 Sleep 700ms
 Type "h"
 Sleep 1s
-Screenshot ../../jk-screenshots/assets/jk-diff-folded-file.png
+Screenshot ../../jk-screenshots/assets/jk-diff-folded-file-v3.png
 
 Hide
 Type "q"

--- a/tapes/readme-log.tape
+++ b/tapes/readme-log.tape
@@ -1,4 +1,4 @@
-Output ../../jk-screenshots/assets/jk-log.gif
+Output ../../jk-screenshots/assets/jk-log-v3.gif
 Output target/betamax/readme-log-final-state.json
 
 Require cargo
@@ -8,7 +8,7 @@ Set Shell "bash"
 Set Theme "Aardvark Ink"
 Set Width 1200
 Set Height 720
-Set Padding 8
+Set Padding 0
 Set Margin 0
 Set WindowBar Colorful
 Set BorderRadius 0
@@ -29,18 +29,18 @@ Enter
 Wait+Screen "JK_BUILD_READY"
 Ctrl+L
 Sleep 200ms
-Show
 
 Type "./target/debug/jk -R . -n 8"
 Enter
 Wait+Screen "jk jj"
 Sleep 1s
-Screenshot ../../jk-screenshots/assets/jk-log.png
+Show
+Screenshot ../../jk-screenshots/assets/jk-log-v3.png
 
 Hide
 Type "?"
 Sleep 500ms
-Screenshot ../../jk-screenshots/assets/jk-log-help.png
+Screenshot ../../jk-screenshots/assets/jk-log-help-v3.png
 
 Type "?"
 Sleep 300ms
@@ -49,11 +49,11 @@ Type "j"
 Sleep 450ms
 Type "j"
 Sleep 700ms
-Screenshot ../../jk-screenshots/assets/jk-log-selection.png
+Screenshot ../../jk-screenshots/assets/jk-log-selection-v3.png
 
 Enter
 Sleep 700ms
-Screenshot ../../jk-screenshots/assets/jk-log-expanded.png
+Screenshot ../../jk-screenshots/assets/jk-log-expanded-v3.png
 
 Type "d"
 Wait+Screen "jk jj diff"


### PR DESCRIPTION
Fixes the README/crates.io media after the Betamax sizing change and the earlier cached captures.

What changed:
- keep setup/build and the `jk` launch command hidden until the TUI is visible
- remove Betamax terminal padding from the README tapes
- switch README image URLs to cache-busted `*-v3` assets
- keep final media dimensions at 1200x720

Generated media:
- `*-v2` media was published in https://github.com/joshka/jk-screenshots/pull/4
- `*-v3` media was published in https://github.com/joshka/jk-screenshots/pull/5 after a premature custom-domain probe cached a `jk-diff-v2.gif` 404
- v3 first GIF frames were inspected locally and start directly in the jk TUI

Validation:
- `just lint-md`
- `file assets/jk-log.gif assets/jk-log-v3.gif assets/jk-diff.gif assets/jk-diff-v3.gif assets/jk-log-v3.png assets/jk-diff-v3.png`
- extracted first GIF frames with ImageMagick and inspected them locally
