### PR TITLE
Document install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,29 @@ keep context open while an editor, shell, or coding agent changes the repository
 
 ![jk log view](https://www.joshka.net/jk-screenshots/assets/jk-log-v3.gif)
 
+## Installation
+
+Install with Homebrew:
+
+```sh
+brew trust --formula joshka/tap/jk
+brew install joshka/tap/jk
+```
+
+The trust command scopes Homebrew's non-official tap trust to the `jk` formula.
+
+Install prebuilt release assets with [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
+
+```sh
+cargo binstall jk
+```
+
+Or build from the crates.io source package:
+
+```sh
+cargo install jk --locked
+```
+
 ## What Works Today
 
 `jk` currently focuses on the inspection loop:

--- a/crates/jk/README.md
+++ b/crates/jk/README.md
@@ -9,6 +9,29 @@ reviewing change descriptions and selected-change diffs.
 
 ![jk diff view](https://www.joshka.net/jk-screenshots/assets/jk-diff-v3.gif)
 
+## Installation
+
+Install with Homebrew:
+
+```sh
+brew trust --formula joshka/tap/jk
+brew install joshka/tap/jk
+```
+
+The trust command scopes Homebrew's non-official tap trust to the `jk` formula.
+
+Install prebuilt release assets with [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
+
+```sh
+cargo binstall jk
+```
+
+Or build from the crates.io source package:
+
+```sh
+cargo install jk --locked
+```
+
 ## Current Status
 
 The supported surface includes:


### PR DESCRIPTION
## Summary

- add Homebrew install commands with formula-scoped tap trust
- document `cargo binstall jk` for prebuilt release assets
- document `cargo install jk --locked` for source installs from crates.io

## Validation

- `just lint-md`
