### PR TITLE
Set package homepage to jk site

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.2.3"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
+homepage = "https://www.joshka.net/jk/"
 repository = "https://github.com/joshka/jk"
 
 [workspace.dependencies]

--- a/crates/jk-cli/Cargo.toml
+++ b/crates/jk-cli/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+homepage.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/jk-core/Cargo.toml
+++ b/crates/jk-core/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+homepage.workspace = true
 repository.workspace = true
 
 [lints]

--- a/crates/jk-tui/Cargo.toml
+++ b/crates/jk-tui/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+homepage.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/jk/Cargo.toml
+++ b/crates/jk/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+homepage.workspace = true
 repository.workspace = true
 
 [dependencies]


### PR DESCRIPTION
## Summary

- set the workspace package homepage to https://www.joshka.net/jk/
- inherit the homepage metadata from all published crates

## Validation

- cargo metadata --no-deps --format-version 1
- curl -L -I https://www.joshka.net/jk/
