### PR TITLE
Trigger Homebrew tap bump after jk release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -162,6 +162,23 @@ jobs:
         # leg or a packaging-script fix.
         run: gh release upload "$RELEASE_TAG" "$ARCHIVE" "$CHECKSUM" --clobber
 
+  bump-homebrew-tap:
+    name: Bump Homebrew tap
+    runs-on: ubuntu-latest
+    needs: prepare-release-assets
+    if: ${{ needs.prepare-release-assets.outputs.jk_released == 'true' }}
+    steps:
+      - name: Trigger tap bump
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ needs.prepare-release-assets.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh workflow run bump-package.yml \
+            --repo joshka/homebrew-tap \
+            --field package=jk \
+            --field version="$VERSION"
+
   release-pr:
     name: Release-plz PR
     # release-plz's quickstart runs `release` and `release-pr` as sibling jobs


### PR DESCRIPTION
# Summary

Add a release-time follow-up job that dispatches the Homebrew tap formula bump workflow when `jk` is released.

The dispatch sends `package=jk` and the released `jk` version to `joshka/homebrew-tap` using `HOMEBREW_TAP_TOKEN`. It intentionally does not pass `tag`, because the `jk` tap updater uses the crates.io source tarball.

## Validation

```sh
actionlint -color=false .github/workflows/release-plz.yml
zizmor .github/workflows/release-plz.yml
zizmor .github/workflows
actionlint -color=false .github/workflows/*.yml
```
