### PR TITLE
Reduce crate README GIFs

### DIFF
--- a/crates/jk/README.md
+++ b/crates/jk/README.md
@@ -7,8 +7,6 @@ reviewing change descriptions and selected-change diffs.
 
 ![jk log view](https://www.joshka.net/jk-screenshots/assets/jk-log-v3.gif)
 
-![jk diff view](https://www.joshka.net/jk-screenshots/assets/jk-diff-v3.gif)
-
 ## Installation
 
 Install with Homebrew:


### PR DESCRIPTION
## Summary

- Keep the crates.io README focused on a single animated demo.
- Remove the extra diff GIF from the crate README.

## Validation

- `just lint-md`
