### PR TITLE
Link license files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,8 @@ The workspace is split into narrow crates:
 - `jk-tui`: Ratatui state, rendering, and input actions.
 
 Those boundaries keep `jj` presentation decisions at the edge while the TUI owns interaction state.
+
+## License
+
+`jk` is dual-licensed under either [MIT](LICENSE-MIT) or
+[Apache-2.0](LICENSE-APACHE).

--- a/crates/jk/README.md
+++ b/crates/jk/README.md
@@ -67,3 +67,9 @@ Near-term work preserves jj-rendered output while adding command-shaped inspecti
 `status`, command mode, command history, workspaces, command previews, and operation recovery.
 
 See the repository README for the current status and development workflow.
+
+## License
+
+`jk` is dual-licensed under either
+[MIT](https://github.com/joshka/jk/blob/main/LICENSE-MIT) or
+[Apache-2.0](https://github.com/joshka/jk/blob/main/LICENSE-APACHE).


### PR DESCRIPTION
## Summary

- link the root MIT and Apache-2.0 license files from the repository README
- add matching license links to the crates.io README

## Validation

- `just lint-md`