### PR TITLE
Release current jk TUI snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,11 +75,13 @@ release-oriented changes.
 
 ## Commit & Pull Request Guidelines
 
-Use plain imperative commit summaries, not conventional commits. Wrap
-commit message bodies at 72 columns. Pull requests should explain
-user-visible behavior, list validation run, and call out release or
-crates.io impact. Link related issues when they exist. Include terminal
-screenshots only for meaningful TUI rendering changes.
+Use plain imperative commit summaries, not conventional commits. Keep
+summary lines short, then wrap every commit-message body line at 72
+columns, including multiline `jj desc` descriptions created during local
+work. Pull requests should explain user-visible behavior, list
+validation run, and call out release or crates.io impact. Link related
+issues when they exist. Include terminal screenshots only for meaningful
+TUI rendering changes.
 
 ## Security & Release Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,125 +1,108 @@
 # Changelog
 
-<!-- markdownlint-disable MD012 MD013 MD024 -->
-## Other
-
-
-- Reduce crate README GIFs ([#34](https://github.com/joshka/jk/pull/34))
-
-
-## Other
-
-
-- Set package homepage to jk site
-
-
-## Other
-
-
-- Set package homepage to jk site
-
-
-## Other
-
-
-- Set package homepage to jk site
-
-
-## Other
-
-
-- Set package homepage to jk site
-
-
-## Other
-
-
-- Clean up README media captures ([#25](https://github.com/joshka/jk/pull/25))
-
-- chore: release v0.2.3 ([#26](https://github.com/joshka/jk/pull/26))
-
-- Start README media inside jk ([#27](https://github.com/joshka/jk/pull/27))
-
-- Document install commands ([#29](https://github.com/joshka/jk/pull/29))
-
-
-## Other
-
-
-- chore: release v0.2.3 ([#26](https://github.com/joshka/jk/pull/26))
-
-
-## Other
-
-
-- chore: release v0.2.3 ([#26](https://github.com/joshka/jk/pull/26))
-
-
-## Other
-
-
-- Clean up README media captures ([#25](https://github.com/joshka/jk/pull/25))
-
-
-## Other
-
-
-- Add selected-change diff experience ([#21](https://github.com/joshka/jk/pull/21))
-
-
-## Other
-
-
-- Add selected-change diff experience ([#21](https://github.com/joshka/jk/pull/21))
-
-
-## Other
-
-
-- Add selected-change diff experience ([#21](https://github.com/joshka/jk/pull/21))
-
-
-## Other
-
-
-- Add selected-change diff experience ([#21](https://github.com/joshka/jk/pull/21))
-
-
-## Other
-
-
-- Wire log MVP workspace dependencies
-
-- Wire jk log terminal app
-
-- Document and record log MVP
-
-
-## Other
-
-
-- Wire log MVP workspace dependencies
-
-- Add ratatui log view
-
-- Harden log MVP review edge cases
-
-
-## Other
-
-
-- Wire log MVP workspace dependencies
-
-- Add jj log loading bridge
-
-- Document and record log MVP
-
-
-## Other
-
-
-- Add semantic log snapshot model
-
-<!-- markdownlint-enable MD012 MD013 MD024 -->
-
-All notable changes to `jk` will be documented here.
+This changelog is written for people deciding whether to install, upgrade, demo, or review `jk`.
+Entries are grouped by user workflow and release impact instead of following the commit history.
+
+## Unreleased
+
+This release candidate turns `jk` from a log/diff inspection helper into a dogfoodable jj TUI.
+The release cutoff is the current inspection, command, history, recovery, workspace, and diff-review
+surface. Rebase and larger action menus remain intentionally deferred.
+
+### Inspection And Navigation
+
+- Keep `jj` as the source of truth for rendered log, diff, show, status, and evolog output while
+  adding interactive navigation around that output.
+- Support `jk`, `jk log`, `jk diff`, `jk show`, and `jk status` entry points, including repository
+  and limit options shared with the top-level command.
+- Add selected-change inspection from the log for show, diff, evolog, and repository status.
+- Preserve log selection when moving into inspection views, refreshing them, and returning to the
+  log.
+- Add ordered revision marks so multi-revision workflows can select parents in the order the user
+  chose them.
+
+### Diff Review
+
+- Add line, page, file, hunk, and horizontal movement for diff review without changing the rendered
+  `jj diff` text.
+- Add file and hunk folding, fold-all and unfold-all commands, and a file-list overlay for jumping
+  within large diffs.
+- Add sticky current-file context with diff stat suffixes and file position, such as `[file 2/7]`.
+- Add diff search with forward and backward match navigation.
+- Add View Options for switching the rendered diff format between patch, summary, stat, types,
+  name-only, git, and color-words output.
+
+### Command Mode And Command History
+
+- Add `:` command mode for running direct `jj` commands from inside the TUI.
+- Capture command output, errors, exit status, duration, command arguments, and operation ids in an
+  in-memory Command History.
+- Keep failed command output available for inspection instead of dropping the user back into an
+  unexplained terminal state.
+- Add history detail, copy, retry, and operation links so command results can be inspected after the
+  command finishes.
+
+### Safe Mutation Previews And Recovery
+
+- Add preview-and-confirm flows for `jj describe`, `jj abandon`, `jj new`, `jj edit`, `jj undo`, and
+  `jj redo`.
+- Show the exact command before it runs, with cancel and copy paths available before confirmation.
+- Prefill describe text from the selected change and support clearing the prompt before rewriting it.
+- Use marked revisions as ordered `jj new` parents.
+- Capture operation ids from mutating commands and expose a recovery footer with undo, redo,
+  operation log, operation show, operation diff, and Command History entry points.
+
+### Workspaces And Operations
+
+- Add a Workspaces screen with list, refresh, selected-workspace log, selected-workspace status,
+  selected-workspace diff, and stale-workspace update paths.
+- Add Operation Log, operation show, and operation diff views so recent repository state changes are
+  inspectable from inside the TUI.
+- Keep workspace and operation inspection on the same rendered-output model as show, status, and
+  diff views.
+
+### Help, Discovery, And Menus
+
+- Generate mode-specific help and hotbar labels from the keymap data used by the app.
+- Add searchable command discovery from help so users can find commands without memorizing every
+  binding.
+- Add View Options and template selectors as menu overlays that wrap, start at the current
+  selection, and support arrow-key movement.
+- Order help content by workflow so common inspection, movement, mutation, recovery, and exit
+  commands are easier to scan.
+- Show the active log template name instead of a placeholder when a custom template is used.
+
+### Documentation, Release Notes, And Media
+
+- Update the repository README and crate README to describe the current jk surface rather
+  than the earlier log/diff-only milestone.
+- Add a release stabilization plan that treats changelog and release notes as written product
+  artifacts based on a feature audit, not generated commit summaries.
+- Document the release cutoff before rebase, the command-preview safety model, current known
+  limitations, and the required public media refresh.
+- Keep generated validation media local until release assets are prepared in the repositories that
+  own public screenshots, GIFs, and website media.
+
+### Known Limitations
+
+- Command History is currently in-memory for the active `jk` session.
+- Rebase, squash, split, restore, bookmark, fetch, and push workflows are still planned.
+- Direct `a`, `n`, and `e` bindings are dogfood shortcuts until the broader action menu exists.
+- Public README GIFs, crates.io media, and website media still need a release-media refresh before
+  they should advertise the full TUI surface.
+- The project website may intentionally lag a source release, but it should not pre-publish
+  unreleased behavior as if it were already available.
+
+## 0.2.5 And Earlier
+
+Earlier releases established the public installation path and the initial `jj`-rendered terminal UI
+foundation:
+
+- log and selected-change diff views;
+- README and crates.io media for the early log/diff experience;
+- Homebrew, `cargo-binstall`, and `cargo install` installation paths;
+- package homepage metadata and release automation cleanup.
+
+The previous generated changelog entries for these releases were duplicated and commit-oriented.
+They have been collapsed here into a reader-facing summary. Use the GitHub release and pull request
+history for exact patch-level archaeology.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,7 @@ dependencies = [
  "color-eyre",
  "crossterm",
  "jk-cli",
+ "jk-core",
  "jk-tui",
  "ratatui",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -8,23 +8,6 @@ keep context open while an editor, shell, or coding agent changes the repository
 
 ![jk log view](https://www.joshka.net/jk-screenshots/assets/jk-log-v3.gif)
 
-## Project Status
-
-`jk` is early, useful for a narrow inspection loop, and moving quickly.
-
-Today it is mostly a refreshable `jj log` / `jj diff` workflow: keep context open while an editor,
-IDE, or coding agent changes the repository, refresh in place, and inspect selected changes without
-losing your place.
-
-The longer-term direction is broader. `jk` should accept the command shapes and flags you would
-normally pass to `jj`, preserve your jj config, and add interaction where it helps: selected
-objects, prompts, confirmation for risky changes, command output, refresh, and operation recovery.
-
-This is not ready for broad adoption yet. Feedback is most useful when it is about product
-direction, current inspection workflows, visual and accessibility problems, large graphs, multiple
-workspaces, narrow terminal splits, or how close a TUI should stay to jj's command and config
-model.
-
 ## Installation
 
 Install with Homebrew:
@@ -48,96 +31,84 @@ Or build from the crates.io source package:
 cargo install jk --locked
 ```
 
-## What Works Today
+## Current Status
 
-`jk` currently focuses on the inspection loop:
+`jk` now covers the daily inspection and recovery loop:
 
 ```text
-log -> details -> diff -> back -> refresh
+log -> inspect -> preview command -> run -> history -> operation recovery
 ```
 
-The supported surface includes:
+The useful current workflows are:
 
-- a full-screen log view backed by `jj`;
-- explicit `jk log` and default-command `jk` entry points;
-- manual refresh without leaving the TUI;
-- movement by change, page, and edge;
-- inline expansion of the selected change description;
-- selected-change diff inspection with `jk diff [REVISION]` or `d` from the log;
-- return from diff to log without losing log selection;
-- line, page, file, hunk, and horizontal movement in the diff view;
-- file folding, fold-all/unfold-all, and hunk folding;
-- sticky current-file context with diff stat suffix and `[file x/y]`;
-- diff search with `/`, `n`, and `N`;
-- retryable empty/error states for selected diffs;
-- mode-specific help overlays with `?`;
-- [Betamax](https://www.joshka.net/betamax/) visual tapes for the log and diff workflows.
+- inspect selected changes with `show`, `diff`, `evolog`, and `status`;
+- review diffs with file/hunk movement, folding, search, file list, and View Options;
+- run direct `jj` commands from `:` command mode and keep captured output in the TUI;
+- preview local mutations before running describe, abandon, new, edit, undo, and redo;
+- use Command History and Operation Log to inspect what ran and recover through `jj op` views;
+- inspect sibling jj workspaces, including workspace-scoped log/status/diff views, without leaving
+  the TUI.
 
 The current implementation intentionally treats rendered `jj` output as the source of truth. The
-TUI parses only enough structure to support navigation, search, sticky headers, and folding.
+TUI parses only enough structure to support navigation, search, sticky headers, folding, command
+recording, and recovery-oriented links.
 
-## Diff Review
+Use `?` inside `jk` for the full key list for the active screen. For task-oriented examples, see
+[Using jk](docs/usage.md).
 
-The diff view preserves `jj diff` output while adding review controls around it.
+Current limitations:
+
+- command history is in-memory for the current `jk` session;
+- rebase, squash, split, restore, bookmarks, fetch, and push are still planned workflows;
+- direct `a`, `n`, and `e` bindings are dogfood shortcuts until the broader action menu exists.
+
+## First Useful Paths
+
+Start with `jk` or `jk log`, then use:
+
+- `Enter`, `d`, `v`, and `s` to inspect the selected change;
+- `:` to run a direct `jj` command without dropping TUI context;
+- `m`, `a`, `n`, `e`, `u`, or `U` to preview a local mutation before it runs;
+- `C` and `o` to inspect Command History and Operation Log;
+- `W` to inspect other jj workspaces.
 
 ![jk diff view](https://www.joshka.net/jk-screenshots/assets/jk-diff-v3.gif)
-
-Useful bindings in the diff view:
-
-| Key                           | Action                       |
-| ----------------------------- | ---------------------------- |
-| `j` / `k`                     | scroll one line              |
-| `Space` / `b`                 | page down / page up          |
-| `g` / `G`                     | jump to top / bottom         |
-| `[` / `]`                     | previous / next file         |
-| `{` / `}`                     | previous / next hunk         |
-| `h` / `l`                     | fold / unfold current file   |
-| `Ctrl-Left` / `Ctrl-Right`    | fold / unfold all files      |
-| `-` / `+`                     | fold / unfold current hunk   |
-| `<` / `>`                     | horizontal scroll            |
-| `/`, `n`, `N`                 | search, next match, previous |
-| `r`                           | refresh                      |
-| `H` / `L`                     | return to the log            |
-| `?`                           | show mode-specific help      |
-| `q` / `Esc`                   | close help, then quit        |
 
 ## Commands
 
 ```sh
 jk
 jk log
+jk log -T builtin_log_compact_full_description
 jk diff
-jk diff <revision>
+jk diff -r <revision>
+jk diff --from <revision> --to <revision>
+jk diff --stat
+jk diff --summary
+jk show <revision>
+jk status
+jk status <fileset>
+jk workspaces
 jk -R /path/to/repo -n 20
-jk log --repository /path/to/repo --limit 20
+jk -R /path/to/repo log --limit 20
 ```
 
 Bare `jk` follows `jj`'s configured `ui.default-command` when that command is log-like enough for
 the semantic navigation pass. Use `jk log` when you want the explicit log command path.
 
-## Current Focus
+## Roadmap
 
 The detailed product and engineering plan lives in
 [docs/product-plan.md](docs/product-plan.md). The shorter
 [docs/roadmap.md](docs/roadmap.md) turns that plan into issue-sized milestones.
 
-The active planning and dogfood work is concentrated around the 0.3 to 0.6 foundations:
+The current stabilization direction is:
 
-- keep `jj` output and config fidelity at the center: revsets, templates, graph style, colors, and
-  diff output should still matter;
-- build the command-spec, global-options, view-stack, mode-stack, keymap, and task foundations that
-  make later workflows reviewable;
-- improve inspection around `log`, `diff`, `show`, `status`, `evolog`, View Options, and file
-  navigation without turning the default screen into a dashboard;
-- dogfood command history, `:` command mode, workspace views, operation recovery, and safe mutation
-  previews before presenting them as stable user workflows;
-- replace rough UI experiments, including selection and highlight behavior, with more readable and
-  accessible defaults;
+- stabilize the current jk surface before starting rebase;
+- keep README, crate README, changelog, website, and media aligned with released behavior;
+- keep mutating workflows behind command previews, command history, and operation recovery;
 - make [Betamax](https://www.joshka.net/betamax/) tapes the source for regression tests,
   README/site media, and release demos.
-
-Some of that work exists only in local dogfood spikes today. The README describes the released
-surface first; the planning docs describe the direction.
 
 ## Development
 
@@ -157,9 +128,11 @@ Visual README media is generated with:
 just readme-media
 ```
 
-The generated screenshots and GIFs live in the separate
-[`joshka/jk-screenshots`](https://github.com/joshka/jk-screenshots) repository and are served from
-`https://www.joshka.net/jk-screenshots/`.
+By default this local development task writes to `target/dogfood-artifacts/readme-media/`. Public
+README, crates.io, and release-note media is published later from the separate
+[`joshka/jk-screenshots`](https://github.com/joshka/jk-screenshots) repository and served from
+`https://www.joshka.net/jk-screenshots/`. Keeping generated media out of this source repo avoids
+making jj handle Git LFS-heavy screenshot and GIF churn.
 
 ## Crates
 
@@ -171,8 +144,3 @@ The workspace is split into narrow crates:
 - `jk-tui`: Ratatui state, rendering, and input actions.
 
 Those boundaries keep `jj` presentation decisions at the edge while the TUI owns interaction state.
-
-## License
-
-`jk` is dual-licensed under either [MIT](LICENSE-MIT) or
-[Apache-2.0](LICENSE-APACHE).

--- a/crates/jk-cli/src/abandon.rs
+++ b/crates/jk-cli/src/abandon.rs
@@ -1,0 +1,120 @@
+//! `jj abandon` mutation command integration.
+
+use jk_core::{GlobalOptions, JjCommandSpec, RefreshPlan, SafetyClass};
+
+const ABANDON_COMMAND: &str = "abandon";
+
+/// Abandon one selected revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AbandonQuery {
+    rev: String,
+}
+
+impl AbandonQuery {
+    /// Creates a `jj abandon REV` query.
+    #[must_use]
+    pub fn new(rev: impl Into<String>) -> Self {
+        Self { rev: rev.into() }
+    }
+
+    /// Returns the revision passed to `jj abandon`.
+    #[must_use]
+    pub fn rev(&self) -> &str {
+        &self.rev
+    }
+}
+
+/// Builds typed `jj abandon` mutation specs.
+#[derive(Clone, Debug, Default)]
+pub struct JjAbandon {
+    global_options: GlobalOptions,
+}
+
+impl JjAbandon {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<std::path::PathBuf>) -> Self {
+        self.global_options = self.global_options.with_repository(repository);
+        self
+    }
+
+    /// Returns the command spec for `query`.
+    #[must_use]
+    pub fn spec_for(&self, query: &AbandonQuery) -> JjCommandSpec {
+        JjCommandSpec::confirm_mutation(
+            [ABANDON_COMMAND, query.rev.as_str()],
+            SafetyClass::DestructiveLocal,
+        )
+        .with_global_options(self.global_options.clone())
+        .with_title(format!("jj abandon {}", query.rev()))
+        .with_refresh_plan(RefreshPlan::None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use jk_core::{ExecutionMode, RefreshPlan};
+
+    use super::*;
+
+    fn strings(args: &[OsString]) -> Vec<String> {
+        args.iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn abandon_builds_confirmed_destructive_spec() {
+        let query = AbandonQuery::new("abc123");
+        let spec = JjAbandon::default().spec_for(&query);
+
+        assert_eq!(strings(spec.argv()), vec!["abandon", "abc123"]);
+        assert_eq!(spec.title(), "jj abandon abc123");
+        assert_eq!(spec.mode(), ExecutionMode::ConfirmMutation);
+        assert_eq!(spec.safety(), SafetyClass::DestructiveLocal);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::None);
+    }
+
+    #[test]
+    fn repository_renders_before_abandon() {
+        let spec = JjAbandon::default()
+            .with_repository("/tmp/repo")
+            .spec_for(&AbandonQuery::new("abc123"));
+        let argv = spec
+            .process_argv()
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            argv,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "abandon",
+                "abc123",
+            ]
+        );
+    }
+
+    #[test]
+    fn command_preview_warns_about_destructive_operation() {
+        let preview = JjAbandon::default()
+            .spec_for(&AbandonQuery::new("abc123"))
+            .command_preview();
+
+        assert_eq!(
+            preview.command_line,
+            "jj --no-pager --color always abandon abc123"
+        );
+        assert_eq!(
+            preview.warnings,
+            vec![jk_core::CommandPreviewWarning::DestructiveLocal]
+        );
+    }
+}

--- a/crates/jk-cli/src/command.rs
+++ b/crates/jk-cli/src/command.rs
@@ -1,0 +1,633 @@
+//! Shared execution adapter for typed `jj` command specs.
+
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+use std::time::SystemTime;
+
+use jk_core::{
+    ColorPolicy, CommandHistory, CommandRecordFinish, CommandRecordStart, CommandResultSummary,
+    CommandSource, ExecutionMode, ExitStatusSummary, ImmutabilityPolicy, JjCommandSpec,
+    OperationIntegrationPolicy, OperationLoadPolicy, OutputPolicy, SafetyClass, StreamSummary,
+    WorkingCopyPolicy,
+};
+
+const HISTORY_STREAM_LIMIT: usize = 8 * 1024;
+
+/// Runs typed `jj` command specs.
+///
+/// Loaders may call [`JjCommandRunner::run`] more than once for a single user action when they need
+/// both rendered output and secondary metadata. Implementations should therefore avoid assuming
+/// one-shot use unless the caller documents that restriction explicitly.
+pub trait JjCommandRunner {
+    /// Runs a typed `jj` command spec.
+    ///
+    /// Returns the child-process output when the command starts, writes any stdin, and exits
+    /// successfully enough for the caller to inspect the [`Output`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying I/O error when spawning, writing, or waiting fails.
+    fn run(&mut self, spec: &JjCommandSpec) -> std::io::Result<Output>;
+}
+
+/// Executes `jj` commands with the system `jj` binary.
+///
+/// Each call spawns a fresh `jj` process. Callers that use loaders with multiple passes should
+/// expect multiple invocations and the corresponding I/O errors if the binary cannot be started or
+/// read.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemJjCommandRunner;
+
+impl JjCommandRunner for SystemJjCommandRunner {
+    fn run(&mut self, spec: &JjCommandSpec) -> std::io::Result<Output> {
+        run_system_jj_spec(spec)
+    }
+}
+
+/// Records command-history entries around another `jj` runner.
+///
+/// Each call to [`JjCommandRunner::run`] records one command-history entry, so loaders that call
+/// the runner multiple times will create multiple retained records for the same user action.
+#[derive(Debug)]
+pub struct RecordingJjCommandRunner<'a, R> {
+    inner: R,
+    history: &'a mut CommandHistory,
+    source: CommandSource,
+}
+
+impl<'a, R> RecordingJjCommandRunner<'a, R> {
+    /// Creates a recording runner for commands from one source action.
+    ///
+    /// Every invocation records the same source metadata alongside the command spec.
+    pub const fn new(inner: R, history: &'a mut CommandHistory, source: CommandSource) -> Self {
+        Self {
+            inner,
+            history,
+            source,
+        }
+    }
+}
+
+impl<R> JjCommandRunner for RecordingJjCommandRunner<'_, R>
+where
+    R: JjCommandRunner,
+{
+    fn run(&mut self, spec: &JjCommandSpec) -> std::io::Result<Output> {
+        let pending = self
+            .history
+            .start(CommandRecordStart::from_spec(spec, self.source.clone()));
+        let result = self.inner.run(spec);
+        let finish = match &result {
+            Ok(output) => finish_from_output(output, SystemTime::now()),
+            Err(error) => {
+                CommandRecordFinish::from_spawn_error(error.to_string(), "", "", SystemTime::now())
+            }
+        };
+        self.history.finish(&pending, finish);
+        result
+    }
+}
+
+impl<R> RecordingJjCommandRunner<'_, R>
+where
+    R: JjCommandRunner,
+{
+    /// Returns the wrapped runner after recording is finished.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+
+    /// Runs a confirmed mutation and records the resulting operation id when the current operation
+    /// context advances in a bounded before/after probe.
+    ///
+    /// The operation probes are intentionally not recorded in command history. Callers should use
+    /// this only after user confirmation, and ordinary read-only specs fall back to
+    /// [`JjCommandRunner::run`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying I/O error when the mutation command or operation probe cannot be
+    /// spawned, written to, or waited on.
+    pub fn run_confirmed_mutation(&mut self, spec: &JjCommandSpec) -> std::io::Result<Output> {
+        if !should_probe_resulting_operation(spec) {
+            return self.run(spec);
+        }
+
+        let before_operation_id = current_operation_id(&mut self.inner, spec).ok();
+        let pending = self
+            .history
+            .start(CommandRecordStart::from_spec(spec, self.source.clone()));
+        let result = self.inner.run(spec);
+        let mut finish = match &result {
+            Ok(output) => finish_from_output(output, SystemTime::now()),
+            Err(error) => {
+                CommandRecordFinish::from_spawn_error(error.to_string(), "", "", SystemTime::now())
+            }
+        };
+
+        if let (Ok(output), Some(before_operation_id)) = (&result, before_operation_id)
+            && output.status.success()
+            && let Ok(after_operation_id) = current_operation_id(&mut self.inner, spec)
+            && after_operation_id != before_operation_id
+        {
+            finish.operation_id = Some(after_operation_id);
+        }
+
+        self.history.finish(&pending, finish);
+        result
+    }
+}
+
+const fn should_probe_resulting_operation(spec: &JjCommandSpec) -> bool {
+    matches!(spec.mode(), ExecutionMode::ConfirmMutation)
+        && matches!(
+            spec.safety(),
+            SafetyClass::LocalMetadata | SafetyClass::LocalRewrite | SafetyClass::DestructiveLocal
+        )
+}
+
+fn current_operation_id(
+    runner: &mut impl JjCommandRunner,
+    spec: &JjCommandSpec,
+) -> std::io::Result<String> {
+    let output = runner.run(&current_operation_id_spec(spec))?;
+    if !output.status.success() {
+        return Err(std::io::Error::other("jj op log failed"));
+    }
+
+    parse_single_operation_id(&output.stdout)
+        .ok_or_else(|| std::io::Error::other("jj op log did not return one operation id"))
+}
+
+fn current_operation_id_spec(spec: &JjCommandSpec) -> JjCommandSpec {
+    let global_options = spec
+        .global_options()
+        .clone()
+        .with_working_copy(WorkingCopyPolicy::Ignore)
+        .with_operation(OperationLoadPolicy::AtOperation("@".to_owned()))
+        .with_operation_integration(OperationIntegrationPolicy::Integrate)
+        .with_immutability(ImmutabilityPolicy::Enforce)
+        .with_output(OutputPolicy {
+            color: ColorPolicy::Never,
+            ..OutputPolicy::default()
+        });
+    JjCommandSpec::render_read_only(["op", "log", "--no-graph", "-T", "id ++ \"\\n\"", "-n", "1"])
+        .with_global_options(global_options)
+}
+
+fn parse_single_operation_id(stdout: &[u8]) -> Option<String> {
+    let rendered = String::from_utf8_lossy(stdout);
+    let mut lines = rendered
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+    let operation_id = lines.next()?;
+    if lines.next().is_some() || !looks_like_operation_id(operation_id) {
+        return None;
+    }
+    Some(operation_id.to_owned())
+}
+
+fn looks_like_operation_id(value: &str) -> bool {
+    value.len() >= 12 && value.chars().all(|character| character.is_ascii_hexdigit())
+}
+
+fn run_system_jj_spec(spec: &JjCommandSpec) -> std::io::Result<Output> {
+    let mut command = build_jj_command(spec);
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    if spec.stdin().is_some() {
+        command.stdin(Stdio::piped());
+    }
+
+    let mut child = command.spawn()?;
+    if let Some(stdin) = spec.stdin() {
+        let child_stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("stdin was not piped"))?;
+        child_stdin.write_all(stdin.as_bytes())?;
+    }
+
+    child.wait_with_output()
+}
+
+fn finish_from_output(output: &Output, ended_at: SystemTime) -> CommandRecordFinish {
+    CommandRecordFinish::from_result(
+        CommandResultSummary {
+            exit_status: Some(exit_status_summary(output.status)),
+            spawn_error: None,
+            stdout: StreamSummary::from_bytes(&output.stdout, HISTORY_STREAM_LIMIT),
+            stderr: StreamSummary::from_bytes(&output.stderr, HISTORY_STREAM_LIMIT),
+        },
+        None,
+        ended_at,
+    )
+}
+
+#[cfg(unix)]
+fn exit_status_summary(status: std::process::ExitStatus) -> ExitStatusSummary {
+    use std::os::unix::process::ExitStatusExt;
+
+    status.code().map_or_else(
+        || {
+            status.signal().map_or_else(
+                || ExitStatusSummary {
+                    code: None,
+                    signal: None,
+                    success: status.success(),
+                },
+                ExitStatusSummary::signal,
+            )
+        },
+        ExitStatusSummary::code,
+    )
+}
+
+#[cfg(not(unix))]
+fn exit_status_summary(status: std::process::ExitStatus) -> ExitStatusSummary {
+    ExitStatusSummary {
+        code: status.code(),
+        signal: None,
+        success: status.success(),
+    }
+}
+
+/// Builds the process command for a typed `jj` command spec.
+pub fn build_jj_command(spec: &JjCommandSpec) -> Command {
+    let mut command = Command::new("jj");
+    command.args(spec.global_argv());
+    command.env_remove("NO_COLOR");
+    command.env_remove("CLICOLOR");
+    command.env_remove("CLICOLOR_FORCE");
+
+    if let Some(cwd) = spec.cwd() {
+        command.current_dir(cwd);
+    }
+
+    command.args(spec.argv());
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use std::io;
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+
+    use jk_core::{SafetyClass, SourceAction, SourceView};
+
+    use super::*;
+
+    fn strings(argv: impl IntoIterator<Item = std::ffi::OsString>) -> Vec<String> {
+        argv.into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn command_adapter_forces_color_and_cleans_color_env() {
+        let command = build_jj_command(&JjCommandSpec::render_read_only(["log"]));
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        let envs = command
+            .get_envs()
+            .map(|(key, value)| (key.to_string_lossy().into_owned(), value.is_none()))
+            .collect::<Vec<_>>();
+
+        assert!(args.windows(2).any(|args| args == ["--color", "always"]));
+        assert!(args.iter().any(|arg| arg == "log"));
+        assert!(envs.contains(&("NO_COLOR".to_owned(), true)));
+        assert!(envs.contains(&("CLICOLOR".to_owned(), true)));
+        assert!(envs.contains(&("CLICOLOR_FORCE".to_owned(), true)));
+    }
+
+    #[test]
+    fn command_adapter_includes_repository_before_spec_argv() {
+        let spec =
+            JjCommandSpec::render_read_only(["diff", "-r", "@"]).with_repository("/tmp/repository");
+        let command = build_jj_command(&spec);
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repository",
+                "diff",
+                "-r",
+                "@"
+            ]
+        );
+        assert_eq!(
+            args.iter()
+                .filter(|arg| arg.as_str() == "--repository")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn command_adapter_uses_spec_rendered_process_argv() {
+        let spec = JjCommandSpec::render_read_only(["status"]).with_repository("/tmp/repository");
+        let command = build_jj_command(&spec);
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        let spec_args = spec
+            .process_argv()
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(args, spec_args);
+    }
+
+    #[test]
+    fn command_adapter_captures_stdout() {
+        let spec = JjCommandSpec::render_read_only(["--version"]);
+        let output = match SystemJjCommandRunner.run(&spec) {
+            Ok(output) => output,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+            Err(error) => panic!("jj --version should run: {error}"),
+        };
+
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("jj "));
+        assert!(output.stderr.is_empty());
+    }
+
+    #[test]
+    fn recording_runner_records_successful_output() {
+        let mut history = CommandHistory::new(4);
+        let spec = JjCommandSpec::render_read_only(["status"]);
+        let mut runner = RecordingJjCommandRunner::new(
+            FakeRunner::success(0, "clean\n", ""),
+            &mut history,
+            CommandSource::new(SourceView::Status, SourceAction::InitialLoad),
+        );
+
+        let output = runner.run(&spec).expect("fake runner succeeds");
+
+        assert!(output.status.success());
+        let record = history.records().next().expect("recorded command");
+        assert_eq!(record.command.spec_preview, "jj status");
+        assert_eq!(record.result.exit_status, Some(ExitStatusSummary::code(0)));
+        assert_eq!(record.result.stdout.snippet, "clean\n");
+        assert!(record.result.spawn_error.is_none());
+    }
+
+    #[test]
+    fn recording_runner_records_spawn_failure() {
+        let mut history = CommandHistory::new(4);
+        let spec = JjCommandSpec::render_read_only(["log"]);
+        let mut runner = RecordingJjCommandRunner::new(
+            FakeRunner::spawn_error("jj missing"),
+            &mut history,
+            CommandSource::new(SourceView::Log, SourceAction::Refresh),
+        );
+
+        let error = runner.run(&spec).expect_err("fake runner fails to spawn");
+
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        let record = history.records().next().expect("recorded command");
+        assert_eq!(record.result.exit_status, None);
+        assert_eq!(record.result.spawn_error.as_deref(), Some("jj missing"));
+    }
+
+    #[test]
+    fn recording_runner_carries_source_view_and_action() {
+        let mut history = CommandHistory::new(4);
+        let spec = JjCommandSpec::render_read_only(["diff"]);
+        let source = CommandSource::new(SourceView::Log, SourceAction::OpenDiff).with_key("enter");
+        let mut runner =
+            RecordingJjCommandRunner::new(FakeRunner::success(0, "diff", ""), &mut history, source);
+
+        runner.run(&spec).expect("fake runner succeeds");
+
+        let record = history.records().next().expect("recorded command");
+        assert_eq!(record.source.view, SourceView::Log);
+        assert_eq!(record.source.action, SourceAction::OpenDiff);
+        assert_eq!(record.source.key.as_deref(), Some("enter"));
+    }
+
+    #[test]
+    fn recording_runner_records_update_stale_as_workspace_action() {
+        let mut history = CommandHistory::new(4);
+        let spec = JjCommandSpec::render_read_only(["workspace", "update-stale"])
+            .with_repository("/tmp/workspace")
+            .with_safety(SafetyClass::LocalMetadata);
+        let mut runner = RecordingJjCommandRunner::new(
+            FakeRunner::success(0, "", "updated\n"),
+            &mut history,
+            CommandSource::new(SourceView::Workspaces, SourceAction::WorkspaceUpdateStale),
+        );
+
+        runner.run(&spec).expect("fake runner succeeds");
+
+        let record = history.records().next().expect("recorded command");
+        assert_eq!(record.source.view, SourceView::Workspaces);
+        assert_eq!(record.source.action, SourceAction::WorkspaceUpdateStale);
+        assert_eq!(record.safety, SafetyClass::LocalMetadata);
+        assert_eq!(record.result.stderr.snippet, "updated\n");
+    }
+
+    #[test]
+    fn confirmed_mutation_records_changed_operation_id() {
+        let mut history = CommandHistory::new(4);
+        let spec = JjCommandSpec::confirm_mutation(
+            ["describe", "-m", "message", "abc123"],
+            SafetyClass::LocalRewrite,
+        );
+        let mut runner = RecordingJjCommandRunner::new(
+            SequencedRunner::successes(vec![
+                output(0, "111111111111\n", ""),
+                output(0, "described\n", ""),
+                output(0, "222222222222\n", ""),
+            ]),
+            &mut history,
+            CommandSource::new(SourceView::Log, SourceAction::DescribeRevision),
+        );
+
+        runner
+            .run_confirmed_mutation(&spec)
+            .expect("fake mutation succeeds");
+
+        let record = history.records().next().expect("recorded mutation");
+        assert_eq!(record.command.spec_preview, "jj describe -m message abc123");
+        assert_eq!(record.operation_id.as_deref(), Some("222222222222"));
+        assert_eq!(history.records().count(), 1);
+    }
+
+    #[test]
+    fn confirmed_mutation_operation_probe_disables_color() {
+        let spec = JjCommandSpec::confirm_mutation(
+            ["describe", "-m", "message", "abc123"],
+            SafetyClass::LocalRewrite,
+        );
+
+        let argv = strings(current_operation_id_spec(&spec).process_argv());
+
+        assert!(argv.windows(2).any(|args| args == ["--color", "never"]));
+        assert!(!argv.windows(2).any(|args| args == ["--color", "always"]));
+    }
+
+    #[test]
+    fn confirmed_mutation_leaves_operation_id_empty_when_context_does_not_change() {
+        let mut history = CommandHistory::new(4);
+        let spec = JjCommandSpec::confirm_mutation(
+            ["describe", "-m", "message", "abc123"],
+            SafetyClass::LocalRewrite,
+        );
+        let mut runner = RecordingJjCommandRunner::new(
+            SequencedRunner::successes(vec![
+                output(0, "111111111111\n", ""),
+                output(0, "described\n", ""),
+                output(0, "111111111111\n", ""),
+            ]),
+            &mut history,
+            CommandSource::new(SourceView::Log, SourceAction::DescribeRevision),
+        );
+
+        runner
+            .run_confirmed_mutation(&spec)
+            .expect("fake mutation succeeds");
+
+        let record = history.records().next().expect("recorded mutation");
+        assert_eq!(record.operation_id, None);
+        assert_eq!(history.records().count(), 1);
+    }
+
+    #[test]
+    fn confirmed_mutation_leaves_operation_id_empty_when_mutation_fails() {
+        let mut history = CommandHistory::new(4);
+        let spec = JjCommandSpec::confirm_mutation(
+            ["describe", "-m", "message", "abc123"],
+            SafetyClass::LocalRewrite,
+        );
+        let mut runner = RecordingJjCommandRunner::new(
+            SequencedRunner::successes(vec![
+                output(0, "111111111111\n", ""),
+                output(1, "", "failed\n"),
+            ]),
+            &mut history,
+            CommandSource::new(SourceView::Log, SourceAction::DescribeRevision),
+        );
+
+        let output = runner
+            .run_confirmed_mutation(&spec)
+            .expect("fake mutation runs");
+
+        assert!(!output.status.success());
+        let record = history.records().next().expect("recorded mutation");
+        assert_eq!(record.operation_id, None);
+        assert_eq!(history.records().count(), 1);
+    }
+
+    #[test]
+    fn confirmed_mutation_runner_does_not_probe_read_only_specs() {
+        let mut history = CommandHistory::new(4);
+        let spec = JjCommandSpec::render_read_only(["status"]);
+        let mut runner = RecordingJjCommandRunner::new(
+            SequencedRunner::successes(vec![output(0, "clean\n", "")]),
+            &mut history,
+            CommandSource::new(SourceView::Status, SourceAction::Refresh),
+        );
+
+        runner
+            .run_confirmed_mutation(&spec)
+            .expect("fake read-only command succeeds");
+
+        let record = history.records().next().expect("recorded command");
+        assert_eq!(record.command.spec_preview, "jj status");
+        assert_eq!(record.operation_id, None);
+        assert_eq!(history.records().count(), 1);
+    }
+
+    struct FakeRunner {
+        result: io::Result<Output>,
+    }
+
+    impl FakeRunner {
+        fn success(code: i32, stdout: &str, stderr: &str) -> Self {
+            Self {
+                result: Ok(Output {
+                    status: exit_status(code),
+                    stdout: stdout.as_bytes().to_vec(),
+                    stderr: stderr.as_bytes().to_vec(),
+                }),
+            }
+        }
+
+        fn spawn_error(message: &str) -> Self {
+            Self {
+                result: Err(io::Error::new(io::ErrorKind::NotFound, message)),
+            }
+        }
+    }
+
+    impl JjCommandRunner for FakeRunner {
+        fn run(&mut self, _spec: &JjCommandSpec) -> io::Result<Output> {
+            std::mem::replace(
+                &mut self.result,
+                Err(io::Error::other("fake runner result already consumed")),
+            )
+        }
+    }
+
+    struct SequencedRunner {
+        outputs: Vec<Output>,
+    }
+
+    impl SequencedRunner {
+        fn successes(outputs: Vec<Output>) -> Self {
+            let mut outputs = outputs;
+            outputs.reverse();
+            Self { outputs }
+        }
+    }
+
+    impl JjCommandRunner for SequencedRunner {
+        fn run(&mut self, _spec: &JjCommandSpec) -> io::Result<Output> {
+            self.outputs
+                .pop()
+                .ok_or_else(|| io::Error::other("fake runner output already consumed"))
+        }
+    }
+
+    fn output(code: i32, stdout: &str, stderr: &str) -> Output {
+        Output {
+            status: exit_status(code),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn exit_status(code: i32) -> std::process::ExitStatus {
+        std::process::ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(not(unix))]
+    fn exit_status(code: i32) -> std::process::ExitStatus {
+        Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+            .args(if cfg!(windows) {
+                vec!["/C".into(), format!("exit {code}").into()]
+            } else {
+                vec!["-c".into(), format!("exit {code}").into()]
+            })
+            .status()
+            .unwrap()
+    }
+}

--- a/crates/jk-cli/src/describe.rs
+++ b/crates/jk-cli/src/describe.rs
@@ -1,0 +1,150 @@
+//! `jj describe` mutation command integration.
+
+use std::path::PathBuf;
+
+use jk_core::{JjCommandSpec, RefreshPlan, SafetyClass};
+
+const DESCRIBE_COMMAND: &str = "describe";
+
+/// Inline description update for one revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DescribeQuery {
+    rev: String,
+    message: String,
+}
+
+impl DescribeQuery {
+    /// Creates an inline `jj describe -m MESSAGE REV` query.
+    #[must_use]
+    pub fn new(rev: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            rev: rev.into(),
+            message: message.into(),
+        }
+    }
+
+    /// Returns the revision passed to `jj describe`.
+    #[must_use]
+    pub fn rev(&self) -> &str {
+        &self.rev
+    }
+
+    /// Returns the inline description message.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+/// Builds typed `jj describe` mutation specs.
+#[derive(Clone, Debug, Default)]
+pub struct JjDescribe {
+    repository: Option<PathBuf>,
+}
+
+impl JjDescribe {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<PathBuf>) -> Self {
+        self.repository = Some(repository.into());
+        self
+    }
+
+    /// Returns the command spec for `query`.
+    #[must_use]
+    pub fn spec_for(&self, query: &DescribeQuery) -> JjCommandSpec {
+        let spec = JjCommandSpec::confirm_mutation(
+            [
+                DESCRIBE_COMMAND,
+                "-m",
+                query.message.as_str(),
+                query.rev.as_str(),
+            ],
+            SafetyClass::LocalRewrite,
+        )
+        .with_title(format!("jj describe {}", query.rev()))
+        .with_refresh_plan(RefreshPlan::None);
+
+        if let Some(repository) = &self.repository {
+            spec.with_repository(repository)
+        } else {
+            spec
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use jk_core::{ExecutionMode, RefreshPlan};
+
+    use super::*;
+    use crate::command::build_jj_command;
+
+    #[test]
+    fn spec_uses_inline_describe_with_message_and_revision() {
+        let query = DescribeQuery::new("abc123", "Update the description");
+        let spec = JjDescribe::default().spec_for(&query);
+
+        assert_eq!(
+            spec.argv()
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["describe", "-m", "Update the description", "abc123"]
+        );
+        assert_eq!(spec.title(), "jj describe abc123");
+        assert_eq!(spec.mode(), ExecutionMode::ConfirmMutation);
+        assert_eq!(spec.safety(), SafetyClass::LocalRewrite);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::None);
+    }
+
+    #[test]
+    fn command_renders_repository_before_describe() {
+        let source = JjDescribe::default().with_repository("/tmp/repo");
+        let spec = source.spec_for(&DescribeQuery::new("abc123", "message"));
+        let command = build_jj_command(&spec);
+
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "describe",
+                "-m",
+                "message",
+                "abc123"
+            ]
+        );
+    }
+
+    #[test]
+    fn process_preview_quotes_message_and_preserves_global_order() {
+        let source = JjDescribe::default().with_repository("/tmp/repo");
+        let spec = source.spec_for(&DescribeQuery::new("abc123", "message with spaces"));
+
+        assert_eq!(
+            spec.process_preview(),
+            "jj --no-pager --color always --repository /tmp/repo describe -m 'message with spaces' abc123"
+        );
+    }
+
+    #[test]
+    fn command_preview_redacts_secret_looking_message() {
+        let spec = JjDescribe::default().spec_for(&DescribeQuery::new(
+            "abc123",
+            "token=abc123 should not render raw",
+        ));
+
+        assert_eq!(
+            spec.command_preview().command_line,
+            "jj --no-pager --color always describe -m 'token=<redacted> should not render raw' abc123"
+        );
+    }
+}

--- a/crates/jk-cli/src/diff.rs
+++ b/crates/jk-cli/src/diff.rs
@@ -1,12 +1,123 @@
 //! Selected-change `jj diff` command integration.
 
 use std::path::PathBuf;
+#[cfg(test)]
 use std::process::Command;
 
-use jk_core::{DiffFileStat, DiffSnapshot};
+use jk_core::{DiffFileStat, DiffSnapshot, JjCommandSpec};
 use thiserror::Error;
 
+#[cfg(test)]
+use crate::command::build_jj_command;
+use crate::command::{JjCommandRunner, SystemJjCommandRunner};
+
 const DIFF_COMMAND: &str = "diff";
+
+/// Rendered `jj diff` output shape.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum DiffFormat {
+    /// Render a patch.
+    #[default]
+    Patch,
+    /// Render `jj diff --summary`.
+    Summary,
+    /// Render `jj diff --stat`.
+    Stat,
+    /// Render `jj diff --types`.
+    Types,
+    /// Render `jj diff --name-only`.
+    NameOnly,
+    /// Render `jj diff --git`.
+    Git,
+    /// Render `jj diff --color-words`.
+    ColorWords,
+}
+
+impl DiffFormat {
+    /// Returns the `jj diff` flag for this format, when the default patch shape needs no flag.
+    #[must_use]
+    pub const fn flag(self) -> Option<&'static str> {
+        match self {
+            Self::Patch => None,
+            Self::Summary => Some("--summary"),
+            Self::Stat => Some("--stat"),
+            Self::Types => Some("--types"),
+            Self::NameOnly => Some("--name-only"),
+            Self::Git => Some("--git"),
+            Self::ColorWords => Some("--color-words"),
+        }
+    }
+
+    /// Returns a compact user-visible label for this format.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Patch => "patch",
+            Self::Summary => "summary",
+            Self::Stat => "stat",
+            Self::Types => "types",
+            Self::NameOnly => "name only",
+            Self::Git => "git",
+            Self::ColorWords => "color words",
+        }
+    }
+}
+
+/// Canonical query shapes supported by `jk diff`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DiffQuery {
+    /// Diff one revision against its parent.
+    Revision {
+        /// Revision to diff against its parent.
+        rev: String,
+        /// Rendered output shape.
+        format: DiffFormat,
+    },
+    /// Diff two revisions.
+    FromTo {
+        /// Starting revision.
+        from: String,
+        /// Ending revision.
+        to: String,
+        /// Rendered output shape.
+        format: DiffFormat,
+    },
+}
+
+impl DiffQuery {
+    /// Returns the query format.
+    #[must_use]
+    pub const fn format(&self) -> DiffFormat {
+        match self {
+            Self::Revision { format, .. } | Self::FromTo { format, .. } => *format,
+        }
+    }
+
+    /// Returns a compact label for places that still expect one diff target.
+    #[must_use]
+    pub fn target_label(&self) -> String {
+        match self {
+            Self::Revision { rev, .. } => rev.clone(),
+            Self::FromTo { from, to, .. } => format!("{from}..{to}"),
+        }
+    }
+
+    /// Returns this query with a different rendered output format.
+    #[must_use]
+    pub fn with_format(&self, format: DiffFormat) -> Self {
+        match self {
+            Self::Revision { rev, .. } => Self::Revision {
+                rev: rev.clone(),
+                format,
+            },
+            Self::FromTo { from, to, .. } => Self::FromTo {
+                from: from.clone(),
+                to: to.clone(),
+                format,
+            },
+        }
+    }
+}
 
 /// Loads a rendered diff for a selected `jj` change.
 ///
@@ -26,23 +137,78 @@ impl JjDiff {
         self
     }
 
+    /// Loads the rendered diff for `query`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query(&self, query: &DiffQuery) -> Result<DiffSnapshot, JjDiffError> {
+        self.load_query_with_runner(query, &mut SystemJjCommandRunner)
+    }
+
+    /// Loads the rendered diff for `query` using the provided command runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query_with_runner(
+        &self,
+        query: &DiffQuery,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<DiffSnapshot, JjDiffError> {
+        let spec = self.spec_for(query);
+        let rendered = Self::run(runner, &spec)?;
+        let stats_output;
+        let stats = if query.format() == DiffFormat::Stat {
+            &rendered
+        } else {
+            stats_output = Self::run(runner, &self.spec_for(&query.with_format(DiffFormat::Stat)))?;
+            &stats_output
+        };
+        let file_stats = parse_stats_lines(stats);
+
+        Ok(DiffSnapshot::new(query.target_label(), rendered)
+            .with_file_stats(file_stats)
+            .with_title(spec.title()))
+    }
+
     /// Loads the rendered diff for `change_id`.
+    ///
+    /// This is compatibility sugar for selected-change callers.
     ///
     /// # Errors
     ///
     /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
     pub fn load(&self, change_id: &str) -> Result<DiffSnapshot, JjDiffError> {
-        let rendered = Self::run(self.diff_command(change_id))?;
-        let stats = Self::run(self.stats_command(change_id))?;
-        let file_stats = parse_stats_lines(&stats);
-
-        Ok(DiffSnapshot::new(change_id, rendered)
-            .with_file_stats(file_stats)
-            .with_title(command_title(change_id)))
+        self.load_query(&DiffQuery::Revision {
+            rev: change_id.to_owned(),
+            format: DiffFormat::Patch,
+        })
     }
 
-    fn run(mut command: Command) -> Result<String, JjDiffError> {
-        let output = command.output()?;
+    /// Returns the command spec for `query`.
+    #[must_use]
+    pub fn spec_for(&self, query: &DiffQuery) -> JjCommandSpec {
+        match query {
+            DiffQuery::Revision { rev, format } => {
+                let mut argv = vec![DIFF_COMMAND, "-r", rev.as_str()];
+                if let Some(flag) = format.flag() {
+                    argv.push(flag);
+                }
+                self.spec(argv)
+            }
+            DiffQuery::FromTo { from, to, format } => {
+                let mut argv = vec![DIFF_COMMAND, "--from", from.as_str(), "--to", to.as_str()];
+                if let Some(flag) = format.flag() {
+                    argv.push(flag);
+                }
+                self.spec(argv)
+            }
+        }
+    }
+
+    fn run(runner: &mut impl JjCommandRunner, spec: &JjCommandSpec) -> Result<String, JjDiffError> {
+        let output = runner.run(spec)?;
         if output.status.success() {
             Ok(String::from_utf8_lossy(&output.stdout).into_owned())
         } else {
@@ -51,42 +217,30 @@ impl JjDiff {
         }
     }
 
+    #[cfg(test)]
     fn diff_command(&self, change_id: &str) -> Command {
-        let mut command = self.base_command("always");
-        command.command.args([DIFF_COMMAND, "-r", change_id]);
-        command.command
+        build_jj_command(&self.spec_for(&DiffQuery::Revision {
+            rev: change_id.to_owned(),
+            format: DiffFormat::Patch,
+        }))
     }
 
+    #[cfg(test)]
     fn stats_command(&self, change_id: &str) -> Command {
-        let mut command = self.base_command("always");
-        command
-            .command
-            .args([DIFF_COMMAND, "-r", change_id, "--stat"]);
-        command.command
+        build_jj_command(&self.spec_for(&DiffQuery::Revision {
+            rev: change_id.to_owned(),
+            format: DiffFormat::Stat,
+        }))
     }
 
-    fn base_command(&self, color: &str) -> JjCommand {
-        let mut command = Command::new("jj");
-        command.args(["--no-pager", "--color", color]);
-        command.env_remove("NO_COLOR");
-        command.env_remove("CLICOLOR");
-        command.env_remove("CLICOLOR_FORCE");
-
+    fn spec<'a>(&self, argv: impl IntoIterator<Item = &'a str>) -> JjCommandSpec {
+        let spec = JjCommandSpec::render_read_only(argv);
         if let Some(repository) = &self.repository {
-            command.arg("--repository").arg(repository);
+            spec.with_repository(repository)
+        } else {
+            spec
         }
-
-        JjCommand { command }
     }
-}
-
-struct JjCommand {
-    command: Command,
-}
-
-/// Builds the title-bar command label for a selected-change diff.
-fn command_title(change_id: &str) -> String {
-    format!("jj diff -r {change_id}")
 }
 
 /// Parses per-file diff stats from jj's rendered `--stat` rows.
@@ -189,8 +343,87 @@ mod tests {
     }
 
     #[test]
-    fn command_title_names_targeted_jj_diff() {
-        assert_eq!(command_title("abc123"), "jj diff -r abc123");
+    fn revision_query_builds_targeted_jj_diff_spec() {
+        let spec = JjDiff::default().spec_for(&DiffQuery::Revision {
+            rev: "abc123".to_owned(),
+            format: DiffFormat::Patch,
+        });
+
+        let argv = spec
+            .argv()
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(argv, ["diff", "-r", "abc123"]);
+        assert_eq!(spec.title(), "jj diff -r abc123");
+    }
+
+    #[test]
+    fn revision_query_renders_repository_before_diff() {
+        let command = JjDiff::default()
+            .with_repository("/tmp/repo")
+            .diff_command("abc123");
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "diff",
+                "-r",
+                "abc123"
+            ]
+        );
+    }
+
+    #[test]
+    fn from_to_stat_query_builds_canonical_spec() {
+        let spec = JjDiff::default().spec_for(&DiffQuery::FromTo {
+            from: "main".to_owned(),
+            to: "@".to_owned(),
+            format: DiffFormat::Stat,
+        });
+
+        let argv = spec
+            .argv()
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(argv, ["diff", "--from", "main", "--to", "@", "--stat"]);
+        assert_eq!(spec.title(), "jj diff --from main --to @ --stat");
+    }
+
+    #[test]
+    fn revision_query_builds_supported_format_specs() {
+        for (format, flag) in [
+            (DiffFormat::Summary, "--summary"),
+            (DiffFormat::Types, "--types"),
+            (DiffFormat::NameOnly, "--name-only"),
+            (DiffFormat::Git, "--git"),
+            (DiffFormat::ColorWords, "--color-words"),
+        ] {
+            let spec = JjDiff::default().spec_for(&DiffQuery::Revision {
+                rev: "abc123".to_owned(),
+                format,
+            });
+            let argv = spec
+                .argv()
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>();
+
+            assert_eq!(argv, ["diff", "-r", "abc123", flag]);
+            assert_eq!(spec.title(), format!("jj diff -r abc123 {flag}"));
+        }
     }
 
     #[test]

--- a/crates/jk-cli/src/edit.rs
+++ b/crates/jk-cli/src/edit.rs
@@ -1,0 +1,117 @@
+//! `jj edit` mutation command integration.
+
+use jk_core::{GlobalOptions, JjCommandSpec, RefreshPlan, SafetyClass};
+
+const EDIT_COMMAND: &str = "edit";
+
+/// Move the working copy to a revision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EditQuery {
+    rev: String,
+}
+
+impl EditQuery {
+    /// Creates a `jj edit REV` query.
+    #[must_use]
+    pub fn new(rev: impl Into<String>) -> Self {
+        Self { rev: rev.into() }
+    }
+
+    /// Returns the revision passed to `jj edit`.
+    #[must_use]
+    pub fn rev(&self) -> &str {
+        &self.rev
+    }
+}
+
+/// Builds typed `jj edit` mutation specs.
+#[derive(Clone, Debug, Default)]
+pub struct JjEdit {
+    global_options: GlobalOptions,
+}
+
+impl JjEdit {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<std::path::PathBuf>) -> Self {
+        self.global_options = self.global_options.with_repository(repository);
+        self
+    }
+
+    /// Returns the command spec for `query`.
+    #[must_use]
+    pub fn spec_for(&self, query: &EditQuery) -> JjCommandSpec {
+        JjCommandSpec::confirm_mutation([EDIT_COMMAND, query.rev()], SafetyClass::LocalRewrite)
+            .with_global_options(self.global_options.clone())
+            .with_title(format!("jj edit {}", query.rev()))
+            .with_refresh_plan(RefreshPlan::None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use jk_core::{ExecutionMode, RefreshPlan};
+
+    use super::*;
+
+    fn strings(args: &[OsString]) -> Vec<String> {
+        args.iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn edit_builds_confirmed_local_rewrite_spec() {
+        let query = EditQuery::new("abc123");
+        let spec = JjEdit::default().spec_for(&query);
+
+        assert_eq!(strings(spec.argv()), vec!["edit", "abc123"]);
+        assert_eq!(spec.title(), "jj edit abc123");
+        assert_eq!(spec.mode(), ExecutionMode::ConfirmMutation);
+        assert_eq!(spec.safety(), SafetyClass::LocalRewrite);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::None);
+    }
+
+    #[test]
+    fn repository_renders_before_edit() {
+        let spec = JjEdit::default()
+            .with_repository("/tmp/repo")
+            .spec_for(&EditQuery::new("abc123"));
+        let argv = spec
+            .process_argv()
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            argv,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "edit",
+                "abc123",
+            ]
+        );
+    }
+
+    #[test]
+    fn command_preview_warns_about_local_rewrite() {
+        let preview = JjEdit::default()
+            .spec_for(&EditQuery::new("abc123"))
+            .command_preview();
+
+        assert_eq!(
+            preview.command_line,
+            "jj --no-pager --color always edit abc123"
+        );
+        assert_eq!(
+            preview.warnings,
+            vec![jk_core::CommandPreviewWarning::LocalRewrite]
+        );
+    }
+}

--- a/crates/jk-cli/src/evolog.rs
+++ b/crates/jk-cli/src/evolog.rs
@@ -1,0 +1,162 @@
+//! Selected-change `jj evolog` command integration.
+
+use std::path::PathBuf;
+
+use jk_core::{InspectionSnapshot, JjCommandSpec};
+use thiserror::Error;
+
+use crate::command::{JjCommandRunner, SystemJjCommandRunner};
+
+const EVOLOG_COMMAND: &str = "evolog";
+
+/// Canonical query shape supported by selected-change evolog inspection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EvologQuery {
+    rev: String,
+}
+
+impl EvologQuery {
+    /// Creates a `jj evolog` query for one revision.
+    #[must_use]
+    pub fn new(rev: impl Into<String>) -> Self {
+        Self { rev: rev.into() }
+    }
+
+    /// Returns the revision passed to `jj evolog -r`.
+    #[must_use]
+    pub fn rev(&self) -> &str {
+        &self.rev
+    }
+
+    /// Returns a compact target label for error and empty-output states.
+    #[must_use]
+    pub fn target_label(&self) -> String {
+        self.rev.clone()
+    }
+}
+
+impl From<String> for EvologQuery {
+    fn from(rev: String) -> Self {
+        Self::new(rev)
+    }
+}
+
+/// Loads rendered `jj evolog` output.
+#[derive(Clone, Debug, Default)]
+pub struct JjEvolog {
+    repository: Option<PathBuf>,
+}
+
+impl JjEvolog {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<PathBuf>) -> Self {
+        self.repository = Some(repository.into());
+        self
+    }
+
+    /// Loads the rendered evolog output for `query`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query(&self, query: &EvologQuery) -> Result<InspectionSnapshot, JjEvologError> {
+        self.load_query_with_runner(query, &mut SystemJjCommandRunner)
+    }
+
+    /// Loads the rendered evolog output for `query` using the provided command runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query_with_runner(
+        &self,
+        query: &EvologQuery,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<InspectionSnapshot, JjEvologError> {
+        let spec = self.spec_for(query);
+        let rendered = Self::run(runner, &spec)?;
+        Ok(InspectionSnapshot::new(query.target_label(), rendered).with_title(spec.title()))
+    }
+
+    /// Returns the command spec for `query`.
+    #[must_use]
+    pub fn spec_for(&self, query: &EvologQuery) -> JjCommandSpec {
+        let spec = JjCommandSpec::render_read_only([EVOLOG_COMMAND, "-r", query.rev()]);
+        if let Some(repository) = &self.repository {
+            spec.with_repository(repository)
+        } else {
+            spec
+        }
+    }
+
+    fn run(
+        runner: &mut impl JjCommandRunner,
+        spec: &JjCommandSpec,
+    ) -> Result<String, JjEvologError> {
+        let output = runner.run(spec)?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            Err(JjEvologError::CommandFailed(stderr))
+        }
+    }
+}
+
+/// Error returned while loading rendered `jj evolog` output.
+#[derive(Debug, Error)]
+pub enum JjEvologError {
+    /// The `jj` process could not be started or read.
+    #[error("failed to run jj evolog: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// `jj evolog` exited unsuccessfully.
+    #[error("jj evolog failed: {0}")]
+    CommandFailed(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::build_jj_command;
+
+    #[test]
+    fn spec_uses_jj_evolog_with_revision() {
+        let spec = JjEvolog::default().spec_for(&EvologQuery::new("abc123"));
+
+        assert_eq!(
+            spec.argv()
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["evolog", "-r", "abc123"]
+        );
+        assert_eq!(spec.title(), "jj evolog -r abc123");
+    }
+
+    #[test]
+    fn command_renders_repository_before_evolog() {
+        let source = JjEvolog::default().with_repository("/tmp/repo");
+        let spec = source.spec_for(&EvologQuery::new("abc123"));
+        let command = build_jj_command(&spec);
+
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "evolog",
+                "-r",
+                "abc123"
+            ]
+        );
+    }
+}

--- a/crates/jk-cli/src/lib.rs
+++ b/crates/jk-cli/src/lib.rs
@@ -10,8 +10,34 @@
 //! rendered-output-first boundary for selected-change inspection. This is a temporary integration
 //! boundary until `jj-cli` / `jj-lib` can provide both pieces without parsing command output.
 
-pub mod diff;
-pub mod log;
+mod command;
 
-pub use diff::{JjDiff, JjDiffError};
-pub use log::{JjLog, JjLogCommand, JjLogError};
+pub mod abandon;
+pub mod describe;
+pub mod diff;
+pub mod edit;
+pub mod evolog;
+pub mod log;
+pub mod new;
+pub mod operation;
+pub mod recovery;
+pub mod show;
+pub mod status;
+pub mod workspaces;
+
+pub use abandon::{AbandonQuery, JjAbandon};
+pub use command::{JjCommandRunner, RecordingJjCommandRunner, SystemJjCommandRunner};
+pub use describe::{DescribeQuery, JjDescribe};
+pub use diff::{DiffFormat, DiffQuery, JjDiff, JjDiffError};
+pub use edit::{EditQuery, JjEdit};
+pub use evolog::{EvologQuery, JjEvolog, JjEvologError};
+pub use log::{JjLog, JjLogCommand, JjLogError, LogTemplateSelection};
+pub use new::{JjNew, NewQuery};
+pub use operation::{JjOperation, JjOperationError, OperationQuery};
+pub use recovery::{JjRecovery, RecoveryCommand};
+pub use show::{JjShow, JjShowError, ShowQuery};
+pub use status::{JjStatus, JjStatusError, StatusQuery};
+pub use workspaces::{
+    JjWorkspaces, JjWorkspacesError, WorkspaceInspectionQuery, WorkspaceListParseError,
+    WorkspaceListSnapshot, WorkspaceSummary,
+};

--- a/crates/jk-cli/src/log.rs
+++ b/crates/jk-cli/src/log.rs
@@ -1,10 +1,15 @@
 //! Log-like `jj` command integration.
 
 use std::path::PathBuf;
+#[cfg(test)]
 use std::process::Command;
 
-use jk_core::LogSnapshot;
+use jk_core::{JjCommandSpec, LogSnapshot};
 use thiserror::Error;
+
+#[cfg(test)]
+use crate::command::build_jj_command;
+use crate::command::{JjCommandRunner, SystemJjCommandRunner};
 
 mod rendered;
 mod semantic;
@@ -13,6 +18,13 @@ use rendered::assign_rendered_lines;
 use semantic::{LOG_TEMPLATE, parse_log_json_lines};
 
 const LOG_COMMAND: &str = "log";
+const COMFORTABLE_LOG_TEMPLATE: &str = "builtin_log_comfortable";
+const COMPACT_LOG_TEMPLATE: &str = "builtin_log_compact";
+const FULL_DESCRIPTION_LOG_TEMPLATE: &str = "builtin_log_compact_full_description";
+const DETAILED_LOG_TEMPLATE: &str = "builtin_log_detailed";
+const ONELINE_LOG_TEMPLATE: &str = "builtin_log_oneline";
+const REDACTED_LOG_TEMPLATE: &str = "builtin_log_redacted";
+const TEMPLATE_TITLE_LIMIT: usize = 48;
 
 /// Loads a log-like view from the local `jj` command.
 ///
@@ -37,6 +49,8 @@ pub struct JjLog {
     repository: Option<PathBuf>,
     command: JjLogCommand,
     limit: Option<usize>,
+    template: LogTemplateSelection,
+    custom_template: Option<String>,
 }
 
 impl Default for JjLog {
@@ -45,6 +59,8 @@ impl Default for JjLog {
             repository: None,
             command: JjLogCommand::ConfiguredDefault,
             limit: None,
+            template: LogTemplateSelection::Configured,
+            custom_template: None,
         }
     }
 }
@@ -58,6 +74,35 @@ pub enum JjLogCommand {
 
     /// Run jj's explicit `log` command.
     Log,
+}
+
+/// Rendered `jj log` template selection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum LogTemplateSelection {
+    /// Let `jj` use the configured rendered template.
+    Configured,
+
+    /// Use jj's built-in comfortable log template.
+    Comfortable,
+
+    /// Use jj's built-in compact log template.
+    Compact,
+
+    /// Use jj's built-in compact template with full descriptions.
+    CompactFullDescription,
+
+    /// Use jk's built-in detailed rendered log template.
+    Detailed,
+
+    /// Use jj's built-in one-line log template.
+    Oneline,
+
+    /// Use jj's redacted log template.
+    Redacted,
+
+    /// Use a caller-provided rendered `jj` template.
+    Custom(String),
 }
 
 impl JjLog {
@@ -82,6 +127,46 @@ impl JjLog {
         self
     }
 
+    /// Sets the rendered log template selection.
+    #[must_use]
+    pub fn with_template(mut self, template: LogTemplateSelection) -> Self {
+        if let LogTemplateSelection::Custom(custom) = &template {
+            self.custom_template = Some(custom.clone());
+        }
+        self.template = template;
+        self
+    }
+
+    /// Clears the rendered log template selection.
+    #[must_use]
+    pub fn with_configured_template(self) -> Self {
+        self.with_template(LogTemplateSelection::Configured)
+    }
+
+    /// Returns the current rendered log template selection.
+    #[must_use]
+    pub const fn template(&self) -> &LogTemplateSelection {
+        &self.template
+    }
+
+    /// Returns selectable rendered log templates for the current source.
+    #[must_use]
+    pub fn template_options(&self) -> Vec<LogTemplateSelection> {
+        let mut options = vec![
+            LogTemplateSelection::Configured,
+            LogTemplateSelection::Comfortable,
+            LogTemplateSelection::Compact,
+            LogTemplateSelection::CompactFullDescription,
+            LogTemplateSelection::Detailed,
+            LogTemplateSelection::Oneline,
+            LogTemplateSelection::Redacted,
+        ];
+        if let Some(custom) = &self.custom_template {
+            options.push(LogTemplateSelection::Custom(custom.clone()));
+        }
+        options
+    }
+
     /// Loads a rendered log snapshot and semantic entries from `jj`.
     ///
     /// This method executes `jj` twice: once for the user's rendered log output and once with a
@@ -95,17 +180,40 @@ impl JjLog {
     /// does not match the expected schema, or the selected command cannot provide semantic log
     /// records.
     pub fn load(&self) -> Result<LogSnapshot, JjLogError> {
+        self.load_with_runner(&mut SystemJjCommandRunner)
+    }
+
+    /// Loads a rendered log snapshot using the provided command runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed, exits unsuccessfully, emits a JSON record that
+    /// does not match the expected schema, or the selected command cannot provide semantic log
+    /// records.
+    pub fn load_with_runner(
+        &self,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<LogSnapshot, JjLogError> {
         let command_args = self.command_args();
-        let rendered = self.run(DefaultCommandMode::Rendered, &command_args)?;
-        let semantic = self.run(DefaultCommandMode::Json, &command_args)?;
+        let rendered_spec = self.command_spec(DefaultCommandMode::Rendered, &command_args);
+        let rendered = Self::run(runner, DefaultCommandMode::Rendered, &rendered_spec)?;
+        let semantic = Self::run(
+            runner,
+            DefaultCommandMode::Json,
+            &self.command_spec(DefaultCommandMode::Json, &command_args),
+        )?;
         let entries = parse_log_json_lines(&semantic)?;
         let entries = assign_rendered_lines(entries, &rendered)?;
 
-        Ok(LogSnapshot::new(rendered, entries).with_title(command_title(&command_args)))
+        Ok(LogSnapshot::new(rendered, entries).with_title(rendered_spec.title()))
     }
 
-    fn run(&self, mode: DefaultCommandMode, command_args: &[String]) -> Result<String, JjLogError> {
-        let output = self.command(mode, command_args).output()?;
+    fn run(
+        runner: &mut impl JjCommandRunner,
+        mode: DefaultCommandMode,
+        spec: &JjCommandSpec,
+    ) -> Result<String, JjLogError> {
+        let output = runner.run(spec)?;
 
         if output.status.success() {
             Ok(String::from_utf8_lossy(&output.stdout).into_owned())
@@ -113,7 +221,7 @@ impl JjLog {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
             if mode == DefaultCommandMode::Json {
                 Err(JjLogError::UnsupportedSemanticCommand {
-                    command: command_title(command_args),
+                    command: spec.title().to_owned(),
                     stderr,
                 })
             } else {
@@ -122,26 +230,32 @@ impl JjLog {
         }
     }
 
+    #[cfg(test)]
     fn command(&self, mode: DefaultCommandMode, command_args: &[String]) -> Command {
-        let mut command = Command::new("jj");
-        command.args(["--no-pager", "--color", "always"]);
-        command.env_remove("NO_COLOR");
-        command.env_remove("CLICOLOR");
-        command.env_remove("CLICOLOR_FORCE");
+        build_jj_command(&self.command_spec(mode, command_args))
+    }
 
-        if let Some(repository) = &self.repository {
-            command.arg("--repository").arg(repository);
-        }
-
-        command.args(command_args);
+    fn command_spec(&self, mode: DefaultCommandMode, command_args: &[String]) -> JjCommandSpec {
+        let mut argv = command_args.to_vec();
         if let Some(limit) = self.limit {
-            command.args(["-n", &limit.to_string()]);
+            argv.push("-n".to_owned());
+            argv.push(limit.to_string());
         }
         if mode == DefaultCommandMode::Json {
-            command.args(["-T", LOG_TEMPLATE]);
+            argv.push("-T".to_owned());
+            argv.push(LOG_TEMPLATE.to_owned());
+        } else if let Some(template) = self.rendered_template() {
+            argv.push("-T".to_owned());
+            argv.push(template.to_owned());
         }
 
-        command
+        let spec = JjCommandSpec::render_read_only(argv)
+            .with_title(command_title(command_args, &self.template));
+        if let Some(repository) = &self.repository {
+            spec.with_repository(repository)
+        } else {
+            spec
+        }
     }
 
     fn command_args(&self) -> Vec<String> {
@@ -150,15 +264,83 @@ impl JjLog {
             JjLogCommand::Log => vec![LOG_COMMAND.to_owned()],
         }
     }
+
+    fn rendered_template(&self) -> Option<&str> {
+        match &self.template {
+            LogTemplateSelection::Configured => None,
+            LogTemplateSelection::Comfortable => Some(COMFORTABLE_LOG_TEMPLATE),
+            LogTemplateSelection::Compact => Some(COMPACT_LOG_TEMPLATE),
+            LogTemplateSelection::CompactFullDescription => Some(FULL_DESCRIPTION_LOG_TEMPLATE),
+            LogTemplateSelection::Detailed => Some(DETAILED_LOG_TEMPLATE),
+            LogTemplateSelection::Oneline => Some(ONELINE_LOG_TEMPLATE),
+            LogTemplateSelection::Redacted => Some(REDACTED_LOG_TEMPLATE),
+            LogTemplateSelection::Custom(template) => Some(template),
+        }
+    }
+}
+
+impl LogTemplateSelection {
+    /// Returns the short label used in interactive template selectors.
+    #[must_use]
+    pub const fn label(&self) -> &str {
+        match self {
+            Self::Configured => "configured",
+            Self::Comfortable => "comfortable",
+            Self::Compact => "compact",
+            Self::CompactFullDescription => "full description",
+            Self::Detailed => "detailed",
+            Self::Oneline => "oneline",
+            Self::Redacted => "redacted",
+            Self::Custom(_) => "custom",
+        }
+    }
+
+    /// Returns the template string passed to `jj -T` for display.
+    #[must_use]
+    pub fn template_name(&self) -> Option<&str> {
+        match self {
+            Self::Configured => None,
+            Self::Comfortable => Some(COMFORTABLE_LOG_TEMPLATE),
+            Self::Compact => Some(COMPACT_LOG_TEMPLATE),
+            Self::CompactFullDescription => Some(FULL_DESCRIPTION_LOG_TEMPLATE),
+            Self::Detailed => Some(DETAILED_LOG_TEMPLATE),
+            Self::Oneline => Some(ONELINE_LOG_TEMPLATE),
+            Self::Redacted => Some(REDACTED_LOG_TEMPLATE),
+            Self::Custom(template) => Some(template),
+        }
+    }
 }
 
 /// Builds the title-bar command label from the jj command arguments.
-fn command_title(command_args: &[String]) -> String {
+fn command_title(command_args: &[String], template: &LogTemplateSelection) -> String {
     let mut title = String::from("jj");
     for arg in command_args {
         title.push(' ');
         title.push_str(arg);
     }
+    match template {
+        LogTemplateSelection::Configured => {}
+        template => {
+            title.push_str(" -T ");
+            title.push_str(&template_title(
+                template.template_name().unwrap_or_default(),
+            ));
+        }
+    }
+    title
+}
+
+fn template_title(template: &str) -> String {
+    let compact = template.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= TEMPLATE_TITLE_LIMIT {
+        return compact;
+    }
+
+    let mut title = compact
+        .chars()
+        .take(TEMPLATE_TITLE_LIMIT.saturating_sub(3))
+        .collect::<String>();
+    title.push_str("...");
     title
 }
 
@@ -265,6 +447,31 @@ mod tests {
     }
 
     #[test]
+    fn explicit_log_command_renders_repository_before_log() {
+        let source = JjLog::default()
+            .with_command(JjLogCommand::Log)
+            .with_repository("/tmp/repo");
+        let command_args = source.command_args();
+        let command = source.command(DefaultCommandMode::Rendered, &command_args);
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "log"
+            ]
+        );
+    }
+
+    #[test]
     fn configured_default_command_uses_bare_jj_with_user_supplied_limit() {
         let source = JjLog::default().with_limit(Some(3));
         let command_args = source.command_args();
@@ -278,13 +485,123 @@ mod tests {
         assert!(!args.iter().any(|arg| arg == "log"));
         assert!(args.windows(2).any(|args| args == ["-n", "3"]));
         assert!(args.windows(2).any(|args| args == ["-T", LOG_TEMPLATE]));
-        assert_eq!(command_title(&command_args), "jj");
+        assert_eq!(
+            command_title(&command_args, &LogTemplateSelection::Configured),
+            "jj"
+        );
     }
 
     #[test]
     fn command_title_names_jj_command_context() {
         let command_args = vec!["log".to_owned(), "-r".to_owned(), "@".to_owned()];
 
-        assert_eq!(command_title(&command_args), "jj log -r @");
+        assert_eq!(
+            command_title(&command_args, &LogTemplateSelection::Configured),
+            "jj log -r @"
+        );
+    }
+
+    #[test]
+    fn command_title_shows_compact_custom_template() {
+        let command_args = vec!["log".to_owned()];
+
+        assert_eq!(
+            command_title(
+                &command_args,
+                &LogTemplateSelection::Custom("builtin_log_compact_full_description".to_owned())
+            ),
+            "jj log -T builtin_log_compact_full_description"
+        );
+    }
+
+    #[test]
+    fn custom_template_only_affects_rendered_command() {
+        let source = JjLog::default()
+            .with_command(JjLogCommand::Log)
+            .with_template(LogTemplateSelection::Custom("description".to_owned()));
+        let command_args = source.command_args();
+        let rendered = source.command(DefaultCommandMode::Rendered, &command_args);
+        let semantic = source.command(DefaultCommandMode::Json, &command_args);
+        let rendered_args = rendered
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        let semantic_args = semantic
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(
+            rendered_args
+                .windows(2)
+                .any(|args| args == ["-T", "description"])
+        );
+        assert!(
+            !semantic_args
+                .windows(2)
+                .any(|args| args == ["-T", "description"])
+        );
+        assert!(
+            semantic_args
+                .windows(2)
+                .any(|args| args == ["-T", LOG_TEMPLATE])
+        );
+    }
+
+    #[test]
+    fn detailed_template_uses_native_jj_template_name() {
+        let source = JjLog::default()
+            .with_command(JjLogCommand::Log)
+            .with_template(LogTemplateSelection::Detailed);
+        let command_args = source.command_args();
+        let command = source.command(DefaultCommandMode::Rendered, &command_args);
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(
+            args.windows(2)
+                .any(|args| args == ["-T", DETAILED_LOG_TEMPLATE])
+        );
+    }
+
+    #[test]
+    fn selector_options_include_jj_log_presets() {
+        let source = JjLog::default();
+
+        assert_eq!(
+            source.template_options(),
+            vec![
+                LogTemplateSelection::Configured,
+                LogTemplateSelection::Comfortable,
+                LogTemplateSelection::Compact,
+                LogTemplateSelection::CompactFullDescription,
+                LogTemplateSelection::Detailed,
+                LogTemplateSelection::Oneline,
+                LogTemplateSelection::Redacted,
+            ]
+        );
+    }
+
+    #[test]
+    fn template_options_include_startup_custom_template() {
+        let source = JjLog::default()
+            .with_command(JjLogCommand::Log)
+            .with_template(LogTemplateSelection::Custom("description".to_owned()));
+
+        assert_eq!(
+            source.template_options(),
+            vec![
+                LogTemplateSelection::Configured,
+                LogTemplateSelection::Comfortable,
+                LogTemplateSelection::Compact,
+                LogTemplateSelection::CompactFullDescription,
+                LogTemplateSelection::Detailed,
+                LogTemplateSelection::Oneline,
+                LogTemplateSelection::Redacted,
+                LogTemplateSelection::Custom("description".to_owned())
+            ]
+        );
     }
 }

--- a/crates/jk-cli/src/new.rs
+++ b/crates/jk-cli/src/new.rs
@@ -1,0 +1,146 @@
+//! `jj new` mutation command integration.
+
+use jk_core::{GlobalOptions, JjCommandSpec, RefreshPlan, SafetyClass};
+
+const NEW_COMMAND: &str = "new";
+
+/// Create a new change from parent revisions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NewQuery {
+    parents: Vec<String>,
+}
+
+impl NewQuery {
+    /// Creates a `jj new PARENTS...` query.
+    #[must_use]
+    pub fn new(parents: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            parents: parents.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Returns whether no explicit parent revisions were provided.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.parents.is_empty()
+    }
+
+    /// Returns the parent revisions passed to `jj new`.
+    #[must_use]
+    pub fn parents(&self) -> &[String] {
+        &self.parents
+    }
+}
+
+/// Builds typed `jj new` mutation specs.
+#[derive(Clone, Debug, Default)]
+pub struct JjNew {
+    global_options: GlobalOptions,
+}
+
+impl JjNew {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<std::path::PathBuf>) -> Self {
+        self.global_options = self.global_options.with_repository(repository);
+        self
+    }
+
+    /// Returns the command spec for `query`.
+    #[must_use]
+    pub fn spec_for(&self, query: &NewQuery) -> JjCommandSpec {
+        let mut argv = Vec::with_capacity(query.parents.len() + 1);
+        argv.push(NEW_COMMAND.to_owned());
+        argv.extend(query.parents.iter().cloned());
+
+        JjCommandSpec::confirm_mutation(argv, SafetyClass::LocalRewrite)
+            .with_global_options(self.global_options.clone())
+            .with_title(new_title(query.parents()))
+            .with_refresh_plan(RefreshPlan::None)
+    }
+}
+
+fn new_title(parents: &[String]) -> String {
+    if parents.is_empty() {
+        return "jj new".to_owned();
+    }
+
+    format!("jj new {}", parents.join(" "))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use jk_core::{ExecutionMode, RefreshPlan};
+
+    use super::*;
+
+    fn strings(args: &[OsString]) -> Vec<String> {
+        args.iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn new_builds_confirmed_local_rewrite_spec() {
+        let query = NewQuery::new(["abc123"]);
+        let spec = JjNew::default().spec_for(&query);
+
+        assert_eq!(strings(spec.argv()), vec!["new", "abc123"]);
+        assert_eq!(spec.title(), "jj new abc123");
+        assert_eq!(spec.mode(), ExecutionMode::ConfirmMutation);
+        assert_eq!(spec.safety(), SafetyClass::LocalRewrite);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::None);
+    }
+
+    #[test]
+    fn new_preserves_multiple_parent_revisions() {
+        let query = NewQuery::new(["abc123", "def456"]);
+        let spec = JjNew::default().spec_for(&query);
+
+        assert_eq!(strings(spec.argv()), vec!["new", "abc123", "def456"]);
+        assert_eq!(spec.title(), "jj new abc123 def456");
+    }
+
+    #[test]
+    fn repository_renders_before_new() {
+        let spec = JjNew::default()
+            .with_repository("/tmp/repo")
+            .spec_for(&NewQuery::new(["abc123"]));
+        let argv = spec
+            .process_argv()
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            argv,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "new",
+                "abc123",
+            ]
+        );
+    }
+
+    #[test]
+    fn command_preview_warns_about_local_rewrite() {
+        let preview = JjNew::default()
+            .spec_for(&NewQuery::new(["abc123"]))
+            .command_preview();
+
+        assert_eq!(
+            preview.command_line,
+            "jj --no-pager --color always new abc123"
+        );
+        assert_eq!(
+            preview.warnings,
+            vec![jk_core::CommandPreviewWarning::LocalRewrite]
+        );
+    }
+}

--- a/crates/jk-cli/src/operation.rs
+++ b/crates/jk-cli/src/operation.rs
@@ -1,0 +1,326 @@
+//! Read-only `jj op ...` command integration.
+
+use jk_core::{GlobalOptions, InspectionSnapshot, JjCommandSpec};
+use thiserror::Error;
+
+use crate::command::{JjCommandRunner, SystemJjCommandRunner};
+
+const OP_COMMAND: &str = "op";
+const LOG_COMMAND: &str = "log";
+const SHOW_COMMAND: &str = "show";
+const DIFF_COMMAND: &str = "diff";
+
+/// Canonical query shapes supported by operation inspection.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OperationQuery {
+    /// Render `jj op log`.
+    Log,
+    /// Render `jj op show OPERATION`.
+    Show {
+        /// Operation to inspect.
+        operation: String,
+    },
+    /// Render `jj op diff --operation OPERATION`.
+    Diff {
+        /// Operation to diff.
+        operation: String,
+    },
+}
+
+impl OperationQuery {
+    /// Creates a `jj op log` query.
+    #[must_use]
+    pub const fn log() -> Self {
+        Self::Log
+    }
+
+    /// Creates a `jj op show OPERATION` query.
+    #[must_use]
+    pub fn show(operation: impl Into<String>) -> Self {
+        Self::Show {
+            operation: operation.into(),
+        }
+    }
+
+    /// Creates a `jj op diff --operation OPERATION` query.
+    #[must_use]
+    pub fn diff(operation: impl Into<String>) -> Self {
+        Self::Diff {
+            operation: operation.into(),
+        }
+    }
+
+    /// Returns a compact target label for error and empty-output states.
+    #[must_use]
+    pub fn target_label(&self) -> String {
+        match self {
+            Self::Log => "operations".to_owned(),
+            Self::Show { operation } | Self::Diff { operation } => operation.clone(),
+        }
+    }
+}
+
+/// Loads rendered read-only `jj op ...` output.
+#[derive(Clone, Debug, Default)]
+pub struct JjOperation {
+    global_options: GlobalOptions,
+}
+
+impl JjOperation {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<std::path::PathBuf>) -> Self {
+        self.global_options = self.global_options.with_repository(repository);
+        self
+    }
+
+    /// Sets the global `jj` options used by generated operation specs.
+    #[must_use]
+    pub fn with_global_options(mut self, global_options: GlobalOptions) -> Self {
+        self.global_options = global_options;
+        self
+    }
+
+    /// Loads rendered operation output for `query`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query(
+        &self,
+        query: &OperationQuery,
+    ) -> Result<InspectionSnapshot, JjOperationError> {
+        self.load_query_with_runner(query, &mut SystemJjCommandRunner)
+    }
+
+    /// Loads rendered operation output for `query` using the provided command runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query_with_runner(
+        &self,
+        query: &OperationQuery,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<InspectionSnapshot, JjOperationError> {
+        let spec = self.spec_for(query);
+        let rendered = Self::run(runner, &spec)?;
+        Ok(InspectionSnapshot::new(query.target_label(), rendered).with_title(spec.title()))
+    }
+
+    /// Returns the command spec for `query`.
+    #[must_use]
+    pub fn spec_for(&self, query: &OperationQuery) -> JjCommandSpec {
+        let argv = match query {
+            OperationQuery::Log => vec![OP_COMMAND, LOG_COMMAND],
+            OperationQuery::Show { operation } => vec![OP_COMMAND, SHOW_COMMAND, operation],
+            OperationQuery::Diff { operation } => {
+                vec![OP_COMMAND, DIFF_COMMAND, "--operation", operation]
+            }
+        };
+
+        JjCommandSpec::render_read_only(argv).with_global_options(self.global_options.clone())
+    }
+
+    fn run(
+        runner: &mut impl JjCommandRunner,
+        spec: &JjCommandSpec,
+    ) -> Result<String, JjOperationError> {
+        let output = runner.run(spec)?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            Err(JjOperationError::CommandFailed(stderr))
+        }
+    }
+}
+
+/// Error returned while loading rendered `jj op ...` output.
+#[derive(Debug, Error)]
+pub enum JjOperationError {
+    /// The `jj` process could not be started or read.
+    #[error("failed to run jj op command: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// `jj op ...` exited unsuccessfully.
+    #[error("jj op command failed: {0}")]
+    CommandFailed(String),
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use std::io;
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::Output;
+
+    use jk_core::{
+        ConfigOverlay, ExecutionMode, OperationLoadPolicy, OutputPolicy, PagerPolicy, RefreshPlan,
+        SafetyClass,
+    };
+
+    use super::*;
+
+    fn strings(argv: impl IntoIterator<Item = std::ffi::OsString>) -> Vec<String> {
+        argv.into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn op_log_builds_read_only_render_spec() {
+        let spec = JjOperation::default().spec_for(&OperationQuery::log());
+
+        assert_eq!(strings(spec.argv().to_vec()), vec!["op", "log"]);
+        assert_eq!(spec.title(), "jj op log");
+        assert_eq!(spec.safety(), SafetyClass::ReadOnly);
+        assert_eq!(spec.mode(), ExecutionMode::RenderReadOnly);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::ReRunSpec);
+    }
+
+    #[test]
+    fn op_show_builds_read_only_render_spec() {
+        let spec = JjOperation::default().spec_for(&OperationQuery::show("abc123"));
+
+        assert_eq!(strings(spec.argv().to_vec()), vec!["op", "show", "abc123"]);
+        assert_eq!(spec.title(), "jj op show abc123");
+        assert_eq!(spec.safety(), SafetyClass::ReadOnly);
+        assert_eq!(spec.mode(), ExecutionMode::RenderReadOnly);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::ReRunSpec);
+    }
+
+    #[test]
+    fn op_diff_builds_read_only_render_spec() {
+        let spec = JjOperation::default().spec_for(&OperationQuery::diff("abc123"));
+
+        assert_eq!(
+            strings(spec.argv().to_vec()),
+            vec!["op", "diff", "--operation", "abc123"]
+        );
+        assert_eq!(spec.title(), "jj op diff --operation abc123");
+        assert_eq!(spec.safety(), SafetyClass::ReadOnly);
+        assert_eq!(spec.mode(), ExecutionMode::RenderReadOnly);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::ReRunSpec);
+    }
+
+    #[test]
+    fn global_options_render_before_operation_command_family() {
+        let global_options = GlobalOptions::default()
+            .with_output(OutputPolicy {
+                pager: PagerPolicy::Disable,
+                ..OutputPolicy::default()
+            })
+            .with_repository("/tmp/repo")
+            .with_operation(OperationLoadPolicy::AtOperation("root-op".to_owned()))
+            .with_config_overlay(ConfigOverlay::Inline {
+                name_value: "ui.color=always".to_owned(),
+            });
+        let spec = JjOperation::default()
+            .with_global_options(global_options)
+            .spec_for(&OperationQuery::diff("abc123"));
+
+        assert_eq!(
+            strings(spec.process_argv()),
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "--at-operation",
+                "root-op",
+                "--config",
+                "ui.color=always",
+                "op",
+                "diff",
+                "--operation",
+                "abc123",
+            ]
+        );
+    }
+
+    #[test]
+    fn load_query_runs_operation_spec_and_uses_rendered_output() {
+        let mut runner = FakeRunner::success("operation output\n", "");
+        let snapshot = JjOperation::default()
+            .load_query_with_runner(&OperationQuery::show("abc123"), &mut runner)
+            .expect("fake runner succeeds");
+
+        assert_eq!(snapshot.title(), "jj op show abc123");
+        assert_eq!(snapshot.target(), "abc123");
+        assert_eq!(snapshot.rendered(), "operation output\n");
+        assert_eq!(runner.argv, vec![vec!["op", "show", "abc123"]]);
+    }
+
+    #[test]
+    fn load_query_reports_failed_operation_command() {
+        let mut runner = FakeRunner::failure("not found\n");
+        let error = JjOperation::default()
+            .load_query_with_runner(&OperationQuery::diff("missing"), &mut runner)
+            .expect_err("fake runner fails");
+
+        assert!(matches!(
+            error,
+            JjOperationError::CommandFailed(message) if message == "not found"
+        ));
+    }
+
+    struct FakeRunner {
+        result: io::Result<Output>,
+        argv: Vec<Vec<String>>,
+    }
+
+    impl FakeRunner {
+        fn success(stdout: &str, stderr: &str) -> Self {
+            Self {
+                result: Ok(Output {
+                    status: exit_status(0),
+                    stdout: stdout.as_bytes().to_vec(),
+                    stderr: stderr.as_bytes().to_vec(),
+                }),
+                argv: Vec::new(),
+            }
+        }
+
+        fn failure(stderr: &str) -> Self {
+            Self {
+                result: Ok(Output {
+                    status: exit_status(1),
+                    stdout: Vec::new(),
+                    stderr: stderr.as_bytes().to_vec(),
+                }),
+                argv: Vec::new(),
+            }
+        }
+    }
+
+    impl JjCommandRunner for FakeRunner {
+        fn run(&mut self, spec: &JjCommandSpec) -> io::Result<Output> {
+            self.argv.push(strings(spec.argv().to_vec()));
+            std::mem::replace(
+                &mut self.result,
+                Err(io::Error::other("fake runner result already consumed")),
+            )
+        }
+    }
+
+    #[cfg(unix)]
+    fn exit_status(code: i32) -> std::process::ExitStatus {
+        std::process::ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(not(unix))]
+    fn exit_status(code: i32) -> std::process::ExitStatus {
+        std::process::Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+            .args(if cfg!(windows) {
+                vec!["/C".into(), format!("exit {code}").into()]
+            } else {
+                vec!["-c".into(), format!("exit {code}").into()]
+            })
+            .status()
+            .unwrap()
+    }
+}

--- a/crates/jk-cli/src/recovery.rs
+++ b/crates/jk-cli/src/recovery.rs
@@ -1,0 +1,115 @@
+//! Local operation recovery command specs.
+
+use jk_core::{GlobalOptions, JjCommandSpec, RefreshPlan, SafetyClass};
+
+const UNDO_COMMAND: &str = "undo";
+const REDO_COMMAND: &str = "redo";
+
+/// Local recovery command supported by the first undo/redo preview surface.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecoveryCommand {
+    /// Preview and run `jj undo`.
+    Undo,
+    /// Preview and run `jj redo`.
+    Redo,
+}
+
+impl RecoveryCommand {
+    const fn argv(self) -> [&'static str; 1] {
+        match self {
+            Self::Undo => [UNDO_COMMAND],
+            Self::Redo => [REDO_COMMAND],
+        }
+    }
+
+    const fn title(self) -> &'static str {
+        match self {
+            Self::Undo => "jj undo",
+            Self::Redo => "jj redo",
+        }
+    }
+}
+
+/// Builds previewable local recovery commands.
+#[derive(Clone, Debug, Default)]
+pub struct JjRecovery {
+    global_options: GlobalOptions,
+}
+
+impl JjRecovery {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<std::path::PathBuf>) -> Self {
+        self.global_options = self.global_options.with_repository(repository);
+        self
+    }
+
+    /// Returns the command spec for `command`.
+    #[must_use]
+    pub fn spec_for(&self, command: RecoveryCommand) -> JjCommandSpec {
+        JjCommandSpec::confirm_mutation(command.argv(), SafetyClass::LocalRewrite)
+            .with_global_options(self.global_options.clone())
+            .with_title(command.title())
+            .with_refresh_plan(RefreshPlan::None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use jk_core::{ExecutionMode, RefreshPlan};
+
+    use super::*;
+
+    fn strings(args: &[OsString]) -> Vec<String> {
+        args.iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn undo_builds_confirmed_local_rewrite_spec() {
+        let spec = JjRecovery::default().spec_for(RecoveryCommand::Undo);
+
+        assert_eq!(strings(spec.argv()), vec!["undo"]);
+        assert_eq!(spec.title(), "jj undo");
+        assert_eq!(spec.safety(), SafetyClass::LocalRewrite);
+        assert_eq!(spec.mode(), ExecutionMode::ConfirmMutation);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::None);
+    }
+
+    #[test]
+    fn redo_builds_confirmed_local_rewrite_spec() {
+        let spec = JjRecovery::default().spec_for(RecoveryCommand::Redo);
+
+        assert_eq!(strings(spec.argv()), vec!["redo"]);
+        assert_eq!(spec.title(), "jj redo");
+        assert_eq!(spec.safety(), SafetyClass::LocalRewrite);
+        assert_eq!(spec.mode(), ExecutionMode::ConfirmMutation);
+    }
+
+    #[test]
+    fn repository_renders_before_recovery_command() {
+        let spec = JjRecovery::default()
+            .with_repository("/tmp/repo")
+            .spec_for(RecoveryCommand::Undo);
+        let argv = spec
+            .process_argv()
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            argv,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "undo",
+            ]
+        );
+    }
+}

--- a/crates/jk-cli/src/show.rs
+++ b/crates/jk-cli/src/show.rs
@@ -1,0 +1,169 @@
+//! `jj show` command integration.
+
+use std::path::PathBuf;
+
+use jk_core::{InspectionSnapshot, JjCommandSpec};
+use thiserror::Error;
+
+use crate::command::{JjCommandRunner, SystemJjCommandRunner};
+
+const SHOW_COMMAND: &str = "show";
+
+/// Canonical query shape supported by `jk show`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ShowQuery {
+    revs: Vec<String>,
+}
+
+impl ShowQuery {
+    /// Creates a `jj show` query for one or more revisions.
+    #[must_use]
+    pub const fn new(revs: Vec<String>) -> Self {
+        Self { revs }
+    }
+
+    /// Returns the revisions passed to `jj show`.
+    #[must_use]
+    pub fn revs(&self) -> &[String] {
+        &self.revs
+    }
+
+    /// Returns a compact target label for error and empty-output states.
+    #[must_use]
+    pub fn target_label(&self) -> String {
+        if self.revs.is_empty() {
+            "@".to_owned()
+        } else {
+            self.revs.join(" ")
+        }
+    }
+}
+
+impl From<String> for ShowQuery {
+    fn from(rev: String) -> Self {
+        Self::new(vec![rev])
+    }
+}
+
+/// Loads rendered `jj show` output.
+#[derive(Clone, Debug, Default)]
+pub struct JjShow {
+    repository: Option<PathBuf>,
+}
+
+impl JjShow {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<PathBuf>) -> Self {
+        self.repository = Some(repository.into());
+        self
+    }
+
+    /// Loads the rendered show output for `query`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query(&self, query: &ShowQuery) -> Result<InspectionSnapshot, JjShowError> {
+        self.load_query_with_runner(query, &mut SystemJjCommandRunner)
+    }
+
+    /// Loads the rendered show output for `query` using the provided command runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query_with_runner(
+        &self,
+        query: &ShowQuery,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<InspectionSnapshot, JjShowError> {
+        let spec = self.spec_for(query);
+        let rendered = Self::run(runner, &spec)?;
+        Ok(InspectionSnapshot::new(query.target_label(), rendered).with_title(spec.title()))
+    }
+
+    /// Returns the command spec for `query`.
+    #[must_use]
+    pub fn spec_for(&self, query: &ShowQuery) -> JjCommandSpec {
+        let mut argv = Vec::with_capacity(query.revs().len() + 1);
+        argv.push(SHOW_COMMAND);
+        argv.extend(query.revs().iter().map(String::as_str));
+
+        let spec = JjCommandSpec::render_read_only(argv);
+        if let Some(repository) = &self.repository {
+            spec.with_repository(repository)
+        } else {
+            spec
+        }
+    }
+
+    fn run(runner: &mut impl JjCommandRunner, spec: &JjCommandSpec) -> Result<String, JjShowError> {
+        let output = runner.run(spec)?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            Err(JjShowError::CommandFailed(stderr))
+        }
+    }
+}
+
+/// Error returned while loading rendered `jj show` output.
+#[derive(Debug, Error)]
+pub enum JjShowError {
+    /// The `jj` process could not be started or read.
+    #[error("failed to run jj show: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// `jj show` exited unsuccessfully.
+    #[error("jj show failed: {0}")]
+    CommandFailed(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::build_jj_command;
+
+    #[test]
+    fn spec_uses_jj_show_with_revisions() {
+        let spec = JjShow::default().spec_for(&ShowQuery::new(vec![
+            "abc123".to_owned(),
+            "def456".to_owned(),
+        ]));
+
+        assert_eq!(
+            spec.argv()
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["show", "abc123", "def456"]
+        );
+        assert_eq!(spec.title(), "jj show abc123 def456");
+    }
+
+    #[test]
+    fn command_renders_repository_before_show() {
+        let source = JjShow::default().with_repository("/tmp/repo");
+        let spec = source.spec_for(&ShowQuery::new(vec!["abc123".to_owned()]));
+        let command = build_jj_command(&spec);
+
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "show",
+                "abc123"
+            ]
+        );
+    }
+}

--- a/crates/jk-cli/src/status.rs
+++ b/crates/jk-cli/src/status.rs
@@ -1,0 +1,166 @@
+//! `jj status` command integration.
+
+use std::path::PathBuf;
+
+use jk_core::{InspectionSnapshot, JjCommandSpec};
+use thiserror::Error;
+
+use crate::command::{JjCommandRunner, SystemJjCommandRunner};
+
+const STATUS_COMMAND: &str = "status";
+
+/// Canonical query shape supported by `jk status`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StatusQuery {
+    filesets: Vec<String>,
+}
+
+impl StatusQuery {
+    /// Creates a `jj status` query with optional filesets.
+    #[must_use]
+    pub const fn new(filesets: Vec<String>) -> Self {
+        Self { filesets }
+    }
+
+    /// Returns the filesets passed to `jj status`.
+    #[must_use]
+    pub fn filesets(&self) -> &[String] {
+        &self.filesets
+    }
+
+    /// Returns a compact target label for error and empty-output states.
+    #[must_use]
+    pub fn target_label(&self) -> String {
+        if self.filesets.is_empty() {
+            "repository".to_owned()
+        } else {
+            self.filesets.join(" ")
+        }
+    }
+}
+
+/// Loads rendered `jj status` output.
+#[derive(Clone, Debug, Default)]
+pub struct JjStatus {
+    repository: Option<PathBuf>,
+}
+
+impl JjStatus {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<PathBuf>) -> Self {
+        self.repository = Some(repository.into());
+        self
+    }
+
+    /// Loads the rendered status output for `query`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query(&self, query: &StatusQuery) -> Result<InspectionSnapshot, JjStatusError> {
+        self.load_query_with_runner(query, &mut SystemJjCommandRunner)
+    }
+
+    /// Loads the rendered status output for `query` using the provided command runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_query_with_runner(
+        &self,
+        query: &StatusQuery,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<InspectionSnapshot, JjStatusError> {
+        let spec = self.spec_for(query);
+        let rendered = Self::run(runner, &spec)?;
+        Ok(InspectionSnapshot::new(query.target_label(), rendered).with_title(spec.title()))
+    }
+
+    /// Returns the command spec for `query`.
+    #[must_use]
+    pub fn spec_for(&self, query: &StatusQuery) -> JjCommandSpec {
+        let mut argv = Vec::with_capacity(query.filesets().len() + 1);
+        argv.push(STATUS_COMMAND);
+        argv.extend(query.filesets().iter().map(String::as_str));
+
+        let spec = JjCommandSpec::render_read_only(argv);
+        if let Some(repository) = &self.repository {
+            spec.with_repository(repository)
+        } else {
+            spec
+        }
+    }
+
+    fn run(
+        runner: &mut impl JjCommandRunner,
+        spec: &JjCommandSpec,
+    ) -> Result<String, JjStatusError> {
+        let output = runner.run(spec)?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            Err(JjStatusError::CommandFailed(stderr))
+        }
+    }
+}
+
+/// Error returned while loading rendered `jj status` output.
+#[derive(Debug, Error)]
+pub enum JjStatusError {
+    /// The `jj` process could not be started or read.
+    #[error("failed to run jj status: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// `jj status` exited unsuccessfully.
+    #[error("jj status failed: {0}")]
+    CommandFailed(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::build_jj_command;
+
+    #[test]
+    fn spec_uses_jj_status_with_filesets() {
+        let spec = JjStatus::default().spec_for(&StatusQuery::new(vec![
+            "crates/jk".to_owned(),
+            "docs".to_owned(),
+        ]));
+
+        assert_eq!(
+            spec.argv()
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["status", "crates/jk", "docs"]
+        );
+        assert_eq!(spec.title(), "jj status crates/jk docs");
+    }
+
+    #[test]
+    fn command_renders_repository_before_status() {
+        let source = JjStatus::default().with_repository("/tmp/repo");
+        let spec = source.spec_for(&StatusQuery::new(vec!["src".to_owned()]));
+        let command = build_jj_command(&spec);
+
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "status",
+                "src"
+            ]
+        );
+    }
+}

--- a/crates/jk-cli/src/workspaces.rs
+++ b/crates/jk-cli/src/workspaces.rs
@@ -1,0 +1,743 @@
+//! `jj workspace list` command integration.
+
+use std::path::{Path, PathBuf};
+
+use jk_core::{
+    ColorPolicy, ExecutionMode, GlobalOptions, InspectionSnapshot, JjCommandSpec, OutputPolicy,
+    RefreshPlan, SafetyClass,
+};
+use thiserror::Error;
+
+use crate::command::{JjCommandRunner, SystemJjCommandRunner};
+
+const WORKSPACE_LIST_TEMPLATE: &str = r#"name ++ "\t" ++ root ++ "\t" ++ target.change_id().short() ++ "\t" ++ target.commit_id().short() ++ "\n""#;
+
+/// A parsed snapshot of known `jj` workspaces.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceListSnapshot {
+    /// Parsed workspace rows.
+    pub workspaces: Vec<WorkspaceSummary>,
+    /// Display title for the command that produced the snapshot.
+    pub title: String,
+}
+
+/// One workspace row from `jj workspace list`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceSummary {
+    /// Workspace name.
+    pub name: String,
+    /// Workspace root reported by `jj`, when present.
+    pub root: Option<PathBuf>,
+    /// Whether this row matches the configured repository path.
+    pub current: bool,
+    /// Short target change id.
+    pub change_id: Option<String>,
+    /// Short target commit id.
+    pub commit_id: Option<String>,
+}
+
+/// Output from a selected-workspace stale metadata update.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceUpdateStaleOutcome {
+    /// Display title for the command that ran.
+    pub title: String,
+    /// Trimmed stdout emitted by `jj`.
+    pub stdout: String,
+    /// Trimmed stderr emitted by `jj`.
+    pub stderr: String,
+}
+
+/// Query for rendering an inspection command in a selected workspace.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceInspectionQuery {
+    workspace_root: PathBuf,
+}
+
+impl WorkspaceInspectionQuery {
+    /// Creates a selected-workspace query.
+    #[must_use]
+    pub fn new(workspace_root: impl Into<PathBuf>) -> Self {
+        Self {
+            workspace_root: workspace_root.into(),
+        }
+    }
+
+    /// Returns the workspace root passed to `jj --repository`.
+    #[must_use]
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+
+    /// Returns a compact target label for error and empty-output states.
+    #[must_use]
+    pub fn target_label(&self) -> String {
+        self.workspace_root.display().to_string()
+    }
+}
+
+/// Selected-workspace inspection command that failed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceInspectionCommand {
+    /// `jj log`.
+    Log,
+    /// `jj status`.
+    Status,
+    /// `jj diff`.
+    Diff,
+}
+
+impl std::fmt::Display for WorkspaceInspectionCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Log => f.write_str("jj log"),
+            Self::Status => f.write_str("jj status"),
+            Self::Diff => f.write_str("jj diff"),
+        }
+    }
+}
+
+/// Loads workspace data from `jj`.
+#[derive(Clone, Debug, Default)]
+pub struct JjWorkspaces {
+    repository: Option<PathBuf>,
+}
+
+impl JjWorkspaces {
+    /// Sets the repository path passed to `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<PathBuf>) -> Self {
+        self.repository = Some(normalized_path(&repository.into()));
+        self
+    }
+
+    /// Loads and parses the workspace list.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed, exits unsuccessfully, or returns malformed
+    /// machine output.
+    pub fn load_list(&self) -> Result<WorkspaceListSnapshot, JjWorkspacesError> {
+        self.load_list_with_runner(&mut SystemJjCommandRunner)
+    }
+
+    /// Loads and parses the workspace list using the provided command runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed, exits unsuccessfully, or returns malformed
+    /// machine output.
+    pub fn load_list_with_runner(
+        &self,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<WorkspaceListSnapshot, JjWorkspacesError> {
+        let spec = self.list_spec();
+        let output = runner.run(&spec)?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            return Err(JjWorkspacesError::CommandFailed(stderr));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let current_root = self
+            .load_current_root_with_runner(runner)
+            .ok()
+            .or_else(|| self.repository.clone());
+        let workspaces = parse_workspace_list(&stdout, current_root.as_deref())?;
+        Ok(WorkspaceListSnapshot {
+            workspaces,
+            title: spec.title().to_owned(),
+        })
+    }
+
+    /// Loads rendered `jj status` output scoped to a selected workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_status(
+        &self,
+        query: &WorkspaceInspectionQuery,
+    ) -> Result<InspectionSnapshot, JjWorkspacesError> {
+        self.load_status_with_runner(query, &mut SystemJjCommandRunner)
+    }
+
+    /// Loads rendered `jj log` output scoped to a selected workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_log(
+        &self,
+        query: &WorkspaceInspectionQuery,
+    ) -> Result<InspectionSnapshot, JjWorkspacesError> {
+        self.load_log_with_runner(query, &mut SystemJjCommandRunner)
+    }
+
+    /// Loads rendered `jj log` output scoped to a selected workspace using the provided runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_log_with_runner(
+        &self,
+        query: &WorkspaceInspectionQuery,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<InspectionSnapshot, JjWorkspacesError> {
+        let spec = self.log_spec(query);
+        let rendered = Self::run_inspection(runner, &spec, WorkspaceInspectionCommand::Log)?;
+        Ok(InspectionSnapshot::new(query.target_label(), rendered).with_title(spec.title()))
+    }
+
+    /// Loads rendered `jj status` output scoped to a selected workspace using the provided runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_status_with_runner(
+        &self,
+        query: &WorkspaceInspectionQuery,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<InspectionSnapshot, JjWorkspacesError> {
+        let spec = self.status_spec(query);
+        let rendered = Self::run_inspection(runner, &spec, WorkspaceInspectionCommand::Status)?;
+        Ok(InspectionSnapshot::new(query.target_label(), rendered).with_title(spec.title()))
+    }
+
+    /// Loads rendered `jj diff` output scoped to a selected workspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_diff(
+        &self,
+        query: &WorkspaceInspectionQuery,
+    ) -> Result<InspectionSnapshot, JjWorkspacesError> {
+        self.load_diff_with_runner(query, &mut SystemJjCommandRunner)
+    }
+
+    /// Loads rendered `jj diff` output scoped to a selected workspace using the provided runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn load_diff_with_runner(
+        &self,
+        query: &WorkspaceInspectionQuery,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<InspectionSnapshot, JjWorkspacesError> {
+        let spec = self.diff_spec(query);
+        let rendered = Self::run_inspection(runner, &spec, WorkspaceInspectionCommand::Diff)?;
+        Ok(InspectionSnapshot::new(query.target_label(), rendered).with_title(spec.title()))
+    }
+
+    /// Runs `jj workspace update-stale` scoped to a selected workspace root.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn update_stale(
+        &self,
+        query: &WorkspaceInspectionQuery,
+    ) -> Result<WorkspaceUpdateStaleOutcome, JjWorkspacesError> {
+        self.update_stale_with_runner(query, &mut SystemJjCommandRunner)
+    }
+
+    /// Runs `jj workspace update-stale` scoped to a selected workspace root using the runner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `jj` cannot be executed or exits unsuccessfully.
+    pub fn update_stale_with_runner(
+        &self,
+        query: &WorkspaceInspectionQuery,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<WorkspaceUpdateStaleOutcome, JjWorkspacesError> {
+        let spec = self.update_stale_spec(query);
+        let output = runner.run(&spec)?;
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        if output.status.success() {
+            Ok(WorkspaceUpdateStaleOutcome {
+                title: spec.title().to_owned(),
+                stdout,
+                stderr,
+            })
+        } else {
+            Err(JjWorkspacesError::UpdateStaleCommandFailed {
+                command: spec.title().to_owned(),
+                stderr,
+                stdout,
+                status: output.status.to_string(),
+            })
+        }
+    }
+
+    /// Returns the `jj workspace list` command spec.
+    #[must_use]
+    pub fn list_spec(&self) -> JjCommandSpec {
+        let output = OutputPolicy {
+            color: ColorPolicy::Never,
+            ..OutputPolicy::default()
+        };
+        let spec = JjCommandSpec::render_read_only([
+            "workspace",
+            "list",
+            "--template",
+            WORKSPACE_LIST_TEMPLATE,
+        ])
+        .with_global_options(GlobalOptions::default().with_output(output))
+        .with_title("jj workspace list");
+        self.with_repository_if_configured(spec)
+    }
+
+    /// Returns the `jj status` command spec scoped to `query`.
+    #[must_use]
+    pub fn status_spec(&self, query: &WorkspaceInspectionQuery) -> JjCommandSpec {
+        let title = format!("jj -R {} status", query.workspace_root().display());
+        JjCommandSpec::render_read_only(["status"])
+            .with_repository(query.workspace_root())
+            .with_title(title)
+    }
+
+    /// Returns the `jj log` command spec scoped to `query`.
+    #[must_use]
+    pub fn log_spec(&self, query: &WorkspaceInspectionQuery) -> JjCommandSpec {
+        let title = format!("jj -R {} log", query.workspace_root().display());
+        JjCommandSpec::render_read_only(["log"])
+            .with_repository(query.workspace_root())
+            .with_title(title)
+    }
+
+    /// Returns the `jj diff` command spec scoped to `query`.
+    #[must_use]
+    pub fn diff_spec(&self, query: &WorkspaceInspectionQuery) -> JjCommandSpec {
+        let title = format!("jj -R {} diff", query.workspace_root().display());
+        JjCommandSpec::render_read_only(["diff"])
+            .with_repository(query.workspace_root())
+            .with_title(title)
+    }
+
+    /// Returns the `jj workspace update-stale` command spec scoped to `query`.
+    #[must_use]
+    pub fn update_stale_spec(&self, query: &WorkspaceInspectionQuery) -> JjCommandSpec {
+        let output = OutputPolicy {
+            color: ColorPolicy::Never,
+            ..OutputPolicy::default()
+        };
+        let title = format!(
+            "jj -R {} workspace update-stale",
+            query.workspace_root().display()
+        );
+        JjCommandSpec::render_read_only(["workspace", "update-stale"])
+            .with_global_options(GlobalOptions::default().with_output(output))
+            .with_repository(query.workspace_root())
+            .with_title(title)
+            .with_mode(ExecutionMode::ConfirmMutation)
+            .with_safety(SafetyClass::LocalMetadata)
+            .with_refresh_plan(RefreshPlan::None)
+    }
+
+    /// Returns the `jj root` command spec used for current-workspace selection.
+    #[must_use]
+    pub fn root_spec(&self) -> JjCommandSpec {
+        let output = OutputPolicy {
+            color: ColorPolicy::Never,
+            ..OutputPolicy::default()
+        };
+        let spec = JjCommandSpec::render_read_only(["root"])
+            .with_global_options(GlobalOptions::default().with_output(output))
+            .with_title("jj root");
+        self.with_repository_if_configured(spec)
+    }
+
+    fn with_repository_if_configured(&self, spec: JjCommandSpec) -> JjCommandSpec {
+        if let Some(repository) = &self.repository {
+            spec.with_repository(repository)
+        } else {
+            spec
+        }
+    }
+
+    fn run_inspection(
+        runner: &mut impl JjCommandRunner,
+        spec: &JjCommandSpec,
+        command: WorkspaceInspectionCommand,
+    ) -> Result<String, JjWorkspacesError> {
+        let output = runner.run(spec)?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            Err(JjWorkspacesError::InspectionCommandFailed { command, stderr })
+        }
+    }
+
+    fn load_current_root_with_runner(
+        &self,
+        runner: &mut impl JjCommandRunner,
+    ) -> Result<PathBuf, JjWorkspacesError> {
+        let output = runner.run(&self.root_spec())?;
+        if output.status.success() {
+            let root = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+            Ok(normalized_path(Path::new(&root)))
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            Err(JjWorkspacesError::CommandFailed(stderr))
+        }
+    }
+}
+
+/// Error returned while loading workspace data from `jj`.
+#[derive(Debug, Error)]
+pub enum JjWorkspacesError {
+    /// The `jj` process could not be started or read.
+    #[error("failed to run jj workspace command: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// `jj workspace list` exited unsuccessfully.
+    #[error("jj workspace list failed: {0}")]
+    CommandFailed(String),
+
+    /// Selected-workspace inspection exited unsuccessfully.
+    #[error("{command} failed: {stderr}")]
+    InspectionCommandFailed {
+        /// The failed `jj` command.
+        command: WorkspaceInspectionCommand,
+        /// Trimmed stderr from `jj`.
+        stderr: String,
+    },
+
+    /// Selected-workspace stale metadata update exited unsuccessfully.
+    #[error("{command} failed: {}", command_error_summary(stderr, stdout, status))]
+    UpdateStaleCommandFailed {
+        /// Display title for the failed command.
+        command: String,
+        /// Trimmed stderr from `jj`.
+        stderr: String,
+        /// Trimmed stdout from `jj`.
+        stdout: String,
+        /// Process exit status.
+        status: String,
+    },
+
+    /// `jj workspace list` returned output that did not match the machine template.
+    #[error("failed to parse jj workspace list output: {0}")]
+    Parse(#[from] WorkspaceListParseError),
+}
+
+/// Error returned when machine-formatted workspace rows are malformed.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error("line {line}: expected 4 tab-separated fields, got {field_count} in {record:?}")]
+pub struct WorkspaceListParseError {
+    line: usize,
+    field_count: usize,
+    record: String,
+}
+
+fn parse_workspace_list(
+    stdout: &str,
+    repository: Option<&Path>,
+) -> Result<Vec<WorkspaceSummary>, WorkspaceListParseError> {
+    let current_repository = repository.map(normalized_path);
+    let mut workspaces = Vec::new();
+
+    for (index, record) in stdout.lines().enumerate() {
+        if record.is_empty() {
+            continue;
+        }
+
+        let fields = record.split('\t').collect::<Vec<_>>();
+        if fields.len() != 4 || fields[0].is_empty() {
+            return Err(WorkspaceListParseError {
+                line: index + 1,
+                field_count: fields.len(),
+                record: record.to_owned(),
+            });
+        }
+
+        let root = optional_path(fields[1]);
+        let current = root
+            .as_deref()
+            .zip(current_repository.as_deref())
+            .is_some_and(|(root, repository)| normalized_path(root) == repository);
+
+        workspaces.push(WorkspaceSummary {
+            name: fields[0].to_owned(),
+            root,
+            current,
+            change_id: optional_string(fields[2]),
+            commit_id: optional_string(fields[3]),
+        });
+    }
+
+    Ok(workspaces)
+}
+
+fn optional_path(value: &str) -> Option<PathBuf> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(value))
+    }
+}
+
+fn optional_string(value: &str) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_owned())
+    }
+}
+
+fn normalized_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn command_error_summary(stderr: &str, stdout: &str, status: &str) -> String {
+    if !stderr.is_empty() {
+        stderr.to_owned()
+    } else if !stdout.is_empty() {
+        stdout.to_owned()
+    } else {
+        status.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use super::*;
+    use crate::command::build_jj_command;
+
+    fn strings(args: &[std::ffi::OsString]) -> Vec<String> {
+        args.iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn list_spec_uses_machine_template_and_repository() {
+        let source = JjWorkspaces::default().with_repository("/tmp/repo");
+        let spec = source.list_spec();
+
+        assert_eq!(
+            strings(spec.argv()),
+            vec!["workspace", "list", "--template", WORKSPACE_LIST_TEMPLATE]
+        );
+        assert_eq!(spec.repository(), Some(Path::new("/tmp/repo")));
+        assert_eq!(
+            strings(&spec.process_argv()),
+            vec![
+                "--no-pager",
+                "--color",
+                "never",
+                "--repository",
+                "/tmp/repo",
+                "workspace",
+                "list",
+                "--template",
+                WORKSPACE_LIST_TEMPLATE
+            ]
+        );
+    }
+
+    #[test]
+    fn list_spec_canonicalizes_relative_repository() {
+        let source = JjWorkspaces::default().with_repository(".");
+        let spec = source.list_spec();
+        let current_dir = std::env::current_dir().expect("current directory should exist");
+
+        assert_eq!(spec.repository(), Some(current_dir.as_path()));
+    }
+
+    #[test]
+    fn list_spec_without_repository_uses_cwd_discovery() {
+        let spec = JjWorkspaces::default().list_spec();
+
+        assert_eq!(spec.repository(), None);
+        assert_eq!(
+            strings(&spec.process_argv()),
+            vec![
+                "--no-pager",
+                "--color",
+                "never",
+                "workspace",
+                "list",
+                "--template",
+                WORKSPACE_LIST_TEMPLATE
+            ]
+        );
+    }
+
+    #[test]
+    fn root_spec_uses_plain_jj_root_for_current_selection() {
+        let spec = JjWorkspaces::default().root_spec();
+
+        assert_eq!(
+            strings(&spec.process_argv()),
+            vec!["--no-pager", "--color", "never", "root"]
+        );
+    }
+
+    #[test]
+    fn log_status_and_diff_specs_render_repository_before_command() {
+        let query = WorkspaceInspectionQuery::new("/tmp/workspace");
+
+        let log = build_jj_command(&JjWorkspaces::default().log_spec(&query));
+        let log_args = log
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            log_args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/workspace",
+                "log"
+            ]
+        );
+
+        let status = build_jj_command(&JjWorkspaces::default().status_spec(&query));
+        let status_args = status
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            status_args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/workspace",
+                "status"
+            ]
+        );
+
+        let diff = build_jj_command(&JjWorkspaces::default().diff_spec(&query));
+        let diff_args = diff
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            diff_args,
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/workspace",
+                "diff"
+            ]
+        );
+    }
+
+    #[test]
+    fn update_stale_spec_scopes_command_to_selected_workspace() {
+        use jk_core::{ExecutionMode, SafetyClass};
+
+        let query = WorkspaceInspectionQuery::new("/tmp/workspace");
+        let spec = JjWorkspaces::default().update_stale_spec(&query);
+        let command = build_jj_command(&spec);
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            vec![
+                "--no-pager",
+                "--color",
+                "never",
+                "--repository",
+                "/tmp/workspace",
+                "workspace",
+                "update-stale"
+            ]
+        );
+        assert_eq!(spec.title(), "jj -R /tmp/workspace workspace update-stale");
+        assert_eq!(spec.repository(), Some(Path::new("/tmp/workspace")));
+        assert_eq!(spec.mode(), ExecutionMode::ConfirmMutation);
+        assert_eq!(spec.safety(), SafetyClass::LocalMetadata);
+    }
+
+    #[test]
+    fn parser_handles_multiple_rows_and_optional_fields() {
+        let stdout = concat!(
+            "default\t/tmp/repo\tabc123\tdef456\n",
+            "scratch\t\tfedcba\t\n",
+            "empty-target\t/tmp/other\t\t\n",
+        );
+
+        let workspaces = parse_workspace_list(stdout, None).expect("rows should parse");
+
+        assert_eq!(
+            workspaces,
+            vec![
+                WorkspaceSummary {
+                    name: "default".to_owned(),
+                    root: Some(PathBuf::from("/tmp/repo")),
+                    current: false,
+                    change_id: Some("abc123".to_owned()),
+                    commit_id: Some("def456".to_owned()),
+                },
+                WorkspaceSummary {
+                    name: "scratch".to_owned(),
+                    root: None,
+                    current: false,
+                    change_id: Some("fedcba".to_owned()),
+                    commit_id: None,
+                },
+                WorkspaceSummary {
+                    name: "empty-target".to_owned(),
+                    root: Some(PathBuf::from("/tmp/other")),
+                    current: false,
+                    change_id: None,
+                    commit_id: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parser_marks_current_workspace_by_repository_root() {
+        let stdout = format!(
+            "default\t{}\tabc123\tdef456\nother\t/tmp/other\tfedcba\t654321\n",
+            std::env::current_dir()
+                .expect("current directory should exist")
+                .display()
+        );
+        let current_dir = std::env::current_dir().expect("current directory should exist");
+
+        let workspaces =
+            parse_workspace_list(&stdout, Some(&current_dir)).expect("rows should parse");
+
+        assert!(workspaces[0].current);
+        assert!(!workspaces[1].current);
+    }
+
+    #[test]
+    fn parser_reports_malformed_records() {
+        let error = parse_workspace_list("default\t/tmp/repo\tabc123\n", None)
+            .expect_err("missing commit id should fail");
+
+        assert_eq!(
+            error,
+            WorkspaceListParseError {
+                line: 1,
+                field_count: 3,
+                record: "default\t/tmp/repo\tabc123".to_owned(),
+            }
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("line 1: expected 4 tab-separated fields")
+        );
+    }
+}

--- a/crates/jk-core/src/command.rs
+++ b/crates/jk-core/src/command.rs
@@ -1,0 +1,957 @@
+//! Command descriptions shared across `jk` crates.
+//!
+//! [`JjCommandSpec`] stores argv as data first, then renders a display-only preview string for
+//! titles, help, and future command previews. Callers must execute the argv directly instead of
+//! sending the preview string through a shell.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+use crate::command_history::redaction::redact_argv;
+
+/// A typed description of one `jj` command.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JjCommandSpec {
+    argv: Vec<OsString>,
+    global_options: GlobalOptions,
+    cwd: Option<PathBuf>,
+    stdin: Option<String>,
+    title: String,
+    mode: ExecutionMode,
+    safety: SafetyClass,
+    refresh_plan: RefreshPlan,
+}
+
+impl JjCommandSpec {
+    /// Creates a read-only `jj` command spec from command arguments after the `jj` binary.
+    #[must_use]
+    pub fn render_read_only(argv: impl IntoIterator<Item = impl Into<OsString>>) -> Self {
+        let argv = argv.into_iter().map(Into::into).collect::<Vec<_>>();
+        let title = preview_argv(&argv);
+        Self {
+            argv,
+            global_options: GlobalOptions::default(),
+            cwd: None,
+            stdin: None,
+            title,
+            mode: ExecutionMode::RenderReadOnly,
+            safety: SafetyClass::ReadOnly,
+            refresh_plan: RefreshPlan::ReRunSpec,
+        }
+    }
+
+    /// Creates a `jj` command spec that must be previewed before mutation execution.
+    #[must_use]
+    pub fn confirm_mutation(
+        argv: impl IntoIterator<Item = impl Into<OsString>>,
+        safety: SafetyClass,
+    ) -> Self {
+        Self::render_read_only(argv)
+            .with_mode(ExecutionMode::ConfirmMutation)
+            .with_safety(safety)
+    }
+
+    /// Sets the process working directory metadata.
+    #[must_use]
+    pub fn with_cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    /// Sets the repository path metadata.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<PathBuf>) -> Self {
+        self.global_options.repository = Some(repository.into());
+        self
+    }
+
+    /// Sets the global `jj` options.
+    #[must_use]
+    pub fn with_global_options(mut self, global_options: GlobalOptions) -> Self {
+        self.global_options = global_options;
+        self
+    }
+
+    /// Sets stdin text for a future command runner.
+    #[must_use]
+    pub fn with_stdin(mut self, stdin: impl Into<String>) -> Self {
+        self.stdin = Some(stdin.into());
+        self
+    }
+
+    /// Sets the display title independently from the executable argv.
+    #[must_use]
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Sets the execution mode.
+    #[must_use]
+    pub const fn with_mode(mut self, mode: ExecutionMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Sets the safety class.
+    #[must_use]
+    pub const fn with_safety(mut self, safety: SafetyClass) -> Self {
+        self.safety = safety;
+        self
+    }
+
+    /// Sets the refresh plan.
+    #[must_use]
+    pub const fn with_refresh_plan(mut self, refresh_plan: RefreshPlan) -> Self {
+        self.refresh_plan = refresh_plan;
+        self
+    }
+
+    /// Returns command arguments after the `jj` binary.
+    #[must_use]
+    pub fn argv(&self) -> &[OsString] {
+        &self.argv
+    }
+
+    /// Returns global `jj` options owned by the spec.
+    #[must_use]
+    pub const fn global_options(&self) -> &GlobalOptions {
+        &self.global_options
+    }
+
+    /// Returns global `jj` arguments rendered before the command family.
+    #[must_use]
+    pub fn global_argv(&self) -> Vec<OsString> {
+        self.global_options.argv()
+    }
+
+    /// Returns process arguments after the `jj` binary.
+    #[must_use]
+    pub fn process_argv(&self) -> Vec<OsString> {
+        let mut argv = self.global_argv();
+        argv.extend(self.argv.iter().cloned());
+        argv
+    }
+
+    /// Returns the process working directory metadata.
+    #[must_use]
+    pub fn cwd(&self) -> Option<&Path> {
+        self.cwd.as_deref()
+    }
+
+    /// Returns the repository path metadata.
+    #[must_use]
+    pub fn repository(&self) -> Option<&Path> {
+        self.global_options.repository()
+    }
+
+    /// Returns stdin text for a future command runner.
+    #[must_use]
+    pub fn stdin(&self) -> Option<&str> {
+        self.stdin.as_deref()
+    }
+
+    /// Returns the display title.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns a display-only command preview.
+    #[must_use]
+    pub fn preview(&self) -> String {
+        preview_argv(&self.argv)
+    }
+
+    /// Returns a display-only process preview with global options before command arguments.
+    #[must_use]
+    pub fn process_preview(&self) -> String {
+        preview_argv(&self.process_argv())
+    }
+
+    /// Returns a command preview suitable for confirmation UI.
+    #[must_use]
+    pub fn command_preview(&self) -> CommandPreview {
+        CommandPreview::from_spec(self)
+    }
+
+    /// Returns the execution mode.
+    #[must_use]
+    pub const fn mode(&self) -> ExecutionMode {
+        self.mode
+    }
+
+    /// Returns the safety class.
+    #[must_use]
+    pub const fn safety(&self) -> SafetyClass {
+        self.safety
+    }
+
+    /// Returns the refresh plan.
+    #[must_use]
+    pub const fn refresh_plan(&self) -> RefreshPlan {
+        self.refresh_plan
+    }
+}
+
+/// Command data shown before a command is allowed to run.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandPreview {
+    /// The executable spec that confirmation should run.
+    pub spec: JjCommandSpec,
+    /// Short command title used by the source view.
+    pub title: String,
+    /// Full `jj` command line, including global options in process order.
+    pub command_line: String,
+    /// Execution mode that determines the confirmation behavior.
+    pub execution_mode: ExecutionMode,
+    /// Safety classification shown to the user.
+    pub safety: SafetyClass,
+    /// Refresh policy requested after a successful command.
+    pub refresh_plan: RefreshPlan,
+    /// User-visible warnings inferred from the command spec.
+    pub warnings: Vec<CommandPreviewWarning>,
+}
+
+impl CommandPreview {
+    /// Builds a preview from the same command spec that execution will receive.
+    #[must_use]
+    pub fn from_spec(spec: &JjCommandSpec) -> Self {
+        Self {
+            spec: spec.clone(),
+            title: spec.title().to_owned(),
+            command_line: preview_argv(&redact_argv(spec.process_argv())),
+            execution_mode: spec.mode(),
+            safety: spec.safety(),
+            refresh_plan: spec.refresh_plan(),
+            warnings: CommandPreviewWarning::from_spec(spec),
+        }
+    }
+
+    /// Returns whether the preview represents a command that needs confirmation.
+    #[must_use]
+    pub const fn requires_confirmation(&self) -> bool {
+        matches!(
+            self.execution_mode,
+            ExecutionMode::ConfirmMutation
+                | ExecutionMode::ConfirmExternalTool
+                | ExecutionMode::DryRunThenConfirm
+        )
+    }
+}
+
+/// Warning shown beside a command preview when flags or safety class deserve attention.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum CommandPreviewWarning {
+    /// The command changes repository-local metadata.
+    LocalMetadata,
+    /// The command rewrites local history.
+    LocalRewrite,
+    /// The command is destructive in the local repository.
+    DestructiveLocal,
+    /// The command writes to a network service or remote.
+    NetworkWrite,
+    /// The command launches an external tool.
+    ExternalCommand,
+    /// The command ignores the current working-copy snapshot.
+    IgnoresWorkingCopy,
+    /// The command inspects or operates at a specific operation.
+    AtOperation(String),
+    /// The command creates an operation but does not integrate it.
+    DoesNotIntegrateOperation,
+    /// The command may rewrite immutable commits.
+    IgnoresImmutableCommits,
+}
+
+impl CommandPreviewWarning {
+    fn from_spec(spec: &JjCommandSpec) -> Vec<Self> {
+        let mut warnings = Vec::new();
+        match spec.safety() {
+            SafetyClass::ReadOnly | SafetyClass::NetworkRead => {}
+            SafetyClass::LocalMetadata => warnings.push(Self::LocalMetadata),
+            SafetyClass::LocalRewrite => warnings.push(Self::LocalRewrite),
+            SafetyClass::DestructiveLocal => warnings.push(Self::DestructiveLocal),
+            SafetyClass::NetworkWrite => warnings.push(Self::NetworkWrite),
+            SafetyClass::ExternalCommand => warnings.push(Self::ExternalCommand),
+        }
+
+        match &spec.global_options.working_copy {
+            WorkingCopyPolicy::SnapshotAndUpdate => {}
+            WorkingCopyPolicy::Ignore => warnings.push(Self::IgnoresWorkingCopy),
+        }
+
+        match &spec.global_options.operation {
+            OperationLoadPolicy::Latest => {}
+            OperationLoadPolicy::AtOperation(operation) => {
+                warnings.push(Self::AtOperation(operation.clone()));
+            }
+        }
+
+        match spec.global_options.operation_integration {
+            OperationIntegrationPolicy::Integrate => {}
+            OperationIntegrationPolicy::DoNotIntegrate => {
+                warnings.push(Self::DoesNotIntegrateOperation);
+            }
+        }
+
+        match spec.global_options.immutability {
+            ImmutabilityPolicy::Enforce => {}
+            ImmutabilityPolicy::Ignore => warnings.push(Self::IgnoresImmutableCommits),
+        }
+
+        warnings
+    }
+}
+
+/// Global `jj` options rendered before the command family.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GlobalOptions {
+    repository: Option<PathBuf>,
+    working_copy: WorkingCopyPolicy,
+    operation: OperationLoadPolicy,
+    operation_integration: OperationIntegrationPolicy,
+    immutability: ImmutabilityPolicy,
+    output: OutputPolicy,
+    debug: bool,
+    config_overlays: Vec<ConfigOverlay>,
+}
+
+impl GlobalOptions {
+    /// Sets the repository passed with `jj --repository`.
+    #[must_use]
+    pub fn with_repository(mut self, repository: impl Into<PathBuf>) -> Self {
+        self.repository = Some(repository.into());
+        self
+    }
+
+    /// Sets whether `jj` should snapshot and update the working copy.
+    #[must_use]
+    pub const fn with_working_copy(mut self, working_copy: WorkingCopyPolicy) -> Self {
+        self.working_copy = working_copy;
+        self
+    }
+
+    /// Sets which operation `jj` should load.
+    #[must_use]
+    pub fn with_operation(mut self, operation: OperationLoadPolicy) -> Self {
+        self.operation = operation;
+        self
+    }
+
+    /// Sets whether `jj` should integrate the loaded operation.
+    #[must_use]
+    pub const fn with_operation_integration(
+        mut self,
+        operation_integration: OperationIntegrationPolicy,
+    ) -> Self {
+        self.operation_integration = operation_integration;
+        self
+    }
+
+    /// Sets whether immutable commits may be rewritten.
+    #[must_use]
+    pub const fn with_immutability(mut self, immutability: ImmutabilityPolicy) -> Self {
+        self.immutability = immutability;
+        self
+    }
+
+    /// Sets output-related `jj` options.
+    #[must_use]
+    pub const fn with_output(mut self, output: OutputPolicy) -> Self {
+        self.output = output;
+        self
+    }
+
+    /// Sets whether `jj --debug` should be rendered.
+    #[must_use]
+    pub const fn with_debug(mut self, debug: bool) -> Self {
+        self.debug = debug;
+        self
+    }
+
+    /// Adds a config overlay in render order.
+    #[must_use]
+    pub fn with_config_overlay(mut self, overlay: ConfigOverlay) -> Self {
+        self.config_overlays.push(overlay);
+        self
+    }
+
+    /// Returns the configured repository path.
+    #[must_use]
+    pub fn repository(&self) -> Option<&Path> {
+        self.repository.as_deref()
+    }
+
+    /// Returns global `jj` arguments in canonical render order.
+    #[must_use]
+    pub fn argv(&self) -> Vec<OsString> {
+        let mut argv = Vec::new();
+
+        self.output.push_argv(&mut argv);
+
+        if let Some(repository) = &self.repository {
+            argv.push("--repository".into());
+            argv.push(repository.as_os_str().to_owned());
+        }
+
+        match (&self.working_copy, &self.operation) {
+            (WorkingCopyPolicy::Ignore, OperationLoadPolicy::Latest) => {
+                argv.push("--ignore-working-copy".into());
+            }
+            (WorkingCopyPolicy::SnapshotAndUpdate, _)
+            | (WorkingCopyPolicy::Ignore, OperationLoadPolicy::AtOperation(_)) => {}
+        }
+
+        match &self.operation {
+            OperationLoadPolicy::Latest => {}
+            OperationLoadPolicy::AtOperation(operation) => {
+                argv.push("--at-operation".into());
+                argv.push(operation.as_str().into());
+            }
+        }
+
+        match self.operation_integration {
+            OperationIntegrationPolicy::Integrate => {}
+            OperationIntegrationPolicy::DoNotIntegrate => {
+                argv.push("--no-integrate-operation".into());
+            }
+        }
+
+        match self.immutability {
+            ImmutabilityPolicy::Enforce => {}
+            ImmutabilityPolicy::Ignore => argv.push("--ignore-immutable".into()),
+        }
+
+        if self.debug {
+            argv.push("--debug".into());
+        }
+
+        for overlay in &self.config_overlays {
+            overlay.push_argv(&mut argv);
+        }
+
+        argv
+    }
+}
+
+impl Default for GlobalOptions {
+    fn default() -> Self {
+        Self {
+            repository: None,
+            working_copy: WorkingCopyPolicy::SnapshotAndUpdate,
+            operation: OperationLoadPolicy::Latest,
+            operation_integration: OperationIntegrationPolicy::Integrate,
+            immutability: ImmutabilityPolicy::Enforce,
+            output: OutputPolicy::default(),
+            debug: false,
+            config_overlays: Vec::new(),
+        }
+    }
+}
+
+/// How `jj` should handle working-copy state before running a command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum WorkingCopyPolicy {
+    /// Snapshot and update the working copy.
+    SnapshotAndUpdate,
+    /// Ignore the working copy.
+    Ignore,
+}
+
+/// Which operation `jj` should load before running a command.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum OperationLoadPolicy {
+    /// Load the latest operation.
+    Latest,
+    /// Load the repository at a specific operation.
+    AtOperation(String),
+}
+
+/// Whether `jj` should integrate the loaded operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum OperationIntegrationPolicy {
+    /// Integrate the loaded operation.
+    Integrate,
+    /// Do not integrate the loaded operation.
+    DoNotIntegrate,
+}
+
+/// Whether `jj` should enforce immutable commits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ImmutabilityPolicy {
+    /// Enforce immutable commits.
+    Enforce,
+    /// Allow commands to rewrite immutable commits.
+    Ignore,
+}
+
+/// Output-related global `jj` options.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OutputPolicy {
+    /// The color policy passed to `jj --color`.
+    pub color: ColorPolicy,
+    /// The pager policy for `jj` output.
+    pub pager: PagerPolicy,
+    /// Whether to pass `jj --quiet`.
+    pub quiet: bool,
+}
+
+impl OutputPolicy {
+    fn push_argv(self, argv: &mut Vec<OsString>) {
+        match self.pager {
+            PagerPolicy::Disable => argv.push("--no-pager".into()),
+            PagerPolicy::Inherit => {}
+        }
+
+        argv.push("--color".into());
+        argv.push(self.color.as_str().into());
+
+        if self.quiet {
+            argv.push("--quiet".into());
+        }
+    }
+}
+
+impl Default for OutputPolicy {
+    fn default() -> Self {
+        Self {
+            color: ColorPolicy::Always,
+            pager: PagerPolicy::Disable,
+            quiet: false,
+        }
+    }
+}
+
+/// Color rendering policy passed to `jj --color`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ColorPolicy {
+    /// Always render color.
+    Always,
+    /// Never render color.
+    Never,
+    /// Render color for debugging.
+    Debug,
+    /// Let `jj` choose automatically.
+    Auto,
+}
+
+impl ColorPolicy {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Always => "always",
+            Self::Never => "never",
+            Self::Debug => "debug",
+            Self::Auto => "auto",
+        }
+    }
+}
+
+/// Pager rendering policy passed to `jj`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum PagerPolicy {
+    /// Disable paging with `jj --no-pager`.
+    Disable,
+    /// Inherit `jj`'s normal pager behavior.
+    Inherit,
+}
+
+/// Config overlays passed through global `jj` options.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ConfigOverlay {
+    /// Inline `NAME=VALUE` config passed with `jj --config`.
+    Inline {
+        /// The raw `NAME=VALUE` value.
+        name_value: String,
+    },
+    /// A config file passed with `jj --config-file`.
+    File(PathBuf),
+}
+
+impl ConfigOverlay {
+    fn push_argv(&self, argv: &mut Vec<OsString>) {
+        match self {
+            Self::Inline { name_value } => {
+                argv.push("--config".into());
+                argv.push(name_value.as_str().into());
+            }
+            Self::File(path) => {
+                argv.push("--config-file".into());
+                argv.push(path.as_os_str().to_owned());
+            }
+        }
+    }
+}
+
+/// How a command should be executed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ExecutionMode {
+    /// Run immediately and render output without confirmation.
+    RenderReadOnly,
+    /// Show a mutation confirmation before execution.
+    ConfirmMutation,
+    /// Restore the terminal and run a foreground external tool.
+    ConfirmExternalTool,
+    /// Run a dry-run first, then ask before the real command.
+    DryRunThenConfirm,
+    /// User-entered command mode.
+    CommandMode,
+}
+
+/// The safety class for command preview and confirmation policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum SafetyClass {
+    /// Read-only command.
+    ReadOnly,
+    /// Local metadata update.
+    LocalMetadata,
+    /// Local history rewrite.
+    LocalRewrite,
+    /// Destructive local operation.
+    DestructiveLocal,
+    /// Network read.
+    NetworkRead,
+    /// Network write.
+    NetworkWrite,
+    /// External command.
+    ExternalCommand,
+}
+
+/// What should refresh after a command succeeds.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum RefreshPlan {
+    /// Do not refresh automatically.
+    None,
+    /// Re-run the command spec that produced the active view.
+    ReRunSpec,
+}
+
+pub fn preview_argv(argv: &[OsString]) -> String {
+    let mut preview = String::from("jj");
+    for arg in argv {
+        preview.push(' ');
+        preview.push_str(&quote_arg(arg));
+    }
+    preview
+}
+
+fn quote_arg(arg: &OsStr) -> String {
+    let arg = arg.to_string_lossy();
+    if arg.is_empty() {
+        return "''".to_owned();
+    }
+
+    if arg
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || "-_./:@".contains(character))
+    {
+        return arg.into_owned();
+    }
+
+    format!("'{}'", arg.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(argv: impl IntoIterator<Item = OsString>) -> Vec<String> {
+        argv.into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn empty_argv_previews_as_jj() {
+        let spec = JjCommandSpec::render_read_only(Vec::<OsString>::new());
+
+        assert_eq!(spec.preview(), "jj");
+        assert_eq!(spec.title(), "jj");
+    }
+
+    #[test]
+    fn default_global_options_render_current_app_globals() {
+        let options = GlobalOptions::default();
+
+        assert_eq!(
+            strings(options.argv()),
+            vec!["--no-pager", "--color", "always"]
+        );
+    }
+
+    #[test]
+    fn repository_renders_before_command_argv() {
+        let spec =
+            JjCommandSpec::render_read_only(["diff", "-r", "@"]).with_repository("/tmp/repo");
+
+        assert_eq!(
+            strings(spec.process_argv()),
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--repository",
+                "/tmp/repo",
+                "diff",
+                "-r",
+                "@"
+            ]
+        );
+        assert_eq!(spec.repository(), Some(Path::new("/tmp/repo")));
+        assert_eq!(
+            spec.global_options().repository(),
+            Some(Path::new("/tmp/repo"))
+        );
+    }
+
+    #[test]
+    fn advanced_global_options_render_before_command_argv() {
+        let global_options = GlobalOptions::default()
+            .with_operation(OperationLoadPolicy::AtOperation("abc123".to_owned()))
+            .with_operation_integration(OperationIntegrationPolicy::DoNotIntegrate)
+            .with_immutability(ImmutabilityPolicy::Ignore)
+            .with_debug(true);
+        let spec = JjCommandSpec::render_read_only(["status"]).with_global_options(global_options);
+
+        assert_eq!(
+            strings(spec.process_argv()),
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--at-operation",
+                "abc123",
+                "--no-integrate-operation",
+                "--ignore-immutable",
+                "--debug",
+                "status"
+            ]
+        );
+    }
+
+    #[test]
+    fn ignore_working_copy_renders_before_command_argv() {
+        let global_options = GlobalOptions::default().with_working_copy(WorkingCopyPolicy::Ignore);
+        let spec = JjCommandSpec::render_read_only(["log"]).with_global_options(global_options);
+
+        assert_eq!(
+            strings(spec.process_argv()),
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--ignore-working-copy",
+                "log"
+            ]
+        );
+    }
+
+    #[test]
+    fn at_operation_does_not_duplicate_implied_working_copy_ignore() {
+        let global_options = GlobalOptions::default()
+            .with_working_copy(WorkingCopyPolicy::Ignore)
+            .with_operation(OperationLoadPolicy::AtOperation("abc123".to_owned()));
+        let spec = JjCommandSpec::render_read_only(["status"]).with_global_options(global_options);
+
+        assert_eq!(
+            strings(spec.process_argv()),
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--at-operation",
+                "abc123",
+                "status"
+            ]
+        );
+    }
+
+    #[test]
+    fn config_overlays_preserve_global_order() {
+        let options = GlobalOptions::default()
+            .with_config_overlay(ConfigOverlay::Inline {
+                name_value: "ui.color=always".to_owned(),
+            })
+            .with_config_overlay(ConfigOverlay::File("/tmp/jj.toml".into()))
+            .with_config_overlay(ConfigOverlay::Inline {
+                name_value: "aliases.l=log".to_owned(),
+            });
+
+        assert_eq!(
+            strings(options.argv()),
+            vec![
+                "--no-pager",
+                "--color",
+                "always",
+                "--config",
+                "ui.color=always",
+                "--config-file",
+                "/tmp/jj.toml",
+                "--config",
+                "aliases.l=log"
+            ]
+        );
+    }
+
+    #[test]
+    fn process_argv_does_not_duplicate_repository() {
+        let spec =
+            JjCommandSpec::render_read_only(["show", "@"]).with_repository("/tmp/repository");
+        let argv = strings(spec.process_argv());
+
+        assert_eq!(
+            argv.iter()
+                .filter(|arg| arg.as_str() == "--repository")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn render_read_only_sets_default_policy() {
+        let spec = JjCommandSpec::render_read_only(["diff", "-r", "abc123"]);
+
+        assert_eq!(spec.mode(), ExecutionMode::RenderReadOnly);
+        assert_eq!(spec.safety(), SafetyClass::ReadOnly);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::ReRunSpec);
+    }
+
+    #[test]
+    fn preview_quotes_whitespace_and_shell_metacharacters() {
+        let spec = JjCommandSpec::render_read_only(["log", "-r", "description('a b')"]);
+
+        assert_eq!(spec.preview(), "jj log -r 'description('\"'\"'a b'\"'\"')'");
+    }
+
+    #[test]
+    fn preview_quotes_backticks() {
+        let spec = JjCommandSpec::render_read_only(["log", "-r", "`echo nope`"]);
+
+        assert_eq!(spec.preview(), "jj log -r '`echo nope`'");
+    }
+
+    #[test]
+    fn process_preview_includes_global_options_before_command_argv() {
+        let spec =
+            JjCommandSpec::render_read_only(["status"]).with_repository("/tmp/repo with spaces");
+
+        assert_eq!(
+            spec.process_preview(),
+            "jj --no-pager --color always --repository '/tmp/repo with spaces' status"
+        );
+        assert_eq!(spec.preview(), "jj status");
+    }
+
+    #[test]
+    fn confirm_mutation_sets_preview_policy() {
+        let spec = JjCommandSpec::confirm_mutation(
+            ["workspace", "update-stale"],
+            SafetyClass::LocalMetadata,
+        );
+
+        assert_eq!(spec.mode(), ExecutionMode::ConfirmMutation);
+        assert_eq!(spec.safety(), SafetyClass::LocalMetadata);
+        assert_eq!(spec.refresh_plan(), RefreshPlan::ReRunSpec);
+    }
+
+    #[test]
+    fn command_preview_uses_process_command_line_and_short_title() {
+        let global_options = GlobalOptions::default()
+            .with_repository("/tmp/repo")
+            .with_working_copy(WorkingCopyPolicy::Ignore);
+        let spec = JjCommandSpec::confirm_mutation(["new", "@"], SafetyClass::LocalRewrite)
+            .with_global_options(global_options)
+            .with_title("new change after @");
+
+        let preview = spec.command_preview();
+
+        assert_eq!(preview.spec, spec);
+        assert_eq!(preview.title, "new change after @");
+        assert_eq!(
+            preview.command_line,
+            "jj --no-pager --color always --repository /tmp/repo --ignore-working-copy new @"
+        );
+        assert_eq!(preview.execution_mode, ExecutionMode::ConfirmMutation);
+        assert_eq!(preview.safety, SafetyClass::LocalRewrite);
+        assert_eq!(preview.refresh_plan, RefreshPlan::ReRunSpec);
+        assert!(preview.requires_confirmation());
+        assert_eq!(
+            preview.warnings,
+            vec![
+                CommandPreviewWarning::LocalRewrite,
+                CommandPreviewWarning::IgnoresWorkingCopy
+            ]
+        );
+    }
+
+    #[test]
+    fn command_preview_redacts_secret_looking_global_options() {
+        let global_options = GlobalOptions::default().with_config_overlay(ConfigOverlay::Inline {
+            name_value: "auth.token=abc123".to_owned(),
+        });
+        let spec = JjCommandSpec::confirm_mutation(
+            ["describe", "-m", "safe", "@"],
+            SafetyClass::LocalRewrite,
+        )
+        .with_global_options(global_options);
+
+        let preview = spec.command_preview();
+
+        assert_eq!(
+            preview.command_line,
+            "jj --no-pager --color always --config 'auth.token=<redacted>' describe -m safe @"
+        );
+        assert_eq!(preview.spec.process_argv(), spec.process_argv());
+    }
+
+    #[test]
+    fn command_preview_warns_for_advanced_global_safety_flags() {
+        let global_options = GlobalOptions::default()
+            .with_operation(OperationLoadPolicy::AtOperation("abc123".to_owned()))
+            .with_operation_integration(OperationIntegrationPolicy::DoNotIntegrate)
+            .with_immutability(ImmutabilityPolicy::Ignore);
+        let spec = JjCommandSpec::confirm_mutation(
+            ["rebase", "-b", "@", "-d", "main"],
+            SafetyClass::LocalRewrite,
+        )
+        .with_global_options(global_options);
+
+        let preview = spec.command_preview();
+
+        assert_eq!(
+            preview.warnings,
+            vec![
+                CommandPreviewWarning::LocalRewrite,
+                CommandPreviewWarning::AtOperation("abc123".to_owned()),
+                CommandPreviewWarning::DoesNotIntegrateOperation,
+                CommandPreviewWarning::IgnoresImmutableCommits
+            ]
+        );
+    }
+
+    #[test]
+    fn metadata_builders_preserve_argv() {
+        let spec = JjCommandSpec::render_read_only(["diff"])
+            .with_cwd("/tmp/work")
+            .with_repository("/tmp/repo")
+            .with_stdin("input")
+            .with_title("custom");
+
+        assert_eq!(spec.argv(), &[OsString::from("diff")]);
+        assert_eq!(spec.cwd(), Some(Path::new("/tmp/work")));
+        assert_eq!(spec.repository(), Some(Path::new("/tmp/repo")));
+        assert_eq!(spec.stdin(), Some("input"));
+        assert_eq!(spec.title(), "custom");
+        assert_eq!(spec.preview(), "jj diff");
+    }
+}

--- a/crates/jk-core/src/command_history/history.rs
+++ b/crates/jk-core/src/command_history/history.rs
@@ -1,0 +1,122 @@
+use std::collections::VecDeque;
+
+use super::{CommandRecord, CommandRecordFinish, CommandRecordStart};
+
+/// A stable command-history id for the current process.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CommandRecordId(u64);
+
+impl CommandRecordId {
+    /// Returns the numeric id assigned by the in-memory history.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Recent command records retained in memory.
+#[derive(Clone, Debug)]
+pub struct CommandHistory {
+    records: VecDeque<CommandRecord>,
+    limit: usize,
+    next_id: u64,
+}
+
+impl CommandHistory {
+    /// Creates an empty command history with a maximum record count.
+    #[must_use]
+    pub const fn new(limit: usize) -> Self {
+        Self {
+            records: VecDeque::new(),
+            limit,
+            next_id: 1,
+        }
+    }
+
+    /// Returns the maximum number of records retained in memory.
+    #[must_use]
+    pub const fn limit(&self) -> usize {
+        self.limit
+    }
+
+    /// Starts a command record before execution.
+    pub fn start(&mut self, input: CommandRecordStart) -> PendingCommandRecord {
+        let id = self.allocate_id();
+        let record = CommandRecord::started(id, input);
+        self.push_record(record);
+        PendingCommandRecord { id }
+    }
+
+    /// Finishes a pending command record.
+    ///
+    /// If the pending record has already been evicted by the history limit, this method does
+    /// nothing.
+    pub fn finish(&mut self, pending: &PendingCommandRecord, finish: CommandRecordFinish) -> bool {
+        if let Some(record) = self
+            .records
+            .iter_mut()
+            .find(|record| record.id == pending.id)
+        {
+            return record.finish(finish);
+        }
+        false
+    }
+
+    /// Appends an already-completed command record.
+    ///
+    /// This is useful for synchronous command paths where the caller already has all timing and
+    /// result data at the recording boundary.
+    pub fn append(
+        &mut self,
+        input: CommandRecordStart,
+        finish: CommandRecordFinish,
+    ) -> CommandRecordId {
+        let pending = self.start(input);
+        let id = pending.id;
+        self.finish(&pending, finish);
+        id
+    }
+
+    /// Returns retained records from oldest to newest.
+    #[must_use]
+    pub fn records(&self) -> impl DoubleEndedIterator<Item = &CommandRecord> {
+        self.records.iter()
+    }
+
+    const fn allocate_id(&mut self) -> CommandRecordId {
+        let id = CommandRecordId(self.next_id);
+        self.next_id += 1;
+        id
+    }
+
+    fn push_record(&mut self, record: CommandRecord) {
+        if self.limit == 0 {
+            return;
+        }
+
+        while self.records.len() >= self.limit {
+            self.records.pop_front();
+        }
+        self.records.push_back(record);
+    }
+}
+
+impl Default for CommandHistory {
+    fn default() -> Self {
+        Self::new(128)
+    }
+}
+
+/// A pending command record handle returned by [`CommandHistory::start`].
+#[derive(Debug, Eq, PartialEq)]
+pub struct PendingCommandRecord {
+    id: CommandRecordId,
+}
+
+impl PendingCommandRecord {
+    /// Returns the id of the pending command record.
+    #[must_use]
+    pub const fn id(&self) -> CommandRecordId {
+        self.id
+    }
+}

--- a/crates/jk-core/src/command_history/identity.rs
+++ b/crates/jk-core/src/command_history/identity.rs
@@ -1,0 +1,251 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use super::redaction::{redact_argv, redact_text};
+use crate::command::preview_argv;
+use crate::{ExecutionMode, GlobalOptions, JjCommandSpec};
+
+/// Command data captured from a typed command spec.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandIdentity {
+    /// Exact process argv after global options are applied, excluding the `jj` binary.
+    pub argv: Vec<OsString>,
+    /// Display-only preview from the command spec.
+    pub spec_preview: String,
+    /// Broad command family for filtering and grouping.
+    pub command_family: CommandFamily,
+    /// Human-readable title from the command spec.
+    pub title: String,
+}
+
+impl CommandIdentity {
+    /// Captures command identity from a typed command spec.
+    #[must_use]
+    pub fn from_spec(spec: &JjCommandSpec) -> Self {
+        Self {
+            argv: redact_argv(spec.process_argv()),
+            spec_preview: redact_text(&spec.preview()).0,
+            command_family: CommandFamily::from_spec(spec),
+            title: redact_text(spec.title()).0,
+        }
+    }
+
+    /// Returns the exact redacted process command line captured for this command.
+    #[must_use]
+    pub fn process_preview(&self) -> String {
+        preview_argv(&self.argv)
+    }
+}
+
+/// Broad command family for history filtering.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum CommandFamily {
+    /// Bare `jj` or configured default command.
+    JjDefault,
+    /// `jj log`.
+    JjLog,
+    /// `jj diff`.
+    JjDiff,
+    /// `jj show`.
+    JjShow,
+    /// `jj status`.
+    JjStatus,
+    /// `jj describe`.
+    JjDescribe,
+    /// `jj new`.
+    JjNew,
+    /// `jj edit`.
+    JjEdit,
+    /// `jj evolog`.
+    JjEvolog,
+    /// `jj workspace ...`.
+    JjWorkspace,
+    /// Future `jj op ...`.
+    JjOperation,
+    /// Future user-entered `:` command.
+    UserJjCommand,
+    /// Future foreground external command.
+    ExternalCommand,
+    /// A command family not yet modeled.
+    Other(String),
+}
+
+impl CommandFamily {
+    fn from_spec(spec: &JjCommandSpec) -> Self {
+        if spec.mode() == ExecutionMode::CommandMode {
+            return Self::UserJjCommand;
+        }
+
+        let Some(command) = spec.argv().first() else {
+            return Self::JjDefault;
+        };
+        match command.to_string_lossy().as_ref() {
+            "log" => Self::JjLog,
+            "diff" => Self::JjDiff,
+            "show" => Self::JjShow,
+            "status" => Self::JjStatus,
+            "describe" => Self::JjDescribe,
+            "new" => Self::JjNew,
+            "edit" => Self::JjEdit,
+            "evolog" => Self::JjEvolog,
+            "workspace" => Self::JjWorkspace,
+            "op" => Self::JjOperation,
+            other => Self::Other(other.to_owned()),
+        }
+    }
+}
+
+/// The view and action that caused a command.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandSource {
+    /// Source view that owned the command action.
+    pub view: SourceView,
+    /// Source action that triggered the command.
+    pub action: SourceAction,
+    /// Optional key binding or command key.
+    pub key: Option<String>,
+}
+
+impl CommandSource {
+    /// Creates a command source without a key binding.
+    #[must_use]
+    pub const fn new(view: SourceView, action: SourceAction) -> Self {
+        Self {
+            view,
+            action,
+            key: None,
+        }
+    }
+
+    /// Adds the key binding that triggered this source action.
+    #[must_use]
+    pub fn with_key(mut self, key: impl Into<String>) -> Self {
+        self.key = Some(key.into());
+        self
+    }
+}
+
+/// App view that triggered a command.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum SourceView {
+    /// Log view.
+    Log,
+    /// Diff view.
+    Diff,
+    /// Show view.
+    Show,
+    /// Status view.
+    Status,
+    /// Evolog view.
+    Evolog,
+    /// Workspaces list.
+    Workspaces,
+    /// Selected workspace log view.
+    WorkspaceLog,
+    /// Selected workspace status view.
+    WorkspaceStatus,
+    /// Selected workspace diff view.
+    WorkspaceDiff,
+    /// Command history view.
+    CommandHistory,
+    /// Operation log view.
+    OperationLog,
+    /// Operation show view.
+    OperationShow,
+    /// Operation diff view.
+    OperationDiff,
+    /// A source view not yet modeled.
+    Other(String),
+}
+
+/// App action that triggered a command.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum SourceAction {
+    /// Initial view load.
+    InitialLoad,
+    /// Explicit refresh.
+    Refresh,
+    /// Open a diff.
+    OpenDiff,
+    /// Open a show view.
+    OpenShow,
+    /// Open a status view.
+    OpenStatus,
+    /// Open an evolog view.
+    OpenEvolog,
+    /// Describe the selected revision.
+    DescribeRevision,
+    /// Abandon the selected revision.
+    AbandonRevision,
+    /// Create a new change from the selected revision.
+    NewRevision,
+    /// Move the working copy to the selected revision.
+    EditRevision,
+    /// List workspaces.
+    WorkspaceList,
+    /// Show selected workspace status.
+    WorkspaceStatus,
+    /// Show selected workspace log.
+    WorkspaceLog,
+    /// Show selected workspace diff.
+    WorkspaceDiff,
+    /// Run selected workspace update-stale.
+    WorkspaceUpdateStale,
+    /// List repository operations.
+    OperationLog,
+    /// Show a selected operation.
+    OperationShow,
+    /// Diff a selected operation.
+    OperationDiff,
+    /// Undo the latest operation.
+    Undo,
+    /// Redo the latest undone operation.
+    Redo,
+    /// Run a user-entered `jj` command.
+    UserJjCommand,
+    /// A source action not yet modeled.
+    Other(String),
+}
+
+/// Context captured when a command starts.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandExecutionContext {
+    /// Process working directory, if set by the command spec.
+    pub cwd: Option<PathBuf>,
+    /// Repository path from global `jj` options, if set.
+    pub repository: Option<PathBuf>,
+    /// Redacted snapshot of global `jj` options.
+    pub global_options: GlobalOptionsSnapshot,
+}
+
+impl CommandExecutionContext {
+    /// Captures execution context from a typed command spec.
+    #[must_use]
+    pub fn from_spec(spec: &JjCommandSpec) -> Self {
+        Self {
+            cwd: spec.cwd().map(PathBuf::from),
+            repository: spec.repository().map(PathBuf::from),
+            global_options: GlobalOptionsSnapshot::from_global_options(spec.global_options()),
+        }
+    }
+}
+
+/// Redacted global `jj` options retained by command history.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GlobalOptionsSnapshot {
+    /// Global argv rendered before the command family, excluding the `jj` binary.
+    pub argv: Vec<OsString>,
+}
+
+impl GlobalOptionsSnapshot {
+    /// Captures redacted global argv from typed global options.
+    #[must_use]
+    pub fn from_global_options(options: &GlobalOptions) -> Self {
+        Self {
+            argv: redact_argv(options.argv()),
+        }
+    }
+}

--- a/crates/jk-core/src/command_history/mod.rs
+++ b/crates/jk-core/src/command_history/mod.rs
@@ -1,0 +1,24 @@
+//! In-memory command history records.
+//!
+//! The history model stores command specs as structured data so future runner and UI layers can
+//! show what ran without reconstructing process details from rendered output.
+
+mod history;
+mod identity;
+mod record;
+pub mod redaction;
+mod result;
+
+pub use history::{CommandHistory, CommandRecordId, PendingCommandRecord};
+pub use identity::{
+    CommandExecutionContext, CommandFamily, CommandIdentity, CommandSource, GlobalOptionsSnapshot,
+    SourceAction, SourceView,
+};
+pub use record::{CommandRecord, CommandRecordFinish, CommandRecordStart, CommandTiming};
+pub use result::{CommandResultSummary, ExitStatusSummary, OutputRetention, StreamSummary};
+
+const DEFAULT_STREAM_LIMIT: usize = 8 * 1024;
+const REDACTED: &str = "<redacted>";
+
+#[cfg(test)]
+mod tests;

--- a/crates/jk-core/src/command_history/record.rs
+++ b/crates/jk-core/src/command_history/record.rs
@@ -1,0 +1,203 @@
+use std::time::{Duration, SystemTime};
+
+use super::{
+    CommandExecutionContext, CommandIdentity, CommandRecordId, CommandResultSummary, CommandSource,
+    DEFAULT_STREAM_LIMIT, ExitStatusSummary, OutputRetention, StreamSummary,
+};
+use crate::{ExecutionMode, JjCommandSpec, RefreshPlan, SafetyClass};
+
+/// One retained command-history record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandRecord {
+    /// Stable id for this in-memory history.
+    pub id: CommandRecordId,
+    /// Command identity captured from a typed spec.
+    pub command: CommandIdentity,
+    /// View and action that triggered the command.
+    pub source: CommandSource,
+    /// Execution context captured before running the command.
+    pub context: CommandExecutionContext,
+    /// Start and finish timing.
+    pub timing: CommandTiming,
+    /// Process or spawn result summary.
+    pub result: CommandResultSummary,
+    /// Output retention policy used for this record.
+    pub retention: OutputRetention,
+    /// Refresh behavior requested by the command spec.
+    pub refresh: RefreshPlan,
+    /// Safety classification requested by the command spec.
+    pub safety: SafetyClass,
+    /// Execution mode requested by the command spec.
+    pub execution_mode: ExecutionMode,
+    /// Operation id reported by `jj`, when cheaply available.
+    pub operation_id: Option<String>,
+}
+
+impl CommandRecord {
+    pub(super) fn started(id: CommandRecordId, input: CommandRecordStart) -> Self {
+        Self {
+            id,
+            command: input.command,
+            source: input.source,
+            context: input.context,
+            timing: CommandTiming {
+                started_at: input.started_at,
+                ended_at: None,
+                duration: None,
+            },
+            result: CommandResultSummary::default(),
+            retention: input.retention,
+            refresh: input.refresh,
+            safety: input.safety,
+            execution_mode: input.execution_mode,
+            operation_id: None,
+        }
+    }
+
+    pub(super) fn finish(&mut self, mut finish: CommandRecordFinish) -> bool {
+        if self.timing.ended_at.is_some() {
+            return false;
+        }
+
+        let duration = finish
+            .ended_at
+            .duration_since(self.timing.started_at)
+            .unwrap_or_default();
+        finish.result.apply_retention(&self.retention);
+        self.timing.ended_at = Some(finish.ended_at);
+        self.timing.duration = Some(duration);
+        self.result = finish.result;
+        self.operation_id = finish.operation_id;
+        true
+    }
+}
+
+/// Fields required when a command starts.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandRecordStart {
+    /// Command identity captured from a typed spec.
+    pub command: CommandIdentity,
+    /// View and action that triggered the command.
+    pub source: CommandSource,
+    /// Execution context captured before running the command.
+    pub context: CommandExecutionContext,
+    /// Start time.
+    pub started_at: SystemTime,
+    /// Output retention policy for this record.
+    pub retention: OutputRetention,
+    /// Refresh behavior requested by the command spec.
+    pub refresh: RefreshPlan,
+    /// Safety classification requested by the command spec.
+    pub safety: SafetyClass,
+    /// Execution mode requested by the command spec.
+    pub execution_mode: ExecutionMode,
+}
+
+impl CommandRecordStart {
+    /// Creates start data from a typed `jj` command spec and source.
+    #[must_use]
+    pub fn from_spec(spec: &JjCommandSpec, source: CommandSource) -> Self {
+        Self {
+            command: CommandIdentity::from_spec(spec),
+            source,
+            context: CommandExecutionContext::from_spec(spec),
+            started_at: SystemTime::now(),
+            retention: OutputRetention::summary_only(DEFAULT_STREAM_LIMIT, DEFAULT_STREAM_LIMIT),
+            refresh: spec.refresh_plan(),
+            safety: spec.safety(),
+            execution_mode: spec.mode(),
+        }
+    }
+
+    /// Sets the start time for deterministic tests or caller-owned timing.
+    #[must_use]
+    pub const fn with_started_at(mut self, started_at: SystemTime) -> Self {
+        self.started_at = started_at;
+        self
+    }
+
+    /// Sets the output retention policy.
+    #[must_use]
+    pub fn with_retention(mut self, retention: OutputRetention) -> Self {
+        self.retention = retention;
+        self
+    }
+}
+
+/// Fields required when a command finishes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandRecordFinish {
+    /// Finish time.
+    pub ended_at: SystemTime,
+    /// Process or spawn result summary.
+    pub result: CommandResultSummary,
+    /// Operation id reported by `jj`, when cheaply available.
+    pub operation_id: Option<String>,
+}
+
+impl CommandRecordFinish {
+    /// Creates finish data for a process result.
+    #[must_use]
+    pub const fn from_result(
+        result: CommandResultSummary,
+        operation_id: Option<String>,
+        ended_at: SystemTime,
+    ) -> Self {
+        Self {
+            ended_at,
+            result,
+            operation_id,
+        }
+    }
+
+    /// Creates finish data for a process exit code and captured output.
+    #[must_use]
+    pub fn from_exit_code(
+        code: i32,
+        stdout: impl AsRef<[u8]>,
+        stderr: impl AsRef<[u8]>,
+        ended_at: SystemTime,
+    ) -> Self {
+        Self::from_result(
+            CommandResultSummary {
+                exit_status: Some(ExitStatusSummary::code(code)),
+                spawn_error: None,
+                stdout: StreamSummary::from_bytes(stdout.as_ref(), DEFAULT_STREAM_LIMIT),
+                stderr: StreamSummary::from_bytes(stderr.as_ref(), DEFAULT_STREAM_LIMIT),
+            },
+            None,
+            ended_at,
+        )
+    }
+
+    /// Creates finish data for a command that failed before producing an exit status.
+    #[must_use]
+    pub fn from_spawn_error(
+        error: impl Into<String>,
+        stdout: impl AsRef<[u8]>,
+        stderr: impl AsRef<[u8]>,
+        ended_at: SystemTime,
+    ) -> Self {
+        Self::from_result(
+            CommandResultSummary {
+                exit_status: None,
+                spawn_error: Some(error.into()),
+                stdout: StreamSummary::from_bytes(stdout.as_ref(), DEFAULT_STREAM_LIMIT),
+                stderr: StreamSummary::from_bytes(stderr.as_ref(), DEFAULT_STREAM_LIMIT),
+            },
+            None,
+            ended_at,
+        )
+    }
+}
+
+/// Timing captured for a command.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandTiming {
+    /// Time at which the command was recorded as started.
+    pub started_at: SystemTime,
+    /// Time at which the command finished.
+    pub ended_at: Option<SystemTime>,
+    /// Duration between start and finish.
+    pub duration: Option<Duration>,
+}

--- a/crates/jk-core/src/command_history/redaction.rs
+++ b/crates/jk-core/src/command_history/redaction.rs
@@ -1,0 +1,124 @@
+use std::ffi::OsString;
+
+use super::REDACTED;
+
+pub fn redact_argv(argv: Vec<OsString>) -> Vec<OsString> {
+    argv.into_iter()
+        .map(|arg| {
+            let Some(arg) = arg.to_str() else {
+                return arg;
+            };
+            OsString::from(redact_text(arg).0)
+        })
+        .collect()
+}
+
+pub(super) fn redact_text(text: &str) -> (String, bool) {
+    let mut output = String::with_capacity(text.len());
+    let mut redacted = false;
+    let mut index = 0;
+
+    while let Some((start, separator, redact_to_line)) = find_secret_assignment(&text[index..]) {
+        let absolute_start = index + start;
+        let value_start = absolute_start + separator;
+        output.push_str(&text[index..value_start]);
+
+        let value_end = if redact_to_line {
+            find_line_end(text, value_start)
+        } else {
+            find_value_end(text, value_start)
+        };
+        output.push_str(REDACTED);
+        redacted = true;
+        index = value_end;
+    }
+
+    output.push_str(&text[index..]);
+    (output, redacted)
+}
+
+fn find_secret_assignment(text: &str) -> Option<(usize, usize, bool)> {
+    for (index, character) in text.char_indices() {
+        if character != '=' && character != ':' {
+            continue;
+        }
+
+        let key_start = text[..index]
+            .char_indices()
+            .rev()
+            .find_map(|(position, character)| {
+                if character.is_ascii_alphanumeric() || "_-. ".contains(character) {
+                    None
+                } else {
+                    Some(position + character.len_utf8())
+                }
+            })
+            .unwrap_or(0);
+        let key = text[key_start..index].trim();
+        if is_secret_key(key) {
+            return Some((
+                key_start,
+                index + character.len_utf8() - key_start,
+                is_authorization_key(key),
+            ));
+        }
+    }
+    None
+}
+
+fn find_value_end(text: &str, value_start: usize) -> usize {
+    let mut saw_quote = None;
+    let mut start = value_start;
+    while let Some(character) = text[start..].chars().next() {
+        if character.is_ascii_whitespace() {
+            start += character.len_utf8();
+        } else if character == '"' || character == '\'' {
+            saw_quote = Some(character);
+            start += character.len_utf8();
+            break;
+        } else {
+            break;
+        }
+    }
+
+    let value_end = text[start..]
+        .char_indices()
+        .find_map(|(offset, character)| {
+            if Some(character) == saw_quote
+                || (saw_quote.is_none() && (character.is_ascii_whitespace() || character == ','))
+            {
+                Some(start + offset)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(text.len());
+
+    if let Some(quote) = saw_quote
+        && text[value_end..].starts_with(quote)
+    {
+        return value_end + quote.len_utf8();
+    }
+    value_end
+}
+
+fn find_line_end(text: &str, value_start: usize) -> usize {
+    text[value_start..]
+        .find('\n')
+        .map_or(text.len(), |offset| value_start + offset)
+}
+
+fn is_secret_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    ["token", "secret", "password", "credential", "auth"]
+        .iter()
+        .any(|needle| key.contains(needle))
+        || key
+            .split(|character: char| !character.is_ascii_alphanumeric())
+            .any(|part| part == "key")
+}
+
+fn is_authorization_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("authorization") || key == "auth"
+}

--- a/crates/jk-core/src/command_history/result.rs
+++ b/crates/jk-core/src/command_history/result.rs
@@ -1,0 +1,195 @@
+use std::path::PathBuf;
+
+use super::redaction::redact_text;
+
+/// Process result summary retained by history.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandResultSummary {
+    /// Exit status summary when the process started and exited.
+    pub exit_status: Option<ExitStatusSummary>,
+    /// Spawn or runner error when no exit status was available.
+    pub spawn_error: Option<String>,
+    /// Bounded stdout summary.
+    pub stdout: StreamSummary,
+    /// Bounded stderr summary.
+    pub stderr: StreamSummary,
+}
+
+impl Default for CommandResultSummary {
+    fn default() -> Self {
+        Self {
+            exit_status: None,
+            spawn_error: None,
+            stdout: StreamSummary::empty(),
+            stderr: StreamSummary::empty(),
+        }
+    }
+}
+
+impl CommandResultSummary {
+    pub(super) fn apply_retention(&mut self, retention: &OutputRetention) {
+        self.stdout.apply_limit(retention.stdout_limit());
+        self.stderr.apply_limit(retention.stderr_limit());
+    }
+}
+
+/// Exit status data that does not require retaining platform-specific process types.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExitStatusSummary {
+    /// Numeric process exit code, when available.
+    pub code: Option<i32>,
+    /// Platform signal number, when available.
+    pub signal: Option<i32>,
+    /// Whether the command succeeded.
+    pub success: bool,
+}
+
+impl ExitStatusSummary {
+    /// Creates a normal exit-code status summary.
+    #[must_use]
+    pub const fn code(code: i32) -> Self {
+        Self {
+            code: Some(code),
+            signal: None,
+            success: code == 0,
+        }
+    }
+
+    /// Creates a signal status summary.
+    #[must_use]
+    pub const fn signal(signal: i32) -> Self {
+        Self {
+            code: None,
+            signal: Some(signal),
+            success: false,
+        }
+    }
+}
+
+/// Bounded output retention policy for a command record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum OutputRetention {
+    /// Retain only bounded stdout and stderr summaries.
+    SummaryOnly {
+        /// Maximum stdout snippet bytes.
+        stdout_limit: usize,
+        /// Maximum stderr snippet bytes.
+        stderr_limit: usize,
+    },
+    /// Retain summaries and point to a local full-output artifact.
+    Artifact {
+        /// Maximum stdout snippet bytes.
+        stdout_limit: usize,
+        /// Maximum stderr snippet bytes.
+        stderr_limit: usize,
+        /// Local artifact path that owns full output.
+        full_output_path: PathBuf,
+    },
+}
+
+impl OutputRetention {
+    /// Creates a summary-only retention policy.
+    #[must_use]
+    pub const fn summary_only(stdout_limit: usize, stderr_limit: usize) -> Self {
+        Self::SummaryOnly {
+            stdout_limit,
+            stderr_limit,
+        }
+    }
+
+    const fn stdout_limit(&self) -> usize {
+        match self {
+            Self::SummaryOnly { stdout_limit, .. } | Self::Artifact { stdout_limit, .. } => {
+                *stdout_limit
+            }
+        }
+    }
+
+    const fn stderr_limit(&self) -> usize {
+        match self {
+            Self::SummaryOnly { stderr_limit, .. } | Self::Artifact { stderr_limit, .. } => {
+                *stderr_limit
+            }
+        }
+    }
+}
+
+/// Bounded and redacted stream summary.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StreamSummary {
+    /// Original stream byte length before redaction or truncation.
+    pub byte_len: usize,
+    /// Original stream line count before redaction or truncation.
+    pub line_count: usize,
+    /// Redacted snippet retained in memory.
+    pub snippet: String,
+    /// Whether the redacted snippet was truncated.
+    pub truncated: bool,
+    /// Whether any obvious secret-looking text was redacted.
+    pub redacted: bool,
+}
+
+impl StreamSummary {
+    /// Creates an empty stream summary.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            byte_len: 0,
+            line_count: 0,
+            snippet: String::new(),
+            truncated: false,
+            redacted: false,
+        }
+    }
+
+    /// Creates a bounded stream summary from bytes.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8], limit: usize) -> Self {
+        Self::from_text(&String::from_utf8_lossy(bytes), limit).with_byte_len(bytes.len())
+    }
+
+    /// Creates a bounded stream summary from text.
+    #[must_use]
+    pub fn from_text(text: &str, limit: usize) -> Self {
+        let byte_len = text.len();
+        let line_count = text.lines().count();
+        let (redacted_text, redacted) = redact_text(text);
+        let (snippet, truncated) = truncate_to_boundary(&redacted_text, limit);
+
+        Self {
+            byte_len,
+            line_count,
+            snippet,
+            truncated,
+            redacted,
+        }
+    }
+
+    const fn with_byte_len(mut self, byte_len: usize) -> Self {
+        self.byte_len = byte_len;
+        self
+    }
+
+    fn apply_limit(&mut self, limit: usize) {
+        let (snippet, truncated) = truncate_to_boundary(&self.snippet, limit);
+        self.truncated |= truncated;
+        self.snippet = snippet;
+    }
+}
+
+fn truncate_to_boundary(text: &str, limit: usize) -> (String, bool) {
+    if text.len() <= limit {
+        return (text.to_owned(), false);
+    }
+
+    if limit == 0 {
+        return (String::new(), true);
+    }
+
+    let mut end = limit;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    (text[..end].to_owned(), true)
+}

--- a/crates/jk-core/src/command_history/tests.rs
+++ b/crates/jk-core/src/command_history/tests.rs
@@ -1,0 +1,445 @@
+use std::ffi::OsString;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use super::*;
+use crate::{
+    ConfigOverlay, ExecutionMode, GlobalOptions, JjCommandSpec, OutputPolicy, PagerPolicy,
+    SafetyClass,
+};
+
+fn strings(argv: &[OsString]) -> Vec<String> {
+    argv.iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect()
+}
+
+fn source(view: SourceView, action: SourceAction) -> CommandSource {
+    CommandSource::new(view, action)
+}
+
+fn started_at() -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::from_secs(1_000)
+}
+
+fn finish_at() -> SystemTime {
+    started_at() + Duration::from_millis(42)
+}
+
+fn start_from_spec(spec: &JjCommandSpec, source: CommandSource) -> CommandRecordStart {
+    CommandRecordStart::from_spec(spec, source).with_started_at(started_at())
+}
+
+fn first_record(history: &CommandHistory) -> &CommandRecord {
+    history
+        .records()
+        .next()
+        .unwrap_or_else(|| panic!("expected record"))
+}
+
+#[test]
+fn starting_and_finishing_record_stores_completed_result() {
+    let spec = JjCommandSpec::render_read_only(["status"]);
+    let mut history = CommandHistory::new(4);
+    let pending = history.start(start_from_spec(
+        &spec,
+        source(SourceView::Status, SourceAction::InitialLoad),
+    ));
+    let pending_id = pending.id();
+
+    assert!(history.finish(
+        &pending,
+        CommandRecordFinish::from_exit_code(0, "clean\n", "", finish_at()),
+    ));
+
+    let record = first_record(&history);
+    assert_eq!(record.id, pending_id);
+    assert_eq!(record.result.exit_status, Some(ExitStatusSummary::code(0)));
+    assert_eq!(record.result.stdout.snippet, "clean\n");
+    assert_eq!(record.timing.duration, Some(Duration::from_millis(42)));
+}
+
+#[test]
+fn record_ids_are_monotonic_across_eviction() {
+    let spec = JjCommandSpec::render_read_only(["log"]);
+    let mut history = CommandHistory::new(2);
+
+    let first = history.start(start_from_spec(
+        &spec,
+        source(SourceView::Log, SourceAction::InitialLoad),
+    ));
+    let second = history.start(start_from_spec(
+        &spec,
+        source(SourceView::Log, SourceAction::Refresh),
+    ));
+    let third = history.start(start_from_spec(
+        &spec,
+        source(SourceView::Log, SourceAction::Refresh),
+    ));
+
+    assert_eq!(first.id().get(), 1);
+    assert_eq!(second.id().get(), 2);
+    assert_eq!(third.id().get(), 3);
+    assert_eq!(
+        history
+            .records()
+            .map(|record| record.id.get())
+            .collect::<Vec<_>>(),
+        vec![2, 3]
+    );
+}
+
+#[test]
+fn history_limit_drops_oldest_records_first() {
+    let spec = JjCommandSpec::render_read_only(["status"]);
+    let mut history = CommandHistory::new(2);
+
+    history.append(
+        start_from_spec(&spec, source(SourceView::Status, SourceAction::InitialLoad)),
+        CommandRecordFinish::from_exit_code(0, "one", "", finish_at()),
+    );
+    history.append(
+        start_from_spec(&spec, source(SourceView::Status, SourceAction::Refresh)),
+        CommandRecordFinish::from_exit_code(0, "two", "", finish_at()),
+    );
+    history.append(
+        start_from_spec(&spec, source(SourceView::Status, SourceAction::Refresh)),
+        CommandRecordFinish::from_exit_code(0, "three", "", finish_at()),
+    );
+
+    assert_eq!(
+        history
+            .records()
+            .map(|record| record.result.stdout.snippet.as_str())
+            .collect::<Vec<_>>(),
+        vec!["two", "three"]
+    );
+}
+
+#[test]
+fn identity_uses_argv_and_global_options_from_spec() {
+    let options = GlobalOptions::default()
+        .with_output(OutputPolicy {
+            pager: PagerPolicy::Disable,
+            ..OutputPolicy::default()
+        })
+        .with_repository("/tmp/repo")
+        .with_config_overlay(ConfigOverlay::Inline {
+            name_value: "ui.color=always".to_owned(),
+        });
+    let spec = JjCommandSpec::render_read_only(["workspace", "update-stale"])
+        .with_global_options(options)
+        .with_title("jj -R /tmp/repo workspace update-stale");
+
+    let start = CommandRecordStart::from_spec(
+        &spec,
+        source(SourceView::Workspaces, SourceAction::WorkspaceUpdateStale),
+    );
+
+    assert_eq!(
+        strings(&start.command.argv),
+        vec![
+            "--no-pager",
+            "--color",
+            "always",
+            "--repository",
+            "/tmp/repo",
+            "--config",
+            "ui.color=always",
+            "workspace",
+            "update-stale"
+        ]
+    );
+    assert_eq!(start.command.spec_preview, "jj workspace update-stale");
+    assert_eq!(
+        start.command.title,
+        "jj -R /tmp/repo workspace update-stale"
+    );
+    assert_eq!(
+        start.context.repository.as_deref(),
+        Some(Path::new("/tmp/repo"))
+    );
+    assert_eq!(
+        strings(&start.context.global_options.argv),
+        vec![
+            "--no-pager",
+            "--color",
+            "always",
+            "--repository",
+            "/tmp/repo",
+            "--config",
+            "ui.color=always"
+        ]
+    );
+    assert_eq!(start.command.command_family, CommandFamily::JjWorkspace);
+}
+
+#[test]
+fn command_mode_specs_use_user_command_family() {
+    let spec = JjCommandSpec::render_read_only(["status"]).with_mode(ExecutionMode::CommandMode);
+    let start = CommandRecordStart::from_spec(
+        &spec,
+        source(
+            SourceView::Other("command mode".to_owned()),
+            SourceAction::UserJjCommand,
+        ),
+    );
+
+    assert_eq!(start.command.command_family, CommandFamily::UserJjCommand);
+    assert_eq!(start.source.action, SourceAction::UserJjCommand);
+}
+
+#[test]
+fn context_global_options_are_redacted() {
+    let spec = JjCommandSpec::render_read_only(["log"]).with_global_options(
+        GlobalOptions::default().with_config_overlay(ConfigOverlay::Inline {
+            name_value: "auth.token=abc123".to_owned(),
+        }),
+    );
+
+    let start =
+        CommandRecordStart::from_spec(&spec, source(SourceView::Log, SourceAction::InitialLoad));
+
+    assert_eq!(
+        strings(&start.context.global_options.argv),
+        vec![
+            "--no-pager",
+            "--color",
+            "always",
+            "--config",
+            "auth.token=<redacted>"
+        ]
+    );
+}
+
+#[test]
+fn source_action_is_independent_from_command_family() {
+    let spec = JjCommandSpec::render_read_only(["status"]);
+    let start = CommandRecordStart::from_spec(
+        &spec,
+        source(SourceView::Workspaces, SourceAction::WorkspaceStatus),
+    );
+
+    assert_eq!(start.command.command_family, CommandFamily::JjStatus);
+    assert_eq!(start.source.view, SourceView::Workspaces);
+    assert_eq!(start.source.action, SourceAction::WorkspaceStatus);
+}
+
+#[test]
+fn workspace_log_source_action_preserves_log_family() {
+    let spec = JjCommandSpec::render_read_only(["log"]);
+    let start = CommandRecordStart::from_spec(
+        &spec,
+        source(SourceView::Workspaces, SourceAction::WorkspaceLog),
+    );
+
+    assert_eq!(start.command.command_family, CommandFamily::JjLog);
+    assert_eq!(start.source.view, SourceView::Workspaces);
+    assert_eq!(start.source.action, SourceAction::WorkspaceLog);
+}
+
+#[test]
+fn new_specs_use_new_family_and_typed_source_action() {
+    let spec = JjCommandSpec::confirm_mutation(["new", "abc123"], SafetyClass::LocalRewrite);
+    let start =
+        CommandRecordStart::from_spec(&spec, source(SourceView::Log, SourceAction::NewRevision));
+
+    assert_eq!(start.command.command_family, CommandFamily::JjNew);
+    assert_eq!(start.source.view, SourceView::Log);
+    assert_eq!(start.source.action, SourceAction::NewRevision);
+}
+
+#[test]
+fn edit_specs_use_edit_family_and_typed_source_action() {
+    let spec = JjCommandSpec::confirm_mutation(["edit", "abc123"], SafetyClass::LocalRewrite);
+    let start =
+        CommandRecordStart::from_spec(&spec, source(SourceView::Log, SourceAction::EditRevision));
+
+    assert_eq!(start.command.command_family, CommandFamily::JjEdit);
+    assert_eq!(start.source.view, SourceView::Log);
+    assert_eq!(start.source.action, SourceAction::EditRevision);
+}
+
+#[test]
+fn operation_specs_use_operation_family_and_typed_source_actions() {
+    let cases = [
+        (
+            JjCommandSpec::render_read_only(["op", "log"]),
+            SourceView::OperationLog,
+            SourceAction::OperationLog,
+        ),
+        (
+            JjCommandSpec::render_read_only(["op", "show", "abc123"]),
+            SourceView::OperationShow,
+            SourceAction::OperationShow,
+        ),
+        (
+            JjCommandSpec::render_read_only(["op", "diff", "--operation", "abc123"]),
+            SourceView::OperationDiff,
+            SourceAction::OperationDiff,
+        ),
+    ];
+
+    for (spec, view, action) in cases {
+        let start = CommandRecordStart::from_spec(&spec, source(view.clone(), action.clone()));
+
+        assert_eq!(start.command.command_family, CommandFamily::JjOperation);
+        assert_eq!(start.source.view, view);
+        assert_eq!(start.source.action, action);
+    }
+}
+
+#[test]
+fn finish_records_duration() {
+    let spec = JjCommandSpec::render_read_only(["diff"]);
+    let mut history = CommandHistory::new(1);
+    let pending = history.start(start_from_spec(
+        &spec,
+        source(SourceView::Diff, SourceAction::OpenDiff),
+    ));
+
+    assert!(history.finish(
+        &pending,
+        CommandRecordFinish::from_exit_code(0, "", "", finish_at()),
+    ));
+
+    assert_eq!(
+        history
+            .records()
+            .next()
+            .and_then(|record| record.timing.duration),
+        Some(Duration::from_millis(42))
+    );
+}
+
+#[test]
+fn spawn_error_has_no_exit_code() {
+    let spec = JjCommandSpec::render_read_only(["log"]);
+    let mut history = CommandHistory::new(1);
+    let pending = history.start(start_from_spec(
+        &spec,
+        source(SourceView::Log, SourceAction::InitialLoad),
+    ));
+
+    assert!(history.finish(
+        &pending,
+        CommandRecordFinish::from_spawn_error("failed to spawn jj", "", "", finish_at()),
+    ));
+
+    let record = first_record(&history);
+    assert_eq!(record.result.exit_status, None);
+    assert_eq!(
+        record.result.spawn_error.as_deref(),
+        Some("failed to spawn jj")
+    );
+}
+
+#[test]
+fn finish_keeps_first_result() {
+    let spec = JjCommandSpec::render_read_only(["status"]);
+    let mut history = CommandHistory::new(1);
+    let pending = history.start(start_from_spec(
+        &spec,
+        source(SourceView::Status, SourceAction::InitialLoad),
+    ));
+
+    assert!(history.finish(
+        &pending,
+        CommandRecordFinish::from_exit_code(0, "first", "", finish_at()),
+    ));
+    assert!(!history.finish(
+        &pending,
+        CommandRecordFinish::from_exit_code(1, "second", "", finish_at()),
+    ));
+
+    let record = first_record(&history);
+    assert_eq!(record.result.exit_status, Some(ExitStatusSummary::code(0)));
+    assert_eq!(record.result.stdout.snippet, "first");
+}
+
+#[test]
+fn finish_applies_record_retention_limits() {
+    let spec = JjCommandSpec::render_read_only(["status"]);
+    let start = start_from_spec(&spec, source(SourceView::Status, SourceAction::InitialLoad))
+        .with_retention(OutputRetention::summary_only(3, 2));
+    let mut history = CommandHistory::new(1);
+    let pending = history.start(start);
+
+    assert!(history.finish(
+        &pending,
+        CommandRecordFinish::from_exit_code(1, "abcdef", "wxyz", finish_at()),
+    ));
+
+    let record = first_record(&history);
+    assert_eq!(record.result.stdout.snippet, "abc");
+    assert!(record.result.stdout.truncated);
+    assert_eq!(record.result.stderr.snippet, "wx");
+    assert!(record.result.stderr.truncated);
+}
+
+#[test]
+fn stream_summary_keeps_counts_and_truncates_on_byte_limit() {
+    let summary = StreamSummary::from_text("alpha\nbeta\ngamma\n", 8);
+
+    assert_eq!(summary.byte_len, 17);
+    assert_eq!(summary.line_count, 3);
+    assert_eq!(summary.snippet, "alpha\nbe");
+    assert!(summary.truncated);
+    assert!(!summary.redacted);
+}
+
+#[test]
+fn stream_summary_redacts_secret_looking_values() {
+    let summary = StreamSummary::from_text(
+        "token=abc123\nnormal=value\nAuthorization: Bearer secret\n",
+        1024,
+    );
+
+    assert_eq!(summary.byte_len, 55);
+    assert_eq!(summary.line_count, 3);
+    assert_eq!(
+        summary.snippet,
+        "token=<redacted>\nnormal=value\nAuthorization:<redacted>\n"
+    );
+    assert!(summary.redacted);
+    assert!(!summary.truncated);
+}
+
+#[test]
+fn stream_summary_does_not_redact_key_as_substring() {
+    let summary = StreamSummary::from_text("monkey=value\napi-key=abc123\n", 1024);
+
+    assert_eq!(summary.snippet, "monkey=value\napi-key=<redacted>\n");
+    assert!(summary.redacted);
+}
+
+#[test]
+fn stream_summary_redaction_handles_non_ascii_graph_prefixes() {
+    let summary = StreamSummary::from_text("│  config.token=abc123\n", 1024);
+
+    assert_eq!(summary.snippet, "│  config.token=<redacted>\n");
+    assert!(summary.redacted);
+}
+
+#[test]
+fn command_identity_redacts_secret_looking_args() {
+    let spec = JjCommandSpec::render_read_only(["log"]).with_global_options(
+        GlobalOptions::default().with_config_overlay(ConfigOverlay::Inline {
+            name_value: "auth.token=abc123".to_owned(),
+        }),
+    );
+
+    let identity = CommandIdentity::from_spec(&spec);
+
+    assert_eq!(
+        strings(&identity.argv),
+        vec![
+            "--no-pager",
+            "--color",
+            "always",
+            "--config",
+            "auth.token=<redacted>",
+            "log"
+        ]
+    );
+}

--- a/crates/jk-core/src/lib.rs
+++ b/crates/jk-core/src/lib.rs
@@ -4,6 +4,21 @@
 //! rendered log body is still owned by `jj`; `jk` only keeps enough structured metadata to move by
 //! change, preserve selection across refresh, and insert inline details at the right rendered line.
 
+mod command;
+mod command_history;
+
+pub use command::{
+    ColorPolicy, CommandPreview, CommandPreviewWarning, ConfigOverlay, ExecutionMode,
+    GlobalOptions, ImmutabilityPolicy, JjCommandSpec, OperationIntegrationPolicy,
+    OperationLoadPolicy, OutputPolicy, PagerPolicy, RefreshPlan, SafetyClass, WorkingCopyPolicy,
+};
+pub use command_history::{
+    CommandExecutionContext, CommandFamily, CommandHistory, CommandIdentity, CommandRecord,
+    CommandRecordFinish, CommandRecordId, CommandRecordStart, CommandResultSummary, CommandSource,
+    CommandTiming, ExitStatusSummary, GlobalOptionsSnapshot, OutputRetention, PendingCommandRecord,
+    SourceAction, SourceView, StreamSummary,
+};
+
 /// A rendered `jj` log view plus semantic records for navigation.
 ///
 /// The `rendered` body is opaque terminal text produced by `jj`. Each [`LogEntry`] in `entries`
@@ -124,6 +139,57 @@ impl DiffSnapshot {
     #[must_use]
     pub fn into_parts(self) -> (String, String, String, Vec<DiffFileStat>) {
         (self.title, self.change_id, self.rendered, self.file_stats)
+    }
+}
+
+/// A rendered read-only `jj` inspection view.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct InspectionSnapshot {
+    title: String,
+    target: String,
+    rendered: String,
+}
+
+impl InspectionSnapshot {
+    /// Creates an inspection snapshot from the target label and rendered terminal text.
+    #[must_use]
+    pub fn new(target: impl Into<String>, rendered: impl Into<String>) -> Self {
+        Self {
+            title: String::new(),
+            target: target.into(),
+            rendered: rendered.into(),
+        }
+    }
+
+    /// Sets the command context shown in the title bar.
+    #[must_use]
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Returns the human-readable command context for the current view.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns the inspected target label.
+    #[must_use]
+    pub fn target(&self) -> &str {
+        &self.target
+    }
+
+    /// Returns the opaque output rendered by `jj`.
+    #[must_use]
+    pub fn rendered(&self) -> &str {
+        &self.rendered
+    }
+
+    /// Consumes the snapshot into its owned title, target, and rendered body.
+    #[must_use]
+    pub fn into_parts(self) -> (String, String, String) {
+        (self.title, self.target, self.rendered)
     }
 }
 

--- a/crates/jk-tui/src/chrome.rs
+++ b/crates/jk-tui/src/chrome.rs
@@ -8,15 +8,8 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::prelude::{Color, Line, Modifier, Span, Style, Text};
 use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 
-/// Default log-view status text shown when there is no transient error.
-pub const LOG_STATUS: &str =
-    "? help  H home  L log  d diff  r refresh  j/k move  space/b page  q quit";
-
-/// Default diff-view status text shown when there is no transient error.
-pub const DIFF_STATUS: &str = "? help  r refresh  j/k line  space/b page  q quit";
-
 /// Renders a small mode-specific help overlay centered in the content area.
-pub fn render_help_overlay(frame: &mut Frame<'_>, area: Rect, title: &str, lines: &[&str]) {
+pub fn render_help_overlay(frame: &mut Frame<'_>, area: Rect, title: &str, lines: &[String]) {
     if area.is_empty() {
         return;
     }
@@ -30,7 +23,7 @@ pub fn render_help_overlay(frame: &mut Frame<'_>, area: Rect, title: &str, lines
             Style::new().add_modifier(Modifier::BOLD),
         )))
         .chain(std::iter::once(Line::from("")))
-        .chain(lines.iter().copied().map(Line::from))
+        .chain(lines.iter().map(|line| Line::from(line.as_str())))
         .collect::<Vec<_>>(),
     );
     let paragraph = Paragraph::new(text)
@@ -118,4 +111,11 @@ pub struct ChromeAreas {
     pub content: Rect,
     title: Rect,
     status: Rect,
+}
+
+impl ChromeAreas {
+    /// Returns the width available to the one-line status row.
+    pub const fn status_width(self) -> u16 {
+        self.status.width
+    }
 }

--- a/crates/jk-tui/src/command_history_view.rs
+++ b/crates/jk-tui/src/command_history_view.rs
@@ -1,0 +1,1136 @@
+//! Provider-neutral command-history list view.
+//!
+//! Callers map retained command records into [`CommandHistorySnapshot`]. The view only owns
+//! selection, scrolling, and rendering for a read-only first history surface.
+
+use std::time::Duration;
+
+use jk_core::{
+    CommandRecord, ExitStatusSummary, InspectionSnapshot, SourceAction, SourceView, StreamSummary,
+};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::prelude::{Color, Line, Modifier, Span, Style, Text};
+use ratatui::widgets::Paragraph;
+
+use crate::ansi_text::strip_ansi;
+use crate::chrome::{ViewChrome, render_help_overlay};
+use crate::keymap::{BindingContext, adaptive_hotbar, help_lines, help_title};
+use crate::selected_row::paint_subtle_selected_row;
+
+const DEFAULT_TITLE: &str = "Command History";
+const DEFAULT_ROW_LIMIT: usize = 128;
+const SUMMARY_LIMIT: usize = 96;
+
+/// A provider-neutral snapshot of retained command history.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CommandHistorySnapshot {
+    title: String,
+    rows: Vec<CommandHistoryRow>,
+}
+
+impl CommandHistorySnapshot {
+    /// Creates a command-history snapshot from display rows.
+    #[must_use]
+    pub fn new(rows: Vec<CommandHistoryRow>) -> Self {
+        Self {
+            title: DEFAULT_TITLE.to_owned(),
+            rows,
+        }
+    }
+
+    /// Creates a newest-first snapshot from retained command records.
+    #[must_use]
+    pub fn from_records<'a>(records: impl DoubleEndedIterator<Item = &'a CommandRecord>) -> Self {
+        Self::new(
+            records
+                .rev()
+                .take(DEFAULT_ROW_LIMIT)
+                .map(CommandHistoryRow::from_record)
+                .collect(),
+        )
+    }
+
+    /// Sets the title shown in the view chrome.
+    #[must_use]
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Returns the title shown in the view chrome.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns rows in display order.
+    #[must_use]
+    pub fn rows(&self) -> &[CommandHistoryRow] {
+        &self.rows
+    }
+}
+
+/// One display row in the command-history list.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandHistoryRow {
+    /// Stable record id from the current in-memory history.
+    pub id: u64,
+    /// Stable operation id reported by `jj`, when available for this command.
+    pub operation_id: Option<String>,
+    /// Compact status marker.
+    pub status: String,
+    /// Source view and action that triggered the command.
+    pub source: String,
+    /// Command title or preview.
+    pub command: String,
+    /// Exact redacted process command line suitable for copying.
+    pub command_line: String,
+    /// Compact output or failure summary.
+    pub summary: String,
+    /// Full retained details for the command-history details view.
+    pub details: CommandHistoryDetails,
+}
+
+impl CommandHistoryRow {
+    /// Creates a display row.
+    #[must_use]
+    pub fn new(
+        id: u64,
+        status: impl Into<String>,
+        source: impl Into<String>,
+        command: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Self {
+        let command = command.into();
+        let summary = summary.into();
+        Self {
+            id,
+            operation_id: None,
+            status: status.into(),
+            source: source.into(),
+            command: command.clone(),
+            command_line: String::new(),
+            summary: summary.clone(),
+            details: CommandHistoryDetails::from_display_parts(id, command, String::new(), summary),
+        }
+    }
+
+    /// Attaches the operation id reported by `jj`, when available.
+    #[must_use]
+    pub fn with_operation_id(mut self, operation_id: Option<String>) -> Self {
+        self.operation_id = operation_id;
+        self
+    }
+
+    /// Attaches the exact command line represented by this row.
+    #[must_use]
+    pub fn with_command_line(mut self, command_line: impl Into<String>) -> Self {
+        self.command_line = command_line.into();
+        self.details.command_line = self.command_line.clone();
+        self
+    }
+
+    /// Maps a retained command record into a display row.
+    #[must_use]
+    pub fn from_record(record: &CommandRecord) -> Self {
+        Self::new(
+            record.id.get(),
+            status_marker(record),
+            source_label(record.source.view.clone(), record.source.action.clone()),
+            command_label(record),
+            result_summary(record),
+        )
+        .with_command_line(record.command.process_preview())
+        .with_details(CommandHistoryDetails::from_record(record))
+        .with_operation_id(record.operation_id.clone())
+    }
+
+    /// Attaches retained command details for the details view.
+    #[must_use]
+    pub fn with_details(mut self, details: CommandHistoryDetails) -> Self {
+        self.details = details;
+        self
+    }
+}
+
+/// Retained display details for one command-history row.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandHistoryDetails {
+    record_id: u64,
+    title: String,
+    source: String,
+    status: String,
+    command_line: String,
+    summary: String,
+    operation_id: Option<String>,
+    duration: Option<Duration>,
+    exit_status: Option<ExitStatusSummary>,
+    spawn_error: Option<String>,
+    stdout: StreamSummary,
+    stderr: StreamSummary,
+}
+
+impl CommandHistoryDetails {
+    fn from_display_parts(
+        record_id: u64,
+        title: impl Into<String>,
+        command_line: impl Into<String>,
+        summary: impl Into<String>,
+    ) -> Self {
+        Self {
+            record_id,
+            title: title.into(),
+            source: String::new(),
+            status: String::new(),
+            command_line: command_line.into(),
+            summary: summary.into(),
+            operation_id: None,
+            duration: None,
+            exit_status: None,
+            spawn_error: None,
+            stdout: StreamSummary::empty(),
+            stderr: StreamSummary::empty(),
+        }
+    }
+
+    fn from_record(record: &CommandRecord) -> Self {
+        Self {
+            record_id: record.id.get(),
+            title: command_label(record),
+            source: source_label(record.source.view.clone(), record.source.action.clone()),
+            status: status_marker(record).to_owned(),
+            command_line: record.command.process_preview(),
+            summary: result_summary(record),
+            operation_id: record.operation_id.clone(),
+            duration: record.timing.duration,
+            exit_status: record.result.exit_status,
+            spawn_error: record.result.spawn_error.clone(),
+            stdout: record.result.stdout.clone(),
+            stderr: record.result.stderr.clone(),
+        }
+    }
+
+    /// Converts retained details into a read-only rendered snapshot.
+    #[must_use]
+    pub fn into_snapshot(self) -> InspectionSnapshot {
+        let target = format!("command {}", self.record_id);
+        InspectionSnapshot::new(target, self.rendered())
+            .with_title(format!("Command {}", self.record_id))
+    }
+
+    fn rendered(&self) -> String {
+        let mut rendered = String::new();
+        push_field(
+            &mut rendered,
+            "Command",
+            command_or_title(&self.command_line, &self.title),
+        );
+        push_field(&mut rendered, "Source", fallback(&self.source, "unknown"));
+        push_field(&mut rendered, "Status", self.status_label());
+        push_field(&mut rendered, "Duration", duration_label(self.duration));
+        push_field(
+            &mut rendered,
+            "Operation",
+            self.operation_id.as_deref().unwrap_or("none"),
+        );
+        if !self.summary.is_empty() {
+            push_field(&mut rendered, "Summary", &self.summary);
+        }
+        if let Some(error) = &self.spawn_error {
+            push_section(&mut rendered, "Spawn error", error);
+        }
+        push_stream_section(&mut rendered, "Stdout", &self.stdout);
+        push_stream_section(&mut rendered, "Stderr", &self.stderr);
+        rendered
+    }
+
+    fn status_label(&self) -> String {
+        if let Some(status) = self.exit_status {
+            if status.success {
+                return "success".to_owned();
+            }
+            if let Some(code) = status.code {
+                return format!("exit {code}");
+            }
+            if let Some(signal) = status.signal {
+                return format!("signal {signal}");
+            }
+            return "failed".to_owned();
+        }
+        if self.spawn_error.is_some() {
+            return "spawn error".to_owned();
+        }
+        fallback(&self.status, "running").to_owned()
+    }
+}
+
+/// The effect requested after applying an input action to the history view.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+#[allow(clippy::large_enum_variant)]
+pub enum CommandHistoryActionResult {
+    /// Continue running the application.
+    Continue,
+    /// Rebuild the snapshot from current in-memory history.
+    Refresh,
+    /// Open the recorded operation for the selected command.
+    OpenOperation {
+        /// Stable operation id selected for `jj op show` or an equivalent operation route.
+        operation_id: String,
+    },
+    /// Open the operation log fallback when the selected command has no operation id.
+    OpenOperationLog,
+    /// Open retained details for the selected command.
+    OpenDetails {
+        /// Details snapshot for a selected command record.
+        details: CommandHistoryDetails,
+    },
+    /// Copy the selected command line.
+    CopyCommand {
+        /// Exact redacted process command line selected for copying.
+        command_line: String,
+    },
+    /// Return to the previous view.
+    ReturnBack,
+    /// Exit the application.
+    Quit,
+}
+
+/// Input actions understood by the command-history view.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum CommandHistoryAction {
+    /// Move to the previous command record.
+    Previous,
+    /// Move to the next command record.
+    Next,
+    /// Page toward older command records.
+    PageNext,
+    /// Page toward newer command records.
+    PagePrevious,
+    /// Move to the newest command record.
+    First,
+    /// Move to the oldest visible command record.
+    Last,
+    /// Refresh the snapshot from the current history.
+    Refresh,
+    /// Open the recorded operation, or the operation log fallback when no id is available.
+    OpenOperation,
+    /// Open retained details for the selected command.
+    OpenDetails,
+    /// Copy the selected command line.
+    CopyCommand,
+    /// Toggle mode-specific help.
+    ToggleHelp,
+    /// Return to the previous view.
+    ReturnBack,
+    /// Quit the TUI.
+    Quit,
+}
+
+/// Interactive read-only command-history list.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CommandHistoryView {
+    snapshot: CommandHistorySnapshot,
+    selected: Option<usize>,
+    scroll_offset: usize,
+    help_visible: bool,
+    status_message: Option<String>,
+}
+
+impl CommandHistoryView {
+    /// Creates a command-history view with the initial snapshot loaded.
+    #[must_use]
+    pub fn new(snapshot: CommandHistorySnapshot) -> Self {
+        let selected = clamp_index(Some(0), snapshot.rows.len());
+        Self {
+            snapshot,
+            selected,
+            scroll_offset: 0,
+            help_visible: false,
+            status_message: None,
+        }
+    }
+
+    /// Creates a command-history view focused on the newest row with a recorded operation id.
+    ///
+    /// Confirmed mutations are often followed by automatic refresh records. Focusing the newest
+    /// operation row keeps the immediate recovery route on the mutation instead of the refresh.
+    #[must_use]
+    pub fn new_focused_on_latest_operation(snapshot: CommandHistorySnapshot) -> Self {
+        let mut view = Self::new(snapshot);
+        if let Some(index) = view
+            .snapshot
+            .rows
+            .iter()
+            .position(|row| row.operation_id.is_some())
+        {
+            view.selected = Some(index);
+            view.scroll_offset = index;
+        }
+        view
+    }
+
+    /// Replaces rows after a refresh.
+    pub fn refresh(&mut self, snapshot: CommandHistorySnapshot) {
+        let previous_selected = self.selected;
+        self.snapshot = snapshot;
+        self.selected = clamp_index(previous_selected.or(Some(0)), self.snapshot.rows.len());
+        self.scroll_offset = clamp_scroll(self.scroll_offset, self.snapshot.rows.len());
+        self.status_message = None;
+    }
+
+    /// Returns the selected row, if any.
+    #[must_use]
+    pub fn selected_row(&self) -> Option<&CommandHistoryRow> {
+        self.selected
+            .and_then(|index| self.snapshot.rows.get(index))
+    }
+
+    /// Shows a temporary status message in the command-history footer.
+    pub fn show_status(&mut self, message: impl Into<String>) {
+        self.status_message = Some(message.into());
+    }
+
+    /// Applies a single input action.
+    #[must_use]
+    pub fn apply(&mut self, action: CommandHistoryAction) -> CommandHistoryActionResult {
+        match action {
+            CommandHistoryAction::Previous => {
+                self.select_previous();
+                CommandHistoryActionResult::Continue
+            }
+            CommandHistoryAction::Next => {
+                self.select_next();
+                CommandHistoryActionResult::Continue
+            }
+            CommandHistoryAction::PagePrevious => {
+                self.page_previous();
+                CommandHistoryActionResult::Continue
+            }
+            CommandHistoryAction::PageNext => {
+                self.page_next();
+                CommandHistoryActionResult::Continue
+            }
+            CommandHistoryAction::First => {
+                if !self.snapshot.rows.is_empty() {
+                    self.selected = Some(0);
+                }
+                CommandHistoryActionResult::Continue
+            }
+            CommandHistoryAction::Last => {
+                if !self.snapshot.rows.is_empty() {
+                    self.selected = Some(self.snapshot.rows.len() - 1);
+                }
+                CommandHistoryActionResult::Continue
+            }
+            CommandHistoryAction::Refresh => CommandHistoryActionResult::Refresh,
+            CommandHistoryAction::OpenOperation => {
+                self.selected_row()
+                    .map_or(CommandHistoryActionResult::Continue, |row| {
+                        row.operation_id.as_ref().map_or(
+                            CommandHistoryActionResult::OpenOperationLog,
+                            |operation_id| CommandHistoryActionResult::OpenOperation {
+                                operation_id: operation_id.clone(),
+                            },
+                        )
+                    })
+            }
+            CommandHistoryAction::OpenDetails => {
+                self.selected_row()
+                    .map_or(CommandHistoryActionResult::Continue, |row| {
+                        CommandHistoryActionResult::OpenDetails {
+                            details: row.details.clone(),
+                        }
+                    })
+            }
+            CommandHistoryAction::CopyCommand => self
+                .selected_row()
+                .and_then(|row| {
+                    if row.command_line.is_empty() {
+                        None
+                    } else {
+                        Some(CommandHistoryActionResult::CopyCommand {
+                            command_line: row.command_line.clone(),
+                        })
+                    }
+                })
+                .unwrap_or(CommandHistoryActionResult::Continue),
+            CommandHistoryAction::ToggleHelp => {
+                self.help_visible = !self.help_visible;
+                CommandHistoryActionResult::Continue
+            }
+            CommandHistoryAction::ReturnBack => CommandHistoryActionResult::ReturnBack,
+            CommandHistoryAction::Quit if self.help_visible => {
+                self.help_visible = false;
+                CommandHistoryActionResult::Continue
+            }
+            CommandHistoryAction::Quit => CommandHistoryActionResult::Quit,
+        }
+    }
+
+    /// Renders the command-history view.
+    pub fn render(&mut self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        self.render_area(frame, area, None);
+    }
+
+    /// Renders the command-history view with a temporary status-line override.
+    pub fn render_with_status(&mut self, frame: &mut Frame<'_>, status: &str) {
+        let area = frame.area();
+        self.render_area(frame, area, Some(status));
+    }
+
+    const fn select_previous(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        self.selected = Some(selected.saturating_sub(1));
+    }
+
+    fn select_next(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        let last = self.snapshot.rows.len().saturating_sub(1);
+        self.selected = Some(selected.saturating_add(1).min(last));
+    }
+
+    const fn page_previous(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        self.selected = Some(selected.saturating_sub(10));
+    }
+
+    fn page_next(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        let last = self.snapshot.rows.len().saturating_sub(1);
+        self.selected = Some(selected.saturating_add(10).min(last));
+    }
+
+    fn keep_selected_in_view(&mut self, height: usize) {
+        self.scroll_offset = clamp_scroll(self.scroll_offset, self.snapshot.rows.len());
+        let Some(selected) = self.selected else {
+            return;
+        };
+        if height == 0 {
+            return;
+        }
+        if selected < self.scroll_offset {
+            self.scroll_offset = selected;
+        } else if selected >= self.scroll_offset.saturating_add(height) {
+            self.scroll_offset = selected.saturating_add(1).saturating_sub(height);
+        }
+    }
+
+    fn render_area(&mut self, frame: &mut Frame<'_>, area: Rect, status_override: Option<&str>) {
+        let areas = ViewChrome::layout(area);
+        self.keep_selected_in_view(usize::from(areas.content.height));
+
+        let fallback_status = adaptive_hotbar(BindingContext::CommandHistory, areas.status_width());
+        let status = self
+            .status_message
+            .as_deref()
+            .or(status_override)
+            .unwrap_or(&fallback_status);
+        let chrome = ViewChrome::new(self.snapshot.title(), status);
+        chrome.render(frame, areas);
+
+        let paragraph = Paragraph::new(self.visible_text());
+        frame.render_widget(paragraph, areas.content);
+
+        if let Some(selected) = self.selected {
+            paint_subtle_selected_row(frame, areas.content, selected, self.scroll_offset);
+        }
+
+        if self.help_visible {
+            render_help_overlay(
+                frame,
+                areas.content,
+                help_title(BindingContext::CommandHistory),
+                &help_lines(BindingContext::CommandHistory),
+            );
+        }
+    }
+
+    fn visible_text(&self) -> Text<'_> {
+        if self.snapshot.rows.is_empty() {
+            return Text::from(vec![
+                Line::from(Span::styled(
+                    "No command history yet.",
+                    Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                )),
+                Line::from(""),
+                Line::from("Commands run by jk will appear here."),
+            ]);
+        }
+
+        let rows = self
+            .snapshot
+            .rows
+            .iter()
+            .skip(self.scroll_offset)
+            .map(history_line)
+            .collect::<Vec<_>>();
+        Text::from(rows)
+    }
+}
+
+fn history_line(row: &CommandHistoryRow) -> Line<'_> {
+    Line::from(vec![
+        Span::styled(
+            format!("{:<4}", row.status),
+            Style::new().fg(status_color(&row.status)),
+        ),
+        Span::raw(" "),
+        Span::styled(format!("{:<22}", row.source), Style::new().fg(Color::Cyan)),
+        Span::raw(" "),
+        Span::styled(&row.command, Style::new().add_modifier(Modifier::BOLD)),
+        Span::raw(summary_suffix(&row.summary)),
+    ])
+}
+
+fn status_color(status: &str) -> Color {
+    match status {
+        "ok" => Color::Green,
+        "fail" | "err" => Color::Red,
+        _ => Color::Yellow,
+    }
+}
+
+const fn status_marker(record: &CommandRecord) -> &'static str {
+    if record.result.spawn_error.is_some() {
+        return "err";
+    }
+    match record.result.exit_status {
+        Some(status) if status.success => "ok",
+        Some(_) => "fail",
+        None => "run",
+    }
+}
+
+fn source_label(view: SourceView, action: SourceAction) -> String {
+    format!("{} {}", view_label(view), action_label(action))
+}
+
+fn view_label(view: SourceView) -> String {
+    match view {
+        SourceView::Log => "log".to_owned(),
+        SourceView::Diff => "diff".to_owned(),
+        SourceView::Show => "show".to_owned(),
+        SourceView::Status => "status".to_owned(),
+        SourceView::Evolog => "evolog".to_owned(),
+        SourceView::Workspaces => "workspaces".to_owned(),
+        SourceView::WorkspaceLog => "workspace log".to_owned(),
+        SourceView::WorkspaceStatus => "workspace status".to_owned(),
+        SourceView::WorkspaceDiff => "workspace diff".to_owned(),
+        SourceView::CommandHistory => "history".to_owned(),
+        SourceView::OperationLog => "operation log".to_owned(),
+        SourceView::OperationShow => "operation show".to_owned(),
+        SourceView::OperationDiff => "operation diff".to_owned(),
+        SourceView::Other(label) => label,
+        _ => "unknown".to_owned(),
+    }
+}
+
+fn action_label(action: SourceAction) -> String {
+    match action {
+        SourceAction::InitialLoad => "load".to_owned(),
+        SourceAction::Refresh => "refresh".to_owned(),
+        SourceAction::OpenDiff | SourceAction::WorkspaceDiff => "diff".to_owned(),
+        SourceAction::OpenShow => "show".to_owned(),
+        SourceAction::OpenStatus | SourceAction::WorkspaceStatus => "status".to_owned(),
+        SourceAction::OpenEvolog => "evolog".to_owned(),
+        SourceAction::DescribeRevision => "describe".to_owned(),
+        SourceAction::WorkspaceList => "list".to_owned(),
+        SourceAction::WorkspaceLog => "log".to_owned(),
+        SourceAction::WorkspaceUpdateStale => "update-stale".to_owned(),
+        SourceAction::OperationLog => "op log".to_owned(),
+        SourceAction::OperationShow => "op show".to_owned(),
+        SourceAction::OperationDiff => "op diff".to_owned(),
+        SourceAction::Undo => "undo".to_owned(),
+        SourceAction::Redo => "redo".to_owned(),
+        SourceAction::UserJjCommand => "command".to_owned(),
+        SourceAction::Other(label) => label,
+        _ => "unknown".to_owned(),
+    }
+}
+
+fn command_label(record: &CommandRecord) -> String {
+    if record.command.title.is_empty() {
+        record.command.spec_preview.clone()
+    } else {
+        record.command.title.clone()
+    }
+}
+
+fn result_summary(record: &CommandRecord) -> String {
+    if let Some(error) = &record.result.spawn_error {
+        return compact(format!("error: {error}"));
+    }
+    if let Some(status) = record.result.exit_status
+        && !status.success
+    {
+        let status = exit_label(status.code, status.signal);
+        if let Some(output) =
+            stream_snippet(&record.result.stderr).or_else(|| stream_snippet(&record.result.stdout))
+        {
+            return compact(format!("{status}: {output}"));
+        }
+        return status;
+    }
+    if let Some(stderr) = stream_snippet(&record.result.stderr) {
+        return compact(format!("stderr: {stderr}"));
+    }
+    if let Some(stdout) = stream_snippet(&record.result.stdout) {
+        return compact(stdout);
+    }
+    String::new()
+}
+
+fn exit_label(code: Option<i32>, signal: Option<i32>) -> String {
+    code.map_or_else(
+        || signal.map_or_else(|| "failed".to_owned(), |signal| format!("signal {signal}")),
+        |code| format!("exit {code}"),
+    )
+}
+
+fn stream_snippet(stream: &StreamSummary) -> Option<String> {
+    if stream.snippet.trim().is_empty() {
+        return None;
+    }
+    let plain = strip_ansi(&stream.snippet);
+    Some(plain.lines().next().unwrap_or("").trim().to_owned())
+}
+
+fn summary_suffix(summary: &str) -> String {
+    if summary.is_empty() {
+        String::new()
+    } else {
+        format!("  {summary}")
+    }
+}
+
+fn compact(text: impl AsRef<str>) -> String {
+    let text = text.as_ref().trim();
+    if text.chars().count() <= SUMMARY_LIMIT {
+        return text.to_owned();
+    }
+
+    let mut truncated = text.chars().take(SUMMARY_LIMIT - 3).collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+fn push_field(rendered: &mut String, label: &str, value: impl AsRef<str>) {
+    rendered.push_str(label);
+    rendered.push_str(": ");
+    rendered.push_str(value.as_ref());
+    rendered.push('\n');
+}
+
+fn push_section(rendered: &mut String, label: &str, body: &str) {
+    rendered.push('\n');
+    rendered.push_str(label);
+    rendered.push_str(":\n");
+    rendered.push_str(body);
+    if !body.ends_with('\n') {
+        rendered.push('\n');
+    }
+}
+
+fn push_stream_section(rendered: &mut String, label: &str, stream: &StreamSummary) {
+    rendered.push('\n');
+    rendered.push_str(label);
+    rendered.push_str(":\n");
+    push_field(rendered, "  bytes", stream.byte_len.to_string());
+    push_field(rendered, "  lines", stream.line_count.to_string());
+    push_field(rendered, "  truncated", bool_label(stream.truncated));
+    push_field(rendered, "  redacted", bool_label(stream.redacted));
+
+    if stream.snippet.is_empty() {
+        rendered.push_str("  <empty>\n");
+        return;
+    }
+
+    rendered.push('\n');
+    rendered.push_str(&stream.snippet);
+    if !stream.snippet.ends_with('\n') {
+        rendered.push('\n');
+    }
+}
+
+const fn command_or_title<'a>(command_line: &'a str, title: &'a str) -> &'a str {
+    if command_line.is_empty() {
+        title
+    } else {
+        command_line
+    }
+}
+
+const fn fallback<'a>(value: &'a str, fallback: &'a str) -> &'a str {
+    if value.is_empty() { fallback } else { value }
+}
+
+fn duration_label(duration: Option<Duration>) -> String {
+    duration.map_or_else(
+        || "unknown".to_owned(),
+        |duration| {
+            let millis = duration.as_millis();
+            if millis == 0 {
+                format!("{} us", duration.as_micros())
+            } else {
+                format!("{millis} ms")
+            }
+        },
+    )
+}
+
+const fn bool_label(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}
+
+fn clamp_index(index: Option<usize>, len: usize) -> Option<usize> {
+    let index = index?;
+    if len == 0 {
+        None
+    } else {
+        Some(index.min(len - 1))
+    }
+}
+
+fn clamp_scroll(scroll_offset: usize, len: usize) -> usize {
+    if len == 0 {
+        0
+    } else {
+        scroll_offset.min(len - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::too_many_arguments)]
+
+    use std::time::{Duration, SystemTime};
+
+    use jk_core::{CommandRecordFinish, CommandRecordStart, JjCommandSpec};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+
+    #[test]
+    fn snapshot_maps_records_newest_first() {
+        let snapshot = CommandHistorySnapshot::from_records(history_with_records().records());
+
+        assert_eq!(
+            snapshot
+                .rows()
+                .iter()
+                .map(|row| row.command.as_str())
+                .collect::<Vec<_>>(),
+            vec!["jj status", "jj log"]
+        );
+        assert_eq!(snapshot.rows()[0].status, "fail");
+        assert_eq!(snapshot.rows()[0].source, "log status");
+        assert_eq!(snapshot.rows()[0].summary, "exit 1: workspace is stale");
+        assert_eq!(
+            snapshot.rows()[0].command_line,
+            "jj --no-pager --color always status"
+        );
+        assert_eq!(
+            snapshot.rows()[0].operation_id.as_deref(),
+            Some("op-status")
+        );
+        assert_eq!(snapshot.rows()[1].operation_id, None);
+    }
+
+    #[test]
+    fn actions_move_and_request_back_refresh_or_quit() {
+        let mut view = CommandHistoryView::new(CommandHistorySnapshot::new(vec![
+            CommandHistoryRow::new(1, "ok", "log load", "jj log", ""),
+            CommandHistoryRow::new(2, "fail", "log status", "jj status", "exit 1"),
+        ]));
+
+        assert_eq!(view.selected_row().map(|row| row.id), Some(1));
+        assert_eq!(
+            view.apply(CommandHistoryAction::Next),
+            CommandHistoryActionResult::Continue
+        );
+        assert_eq!(view.selected_row().map(|row| row.id), Some(2));
+        assert_eq!(
+            view.apply(CommandHistoryAction::Previous),
+            CommandHistoryActionResult::Continue
+        );
+        assert_eq!(view.selected_row().map(|row| row.id), Some(1));
+        assert_eq!(
+            view.apply(CommandHistoryAction::Refresh),
+            CommandHistoryActionResult::Refresh
+        );
+        assert_eq!(
+            view.apply(CommandHistoryAction::ReturnBack),
+            CommandHistoryActionResult::ReturnBack
+        );
+        assert_eq!(
+            view.apply(CommandHistoryAction::Quit),
+            CommandHistoryActionResult::Quit
+        );
+    }
+
+    #[test]
+    fn focused_constructor_selects_newest_operation_row() {
+        let view =
+            CommandHistoryView::new_focused_on_latest_operation(CommandHistorySnapshot::new(vec![
+                CommandHistoryRow::new(3, "ok", "log refresh", "jj log", ""),
+                CommandHistoryRow::new(2, "ok", "log describe", "jj describe @", "")
+                    .with_operation_id(Some("op2".to_owned())),
+                CommandHistoryRow::new(1, "ok", "log load", "jj log", "")
+                    .with_operation_id(Some("op1".to_owned())),
+            ]));
+
+        assert_eq!(view.selected_row().map(|row| row.id), Some(2));
+    }
+
+    #[test]
+    fn focused_constructor_keeps_newest_row_without_operation_ids() {
+        let view =
+            CommandHistoryView::new_focused_on_latest_operation(CommandHistorySnapshot::new(vec![
+                CommandHistoryRow::new(2, "ok", "log refresh", "jj log", ""),
+                CommandHistoryRow::new(1, "ok", "log load", "jj log", ""),
+            ]));
+
+        assert_eq!(view.selected_row().map(|row| row.id), Some(2));
+    }
+
+    #[test]
+    fn open_operation_result_carries_selected_operation_id() {
+        let mut view = CommandHistoryView::new(CommandHistorySnapshot::new(vec![
+            CommandHistoryRow::new(1, "ok", "log load", "jj log", "")
+                .with_operation_id(Some("op-log".to_owned())),
+        ]));
+
+        assert_eq!(
+            view.apply(CommandHistoryAction::OpenOperation),
+            CommandHistoryActionResult::OpenOperation {
+                operation_id: "op-log".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn open_operation_falls_back_to_operation_log_without_id() {
+        let mut view =
+            CommandHistoryView::new(CommandHistorySnapshot::new(vec![CommandHistoryRow::new(
+                1, "ok", "log load", "jj log", "",
+            )]));
+
+        assert_eq!(
+            view.apply(CommandHistoryAction::OpenOperation),
+            CommandHistoryActionResult::OpenOperationLog
+        );
+    }
+
+    #[test]
+    fn open_operation_without_selected_row_is_noop() {
+        let mut view = CommandHistoryView::new(CommandHistorySnapshot::new(Vec::new()));
+
+        assert_eq!(
+            view.apply(CommandHistoryAction::OpenOperation),
+            CommandHistoryActionResult::Continue
+        );
+    }
+
+    #[test]
+    fn copy_command_result_carries_selected_command_line() {
+        let mut view = CommandHistoryView::new(CommandHistorySnapshot::new(vec![
+            CommandHistoryRow::new(1, "ok", "log load", "jj log", "")
+                .with_command_line("jj --no-pager --color always log"),
+        ]));
+
+        assert_eq!(
+            view.apply(CommandHistoryAction::CopyCommand),
+            CommandHistoryActionResult::CopyCommand {
+                command_line: "jj --no-pager --color always log".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn open_details_result_carries_selected_details() {
+        let snapshot = CommandHistorySnapshot::from_records(history_with_records().records());
+        let mut view = CommandHistoryView::new(snapshot);
+
+        let CommandHistoryActionResult::OpenDetails { details } =
+            view.apply(CommandHistoryAction::OpenDetails)
+        else {
+            panic!("expected details result");
+        };
+        let details = details.into_snapshot();
+
+        assert_eq!(details.title(), "Command 2");
+        assert_eq!(details.target(), "command 2");
+        assert!(
+            details
+                .rendered()
+                .contains("Command: jj --no-pager --color always status")
+        );
+        assert!(details.rendered().contains("Source: log status"));
+        assert!(details.rendered().contains("Status: exit 1"));
+        assert!(details.rendered().contains("Duration: 1 ms"));
+        assert!(details.rendered().contains("Operation: op-status"));
+        assert!(
+            details
+                .rendered()
+                .contains("Summary: exit 1: workspace is stale")
+        );
+        assert!(details.rendered().contains("Stdout:"));
+        assert!(details.rendered().contains("<empty>"));
+        assert!(details.rendered().contains("Stderr:"));
+        assert!(details.rendered().contains("workspace is stale"));
+    }
+
+    #[test]
+    fn basic_render_contains_title_status_source_command_and_summary() {
+        let mut view = CommandHistoryView::new(CommandHistorySnapshot::from_records(
+            history_with_records().records(),
+        ));
+        let backend = TestBackend::new(96, 6);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("jk Command History"));
+        assert!(rendered.contains("fail log status"));
+        assert!(rendered.contains("jj status"));
+        assert!(rendered.contains("exit 1: workspace is stale"));
+        assert!(rendered.contains("ok   log load"));
+        assert!(rendered.contains("jj log"));
+        assert!(rendered.contains("Esc back"));
+    }
+
+    #[test]
+    fn render_with_status_shows_copy_feedback() {
+        let mut view =
+            CommandHistoryView::new(CommandHistorySnapshot::new(vec![CommandHistoryRow::new(
+                1, "ok", "log load", "jj log", "",
+            )]));
+        view.show_status("copied command");
+        let backend = TestBackend::new(72, 4);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("copied command"));
+    }
+
+    #[test]
+    fn empty_render_explains_history_is_empty() {
+        let mut view = CommandHistoryView::new(CommandHistorySnapshot::new(Vec::new()));
+        let backend = TestBackend::new(72, 6);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("No command history yet."));
+        assert!(rendered.contains("Commands run by jk will appear here."));
+    }
+
+    #[test]
+    fn snapshot_strips_ansi_from_output_summary() {
+        let mut history = jk_core::CommandHistory::new(8);
+        append_record(
+            &mut history,
+            &JjCommandSpec::render_read_only(["log"]),
+            SourceView::Log,
+            SourceAction::InitialLoad,
+            0,
+            "\u{1b}[1m\u{1b}[38;5;2m@\u{1b}[0m current\n",
+            "",
+            None,
+        );
+
+        let snapshot = CommandHistorySnapshot::from_records(history.records());
+
+        assert_eq!(snapshot.rows()[0].summary, "@ current");
+    }
+
+    fn history_with_records() -> jk_core::CommandHistory {
+        let mut history = jk_core::CommandHistory::new(8);
+        append_record(
+            &mut history,
+            &JjCommandSpec::render_read_only(["log"]),
+            SourceView::Log,
+            SourceAction::InitialLoad,
+            0,
+            "log output\n",
+            "",
+            None,
+        );
+        append_record(
+            &mut history,
+            &JjCommandSpec::render_read_only(["status"]),
+            SourceView::Log,
+            SourceAction::OpenStatus,
+            1,
+            "",
+            "workspace is stale\nmore detail\n",
+            Some("op-status"),
+        );
+        history
+    }
+
+    fn append_record(
+        history: &mut jk_core::CommandHistory,
+        spec: &JjCommandSpec,
+        view: SourceView,
+        action: SourceAction,
+        code: i32,
+        stdout: &str,
+        stderr: &str,
+        operation_id: Option<&str>,
+    ) {
+        let start = CommandRecordStart::from_spec(spec, jk_core::CommandSource::new(view, action))
+            .with_started_at(SystemTime::UNIX_EPOCH);
+        let mut finish = CommandRecordFinish::from_exit_code(
+            code,
+            stdout,
+            stderr,
+            SystemTime::UNIX_EPOCH + Duration::from_millis(1),
+        );
+        finish.operation_id = operation_id.map(str::to_owned);
+        history.append(start, finish);
+    }
+
+    fn buffer_to_string(buffer: &ratatui::buffer::Buffer) -> String {
+        let area = buffer.area;
+        let mut text = String::new();
+
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
+
+        text
+    }
+}

--- a/crates/jk-tui/src/command_preview_view.rs
+++ b/crates/jk-tui/src/command_preview_view.rs
@@ -1,0 +1,368 @@
+//! Draw-only confirmation preview for commands that may mutate state.
+//!
+//! This view renders [`jk_core::CommandPreview`] data and intentionally owns no execution behavior.
+
+use jk_core::{CommandPreview, CommandPreviewWarning, ExecutionMode, RefreshPlan, SafetyClass};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::prelude::{Color, Line, Modifier, Span, Style, Text};
+use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
+
+const PANEL_WIDTH: u16 = 78;
+const MIN_PANEL_HEIGHT: u16 = 8;
+
+/// A compact confirmation view for a pending command.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandPreviewView {
+    preview: CommandPreview,
+    status: Option<String>,
+}
+
+impl CommandPreviewView {
+    /// Creates a view for a pending command preview.
+    #[must_use]
+    pub const fn new(preview: CommandPreview) -> Self {
+        Self {
+            preview,
+            status: None,
+        }
+    }
+
+    /// Returns the preview being rendered.
+    #[must_use]
+    pub const fn preview(&self) -> &CommandPreview {
+        &self.preview
+    }
+
+    /// Sets a temporary footer status message.
+    #[must_use]
+    pub fn with_status(mut self, status: Option<String>) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Renders the command preview without executing anything.
+    pub fn render(&self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        if area.is_empty() {
+            return;
+        }
+
+        let text = self.body_text();
+        let panel_width = PANEL_WIDTH.min(area.width);
+        let content_width = panel_width.saturating_sub(2).max(1);
+        let panel = centered_panel(area, panel_height(&text, content_width).saturating_add(3));
+        frame.render_widget(Clear, panel);
+
+        let block = Block::bordered()
+            .title(" Confirm command ")
+            .style(Style::new().fg(Color::White).bg(Color::Black));
+        let inner = block.inner(panel);
+        frame.render_widget(block, panel);
+        if inner.is_empty() {
+            return;
+        }
+
+        let footer_area = Rect {
+            x: inner.x,
+            y: inner.y + inner.height.saturating_sub(1),
+            width: inner.width,
+            height: 1,
+        };
+        let body_area = Rect {
+            x: inner.x,
+            y: inner.y,
+            width: inner.width,
+            height: inner.height.saturating_sub(1),
+        };
+
+        if !body_area.is_empty() {
+            let paragraph = Paragraph::new(text)
+                .style(Style::new().fg(Color::White).bg(Color::Black))
+                .wrap(Wrap { trim: false });
+            frame.render_widget(paragraph, body_area);
+        }
+        frame.render_widget(
+            Paragraph::new(footer_line(self.status.as_deref()))
+                .style(Style::new().fg(Color::White).bg(Color::Black)),
+            footer_area,
+        );
+    }
+
+    fn body_text(&self) -> Text<'_> {
+        let mut lines = vec![
+            Line::from(Span::styled(
+                self.preview.title.as_str(),
+                Style::new().add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Command",
+                Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled(
+                self.preview.command_line.as_str(),
+                Style::new().fg(Color::Yellow),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Summary",
+                Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(format!("Safety: {}", safety_label(self.preview.safety))),
+            Line::from(format!(
+                "Execution: {}",
+                execution_label(self.preview.execution_mode)
+            )),
+            Line::from(format!(
+                "Refresh: {}",
+                refresh_label(self.preview.refresh_plan)
+            )),
+        ];
+
+        lines.push(Line::from(""));
+        if self.preview.warnings.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "No warnings for this command.",
+                Style::new().fg(Color::Green),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "Warnings",
+                Style::new().fg(Color::Red).add_modifier(Modifier::BOLD),
+            )));
+            lines.extend(self.preview.warnings.iter().map(warning_line));
+        }
+
+        Text::from(lines)
+    }
+}
+
+fn footer_line(status: Option<&str>) -> Line<'static> {
+    if let Some(status) = status {
+        return Line::from(vec![
+            Span::styled(
+                status.to_owned(),
+                Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("    "),
+            Span::styled("enter run", Style::new().fg(Color::Green)),
+            Span::raw("    "),
+            Span::styled("esc cancel", Style::new().fg(Color::Red)),
+        ]);
+    }
+
+    Line::from(vec![
+        Span::styled(
+            "enter run",
+            Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("    "),
+        Span::styled(
+            "y copy",
+            Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("    "),
+        Span::styled(
+            "esc cancel",
+            Style::new().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ),
+    ])
+}
+
+fn warning_line(warning: &CommandPreviewWarning) -> Line<'_> {
+    Line::from(vec![
+        Span::styled("! ", Style::new().fg(Color::Red)),
+        Span::raw(warning_label(warning)),
+    ])
+}
+
+const fn safety_label(safety: SafetyClass) -> &'static str {
+    match safety {
+        SafetyClass::ReadOnly => "read-only",
+        SafetyClass::LocalMetadata => "local metadata",
+        SafetyClass::LocalRewrite => "local rewrite",
+        SafetyClass::DestructiveLocal => "destructive local",
+        SafetyClass::NetworkRead => "network read",
+        SafetyClass::NetworkWrite => "network write",
+        SafetyClass::ExternalCommand => "external command",
+        _ => "unknown",
+    }
+}
+
+const fn execution_label(mode: ExecutionMode) -> &'static str {
+    match mode {
+        ExecutionMode::RenderReadOnly => "render read-only",
+        ExecutionMode::ConfirmMutation => "confirm mutation",
+        ExecutionMode::ConfirmExternalTool => "confirm external tool",
+        ExecutionMode::DryRunThenConfirm => "dry-run then confirm",
+        ExecutionMode::CommandMode => "command mode",
+        _ => "unknown",
+    }
+}
+
+const fn refresh_label(refresh_plan: RefreshPlan) -> &'static str {
+    match refresh_plan {
+        RefreshPlan::None => "app-controlled refresh",
+        RefreshPlan::ReRunSpec => "re-run current command",
+        _ => "unknown",
+    }
+}
+
+fn warning_label(warning: &CommandPreviewWarning) -> String {
+    match warning {
+        CommandPreviewWarning::LocalMetadata => "Changes local repository metadata.".to_owned(),
+        CommandPreviewWarning::LocalRewrite => "Rewrites local history.".to_owned(),
+        CommandPreviewWarning::DestructiveLocal => {
+            "Performs a destructive local operation.".to_owned()
+        }
+        CommandPreviewWarning::NetworkWrite => "Writes to a remote or network service.".to_owned(),
+        CommandPreviewWarning::ExternalCommand => "Runs an external command.".to_owned(),
+        CommandPreviewWarning::IgnoresWorkingCopy => {
+            "Ignores the current working-copy snapshot.".to_owned()
+        }
+        CommandPreviewWarning::AtOperation(operation) => {
+            format!("Runs at operation {operation}.")
+        }
+        CommandPreviewWarning::DoesNotIntegrateOperation => {
+            "Does not integrate the loaded operation.".to_owned()
+        }
+        CommandPreviewWarning::IgnoresImmutableCommits => {
+            "May rewrite immutable commits.".to_owned()
+        }
+        _ => "Review this command before running.".to_owned(),
+    }
+}
+
+fn centered_panel(area: Rect, preferred_height: u16) -> Rect {
+    let width = PANEL_WIDTH.min(area.width);
+    let height = preferred_height.max(MIN_PANEL_HEIGHT).min(area.height);
+
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+fn panel_height(text: &Text<'_>, content_width: u16) -> u16 {
+    let content_width = usize::from(content_width.max(1));
+    let text_height = text
+        .lines
+        .iter()
+        .map(|line| line.width().div_ceil(content_width).max(1))
+        .sum::<usize>();
+    text_height.saturating_add(2).try_into().unwrap_or(u16::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use jk_core::{
+        ExecutionMode, GlobalOptions, JjCommandSpec, RefreshPlan, SafetyClass, WorkingCopyPolicy,
+    };
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+
+    #[test]
+    fn command_preview_renders_command_warning_and_key_hints() {
+        let global_options = GlobalOptions::default().with_working_copy(WorkingCopyPolicy::Ignore);
+        let preview = JjCommandSpec::confirm_mutation(
+            ["describe", "--message", "Update preview renderer"],
+            SafetyClass::LocalRewrite,
+        )
+        .with_global_options(global_options)
+        .with_title("Describe workspace")
+        .command_preview();
+        let view = CommandPreviewView::new(preview);
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("Confirm command"));
+        assert!(rendered.contains("Describe workspace"));
+        assert!(rendered.contains("jj --no-pager --color always --ignore-working-copy describe"));
+        assert!(rendered.contains("--message"));
+        assert!(rendered.contains("'Update preview renderer'"));
+        assert!(rendered.contains("Safety: local rewrite"));
+        assert!(rendered.contains("Execution: confirm mutation"));
+        assert!(rendered.contains("Rewrites local history."));
+        assert!(rendered.contains("Ignores the current working-copy snapshot."));
+        assert!(rendered.contains("enter"));
+        assert!(rendered.contains("run"));
+        assert!(rendered.contains('y'));
+        assert!(rendered.contains("copy"));
+        assert!(rendered.contains("esc"));
+        assert!(rendered.contains("cancel"));
+    }
+
+    #[test]
+    fn command_preview_without_warnings_says_so() {
+        let preview = JjCommandSpec::render_read_only(["log"])
+            .with_mode(ExecutionMode::RenderReadOnly)
+            .with_safety(SafetyClass::ReadOnly)
+            .with_refresh_plan(RefreshPlan::None)
+            .with_title("Refresh log")
+            .command_preview();
+        let view = CommandPreviewView::new(preview);
+        let backend = TestBackend::new(80, 14);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("jj --no-pager --color always log"));
+        assert!(rendered.contains("Safety: read-only"));
+        assert!(rendered.contains("No warnings for this command."));
+        assert!(rendered.contains("enter run"));
+        assert!(rendered.contains("y copy"));
+        assert!(rendered.contains("esc cancel"));
+    }
+
+    #[test]
+    fn command_preview_status_replaces_copy_hint() {
+        let preview = JjCommandSpec::render_read_only(["undo"])
+            .with_title("Undo latest operation")
+            .command_preview();
+        let view = CommandPreviewView::new(preview).with_status(Some("copied command".to_owned()));
+        let backend = TestBackend::new(80, 14);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("copied command"));
+        assert!(rendered.contains("enter run"));
+        assert!(!rendered.contains("y copy"));
+    }
+
+    fn buffer_to_string(buffer: &ratatui::buffer::Buffer) -> String {
+        let area = buffer.area;
+        let mut text = String::new();
+
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
+
+        text
+    }
+}

--- a/crates/jk-tui/src/diff_state.rs
+++ b/crates/jk-tui/src/diff_state.rs
@@ -9,6 +9,7 @@ use crate::chrome::title_or_default;
 
 const HORIZONTAL_SCROLL_STEP: usize = 8;
 const DIFF_HORIZONTAL_STATUS: &str = "</> horizontal scroll";
+const DIFF_FILE_STATUS_HINT: &str = "  f files  [/] file  { } hunk  ? help";
 
 /// Semantic state behind a rendered selected-change diff.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -105,6 +106,29 @@ impl DiffState {
     /// Returns the first rendered column currently visible in the viewport.
     pub const fn horizontal_offset(&self) -> usize {
         self.horizontal_offset
+    }
+
+    /// Returns the number of file sections in this diff.
+    pub const fn file_count(&self) -> usize {
+        self.sections.len()
+    }
+
+    /// Returns the currently selected file section index.
+    pub const fn selected_file_index(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Returns the file paths discovered in this diff.
+    pub fn file_paths(&self) -> Vec<&str> {
+        self.sections
+            .iter()
+            .map(|section| section.path.as_str())
+            .collect()
+    }
+
+    /// Selects a file section by index.
+    pub fn select_file_index(&mut self, index: usize) {
+        self.select_index(index);
     }
 
     /// Scrolls one visible line toward the start of the diff.
@@ -484,6 +508,29 @@ impl DiffState {
         })
     }
 
+    /// Returns compact status-line text for the current file selection.
+    pub fn current_file_status(&self, width: usize) -> Option<String> {
+        let selected = self.selected?;
+        let section = self.selected_section()?;
+        let file_count = self.sections.len();
+        let prefix = format!("file {}/{} ", selected + 1, file_count);
+        let minimal = prefix.trim_end().to_owned();
+
+        if width <= visible_width(&minimal) {
+            return Some(minimal);
+        }
+
+        let hint_width = visible_width(DIFF_FILE_STATUS_HINT);
+        let hint = if width >= visible_width(&prefix) + visible_width(&section.path) + hint_width {
+            DIFF_FILE_STATUS_HINT
+        } else {
+            ""
+        };
+        let path_width = width.saturating_sub(visible_width(&prefix) + visible_width(hint));
+        let path = compact_status_path(&section.path, path_width);
+        Some(format!("{prefix}{path}{hint}"))
+    }
+
     /// Returns whether the selected file section is collapsed.
     #[cfg(test)]
     pub fn selected_file_is_collapsed(&self) -> bool {
@@ -858,6 +905,26 @@ fn visible_width(text: &str) -> usize {
     strip_ansi(text).chars().count()
 }
 
+fn compact_status_path(path: &str, width: usize) -> String {
+    if visible_width(path) <= width {
+        return path.to_owned();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    if width <= 3 {
+        return take_tail_chars(path, width);
+    }
+
+    format!("...{}", take_tail_chars(path, width - 3))
+}
+
+fn take_tail_chars(text: &str, count: usize) -> String {
+    let mut tail = text.chars().rev().take(count).collect::<Vec<_>>();
+    tail.reverse();
+    tail.into_iter().collect()
+}
+
 /// Returns visible line numbers whose plain text contains `query`.
 fn matching_visible_lines(rendered: &str, query: &str) -> Vec<usize> {
     let query = query.to_lowercase();
@@ -885,6 +952,8 @@ fn selected_match_at_or_after(matches: &[usize], scroll_offset: usize) -> Option
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::expect_used)]
+
     use super::*;
 
     #[test]
@@ -913,6 +982,33 @@ mod tests {
             "Modified regular file src/a.rs: |   1 \u{1b}[38;5;2m+\u{1b}[38;5;1m\u{1b}[39m"
         ));
         assert!(!state.visible_rendered().contains("newer"));
+    }
+
+    #[test]
+    fn file_paths_expose_jumpable_diff_files() {
+        let state = DiffState::new(snapshot(
+            "aaa",
+            "Modified regular file src/a.rs:\n a\nAdded regular file src/b.rs:\n b\n",
+        ));
+
+        assert_eq!(state.file_count(), 2);
+        assert_eq!(state.file_paths(), vec!["src/a.rs", "src/b.rs"]);
+        assert_eq!(state.selected_file_index(), Some(0));
+    }
+
+    #[test]
+    fn selecting_file_index_jumps_to_section() {
+        let mut state = DiffState::new(snapshot(
+            "aaa",
+            "Modified regular file src/a.rs:\n a\nModified regular file src/b.rs:\n b\n",
+        ));
+        state.keep_selected_in_view(2);
+
+        state.select_file_index(1);
+
+        assert_eq!(state.scroll_offset(), 2);
+        assert_eq!(state.selected_file_index(), Some(1));
+        assert_eq!(state.selected_visible_line(), Some(2));
     }
 
     #[test]
@@ -1128,6 +1224,40 @@ mod tests {
         state.scroll_left();
 
         assert_eq!(state.horizontal_offset(), 8);
+    }
+
+    #[test]
+    fn current_file_status_tracks_selected_file() {
+        let mut state = DiffState::new(snapshot(
+            "aaa",
+            "Modified regular file src/a.rs:\n a\nModified regular file src/b.rs:\n b\n",
+        ));
+
+        assert_eq!(
+            state.current_file_status(80),
+            Some("file 1/2 src/a.rs  f files  [/] file  { } hunk  ? help".to_owned())
+        );
+
+        state.select_next_file();
+
+        assert_eq!(
+            state.current_file_status(80),
+            Some("file 2/2 src/b.rs  f files  [/] file  { } hunk  ? help".to_owned())
+        );
+    }
+
+    #[test]
+    fn current_file_status_compacts_long_paths_to_width() {
+        let state = DiffState::new(snapshot(
+            "aaa",
+            "Modified regular file crates/jk-tui/src/very/long/path/component/diff_state.rs:\n a\n",
+        ));
+        let status = state.current_file_status(32).expect("status");
+
+        assert!(visible_width(&status) <= 32);
+        assert!(status.starts_with("file 1/1 "));
+        assert!(status.contains("..."));
+        assert!(status.ends_with("diff_state.rs"));
     }
 
     #[test]

--- a/crates/jk-tui/src/diff_view.rs
+++ b/crates/jk-tui/src/diff_view.rs
@@ -5,8 +5,9 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::widgets::Paragraph;
 
-use crate::chrome::{DIFF_STATUS, ViewChrome, render_help_overlay};
+use crate::chrome::{ViewChrome, render_help_overlay};
 use crate::diff_state::DiffState;
+use crate::keymap::{BindingContext, adaptive_hotbar, help_lines, help_title};
 use crate::rendered_log::rendered_text;
 use crate::selected_row::paint_subtle_selected_row;
 
@@ -154,6 +155,29 @@ impl DiffView {
         self.status_message = None;
     }
 
+    /// Returns the number of file sections available for navigation.
+    #[must_use]
+    pub const fn file_count(&self) -> usize {
+        self.state.file_count()
+    }
+
+    /// Returns the file paths available for navigation.
+    #[must_use]
+    pub fn file_paths(&self) -> Vec<&str> {
+        self.state.file_paths()
+    }
+
+    /// Returns the currently selected file section index.
+    #[must_use]
+    pub const fn selected_file_index(&self) -> Option<usize> {
+        self.state.selected_file_index()
+    }
+
+    /// Jumps to a file section by index.
+    pub fn select_file_index(&mut self, index: usize) {
+        self.state.select_file_index(index);
+    }
+
     /// Shows a refresh or integration error without replacing the current diff.
     pub fn show_error(&mut self, error: impl Into<String>) {
         self.status_message = Some(error.into());
@@ -274,6 +298,14 @@ impl DiffView {
         self.render_area(frame, area, Some(status));
     }
 
+    /// Renders the diff view with a caller-owned centered overlay.
+    pub fn render_with_overlay(&mut self, frame: &mut Frame<'_>, title: &str, lines: &[String]) {
+        let area = frame.area();
+        self.render_area(frame, area, None);
+        let areas = ViewChrome::layout(area);
+        render_help_overlay(frame, areas.content, title, lines);
+    }
+
     fn render_area(&mut self, frame: &mut Frame<'_>, area: Rect, status_override: Option<&str>) {
         let areas = ViewChrome::layout(area);
         let height = usize::from(areas.content.height);
@@ -292,11 +324,16 @@ impl DiffView {
 
         let search_status = self.state.search_status();
         let horizontal_status = self.state.horizontal_status();
+        let file_status = self
+            .state
+            .current_file_status(usize::from(areas.status_width()));
+        let fallback_status = adaptive_hotbar(BindingContext::Diff, areas.status_width());
         let status = status_override
             .or(self.status_message.as_deref())
             .or(search_status.as_deref())
             .or(horizontal_status.as_deref())
-            .unwrap_or(DIFF_STATUS);
+            .or(file_status.as_deref())
+            .unwrap_or(&fallback_status);
         let chrome = ViewChrome::new(self.state.title(), status);
         chrome.render(frame, areas);
 
@@ -322,7 +359,12 @@ impl DiffView {
         }
 
         if self.help_visible {
-            render_help_overlay(frame, areas.content, "Diff keys", DIFF_HELP);
+            render_help_overlay(
+                frame,
+                areas.content,
+                help_title(BindingContext::Diff),
+                &help_lines(BindingContext::Diff),
+            );
         }
     }
 
@@ -344,22 +386,6 @@ impl DiffView {
         )
     }
 }
-
-const DIFF_HELP: &[&str] = &[
-    "j/k or arrows        scroll one line",
-    "space / b, Ctrl-f/b  page down/up",
-    "g/G or Home/End      jump to top/bottom",
-    "[ / ]                previous/next file",
-    "{ / }                previous/next hunk",
-    "h / l                fold/unfold current file",
-    "Ctrl-left/right      fold/unfold all files",
-    "- / +                fold/unfold current hunk",
-    "< / >                horizontal scroll",
-    "/, n, N              search, next, previous",
-    "r                    refresh",
-    "H / L                return to log",
-    "?, q, Esc            close help",
-];
 
 /// Returns the portion of a content area left after a sticky file header row.
 const fn area_below_sticky_header(area: Rect) -> Rect {
@@ -417,7 +443,7 @@ mod tests {
 
         let rendered = buffer_to_string(terminal.backend().buffer());
         assert!(rendered.contains("Modified regular file src/b.rs:"));
-        assert!(buffer_line(terminal.backend().buffer(), 4).contains("r refresh"));
+        assert!(buffer_line(terminal.backend().buffer(), 4).contains("file 1/1 src/b.rs"));
     }
 
     #[test]
@@ -511,6 +537,25 @@ mod tests {
     }
 
     #[test]
+    fn render_status_shows_current_file_context() {
+        let mut view = DiffView::new(snapshot(
+            "aaa",
+            "Modified regular file src/a.rs:\n a\nModified regular file src/b.rs:\n b\n",
+        ));
+        let backend = TestBackend::new(72, 5);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        assert!(buffer_line(terminal.backend().buffer(), 4).contains("file 1/2 src/a.rs"));
+        assert!(buffer_line(terminal.backend().buffer(), 4).contains("f files"));
+    }
+
+    #[test]
     fn help_action_shows_diff_specific_keys() {
         let mut view = DiffView::new(snapshot("aaa", "Modified regular file src/a.rs:\n alpha\n"));
         let _ = view.apply(DiffAction::ToggleHelp);
@@ -525,8 +570,25 @@ mod tests {
 
         let rendered = buffer_to_string(terminal.backend().buffer());
         assert!(rendered.contains("Diff keys"));
+        assert!(rendered.contains("f                    open file list"));
         assert!(rendered.contains("[ / ]                previous/next file"));
         assert!(rendered.contains("/, n, N              search, next, previous"));
+    }
+
+    #[test]
+    fn exposes_file_list_navigation_state() {
+        let mut view = DiffView::new(snapshot(
+            "aaa",
+            "Modified regular file src/a.rs:\n a\nModified regular file src/b.rs:\n b\n",
+        ));
+
+        assert_eq!(view.file_count(), 2);
+        assert_eq!(view.file_paths(), vec!["src/a.rs", "src/b.rs"]);
+        assert_eq!(view.selected_file_index(), Some(0));
+
+        view.select_file_index(1);
+
+        assert_eq!(view.selected_file_index(), Some(1));
     }
 
     #[test]

--- a/crates/jk-tui/src/keymap.rs
+++ b/crates/jk-tui/src/keymap.rs
@@ -1,0 +1,1350 @@
+//! Display metadata for contextual key help and hotbar text.
+//!
+//! Dispatch still lives in the binary's terminal adapter. This module is only the visible binding
+//! registry used by TUI chrome until input dispatch can share the same data model.
+
+/// Screen-specific binding set.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BindingContext {
+    /// The revision log view.
+    Log,
+    /// The selected-change diff view.
+    Diff,
+    /// A rendered read-only inspection view, such as show or status.
+    Inspection,
+    /// The workspace list view.
+    Workspaces,
+    /// The command-history list view.
+    CommandHistory,
+    /// The operation log list view.
+    OperationLog,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ActionId {
+    Move,
+    LineScroll,
+    Page,
+    FirstLast,
+    Mark,
+    ClearMarks,
+    Expand,
+    Collapse,
+    OpenShow,
+    OpenDiff,
+    OpenLog,
+    OpenDescribe,
+    OpenEvolog,
+    OpenStatus,
+    OpenOperation,
+    OpenOperationLog,
+    OpenCommandHistory,
+    OpenCommandDetails,
+    CopyCommand,
+    CommandMode,
+    NewChange,
+    EditChange,
+    Abandon,
+    Undo,
+    Redo,
+    UpdateStale,
+    ViewOptions,
+    Refresh,
+    SwitchLogCommand,
+    OpenFileList,
+    File,
+    Hunk,
+    FoldFile,
+    FoldAll,
+    FoldHunk,
+    HorizontalScroll,
+    Search,
+    ReturnToLog,
+    ReturnBack,
+    CloseHelp,
+    Quit,
+}
+
+impl ActionId {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Move => "Move selection",
+            Self::LineScroll => "Scroll line",
+            Self::Page => "Page",
+            Self::FirstLast => "Jump to edge",
+            Self::Mark => "Mark revision",
+            Self::ClearMarks => "Clear marks",
+            Self::Expand => "Expand change",
+            Self::Collapse => "Collapse change",
+            Self::OpenShow => "Open show",
+            Self::OpenDiff => "Open diff",
+            Self::OpenLog => "Open log",
+            Self::OpenDescribe => "Describe revision",
+            Self::OpenEvolog => "Open evolog",
+            Self::OpenStatus => "Open status",
+            Self::OpenOperation => "Open operation",
+            Self::OpenOperationLog => "Open operation log",
+            Self::OpenCommandHistory => "Open command history",
+            Self::OpenCommandDetails => "Open command details",
+            Self::CopyCommand => "Copy command",
+            Self::CommandMode => "Run jj command",
+            Self::NewChange => "New change",
+            Self::EditChange => "Edit change",
+            Self::Abandon => "Abandon revision",
+            Self::Undo => "Undo",
+            Self::Redo => "Redo",
+            Self::UpdateStale => "Update stale",
+            Self::ViewOptions => "View options",
+            Self::Refresh => "Refresh",
+            Self::SwitchLogCommand => "Switch log command",
+            Self::OpenFileList => "Open file list",
+            Self::File => "Move file",
+            Self::Hunk => "Move hunk",
+            Self::FoldFile => "Fold file",
+            Self::FoldAll => "Fold all files",
+            Self::FoldHunk => "Fold hunk",
+            Self::HorizontalScroll => "Horizontal scroll",
+            Self::Search => "Search output",
+            Self::ReturnToLog => "Return to log",
+            Self::ReturnBack => "Return back",
+            Self::CloseHelp => "Close help",
+            Self::Quit => "Quit",
+        }
+    }
+}
+
+/// Command or interaction family used by searchable discovery.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommandFamily {
+    /// Commands and actions related to `jj log`.
+    JjLog,
+    /// Commands and actions related to `jj diff`.
+    JjDiff,
+    /// Commands and actions related to `jj describe`.
+    JjDescribe,
+    /// Commands and actions related to `jj new`.
+    JjNew,
+    /// Commands and actions related to `jj edit`.
+    JjEdit,
+    /// Commands and actions related to `jj evolog`.
+    JjEvolog,
+    /// Commands and actions related to `jj show`.
+    JjShow,
+    /// Commands and actions related to `jj status`.
+    JjStatus,
+    /// Commands and actions related to `jj workspace`.
+    JjWorkspace,
+    /// Commands and actions related to `jj operation`.
+    JjOperation,
+    /// Command history and transcripts.
+    History,
+    /// In-view output search.
+    Search,
+    /// Refreshing the active view.
+    Refresh,
+    /// Selection, scrolling, and viewport movement.
+    Navigation,
+    /// Ordered revision mark actions.
+    Mark,
+    /// Diff folding actions.
+    Fold,
+    /// Diff file-section movement.
+    File,
+    /// Diff hunk movement.
+    Hunk,
+    /// View-scoped display and template options.
+    ViewOptions,
+    /// User-entered `jj` command mode.
+    CommandMode,
+    /// Help and discovery controls.
+    Help,
+    /// Quitting the application.
+    Quit,
+}
+
+impl CommandFamily {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::JjLog => "jj log",
+            Self::JjDiff => "jj diff",
+            Self::JjDescribe => "jj describe",
+            Self::JjNew => "jj new",
+            Self::JjEdit => "jj edit",
+            Self::JjEvolog => "jj evolog",
+            Self::JjShow => "jj show",
+            Self::JjStatus => "jj status",
+            Self::JjWorkspace => "jj workspace",
+            Self::JjOperation => "jj operation",
+            Self::History => "history",
+            Self::Search => "search",
+            Self::Refresh => "refresh",
+            Self::Navigation => "navigation",
+            Self::Mark => "mark",
+            Self::Fold => "fold",
+            Self::File => "file",
+            Self::Hunk => "hunk",
+            Self::ViewOptions => "view options",
+            Self::CommandMode => "jj command",
+            Self::Help => "help",
+            Self::Quit => "quit",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct KeyBinding {
+    action: ActionId,
+    keys: &'static str,
+    help: &'static str,
+    command_family: Option<CommandFamily>,
+    aliases: &'static [&'static str],
+    hotbar: Option<&'static str>,
+    hotbar_rank: Option<u8>,
+    show_in_help: bool,
+    show_in_discovery: bool,
+}
+
+impl KeyBinding {
+    const fn new(action: ActionId, keys: &'static str, help: &'static str) -> Self {
+        Self {
+            action,
+            keys,
+            help,
+            command_family: None,
+            aliases: &[],
+            hotbar: None,
+            hotbar_rank: None,
+            show_in_help: true,
+            show_in_discovery: true,
+        }
+    }
+
+    const fn with_family(mut self, command_family: CommandFamily) -> Self {
+        self.command_family = Some(command_family);
+        self
+    }
+
+    const fn with_aliases(mut self, aliases: &'static [&'static str]) -> Self {
+        self.aliases = aliases;
+        self
+    }
+
+    const fn with_hotbar(mut self, rank: u8, hotbar: &'static str) -> Self {
+        self.hotbar = Some(hotbar);
+        self.hotbar_rank = Some(rank);
+        self
+    }
+
+    const fn hotbar_only(mut self) -> Self {
+        self.show_in_help = false;
+        self
+    }
+
+    fn help_line(self) -> String {
+        format!("{:<21}{}", self.keys, self.help)
+    }
+}
+
+const LOG_BINDINGS: &[KeyBinding] = &[
+    KeyBinding::new(ActionId::OpenShow, "enter", "open selected-change show")
+        .with_family(CommandFamily::JjShow)
+        .with_aliases(&["details", "inspect"])
+        .with_hotbar(4, "enter show"),
+    KeyBinding::new(ActionId::OpenDiff, "d", "open selected-change diff")
+        .with_family(CommandFamily::JjDiff)
+        .with_hotbar(5, "d diff"),
+    KeyBinding::new(ActionId::OpenEvolog, "v", "open selected-change evolog")
+        .with_family(CommandFamily::JjEvolog)
+        .with_aliases(&[
+            "evolution",
+            "history",
+            "change",
+            "version",
+            "selected change",
+        ])
+        .with_hotbar(7, "v evolog"),
+    KeyBinding::new(ActionId::OpenStatus, "s", "open repository status")
+        .with_family(CommandFamily::JjStatus)
+        .with_hotbar(8, "s status"),
+    KeyBinding::new(ActionId::OpenOperationLog, "o", "open operation log")
+        .with_family(CommandFamily::JjOperation)
+        .with_aliases(&["operation", "op log", "undo", "redo", "recovery"])
+        .with_hotbar(10, "o ops"),
+    KeyBinding::new(ActionId::OpenDescribe, "m", "describe selected revision")
+        .with_family(CommandFamily::JjDescribe)
+        .with_aliases(&["message", "description", "mutation", "preview"])
+        .with_hotbar(6, "m describe"),
+    KeyBinding::new(ActionId::NewChange, "n", "preview jj new")
+        .with_family(CommandFamily::JjNew)
+        .with_aliases(&["new", "change", "parent", "mutation", "preview"])
+        .with_hotbar(15, "n new"),
+    KeyBinding::new(ActionId::EditChange, "e", "preview jj edit")
+        .with_family(CommandFamily::JjEdit)
+        .with_aliases(&["edit", "checkout", "working copy", "mutation", "preview"])
+        .with_hotbar(17, "e edit"),
+    KeyBinding::new(ActionId::Abandon, "a", "preview jj abandon")
+        .with_family(CommandFamily::JjOperation)
+        .with_aliases(&["abandon", "delete", "destructive", "mutation", "preview"])
+        .with_hotbar(16, "a abandon"),
+    KeyBinding::new(ActionId::Undo, "u", "preview jj undo")
+        .with_family(CommandFamily::JjOperation)
+        .with_aliases(&["undo", "operation", "recovery"])
+        .with_hotbar(12, "u undo"),
+    KeyBinding::new(ActionId::Redo, "U", "preview jj redo")
+        .with_family(CommandFamily::JjOperation)
+        .with_aliases(&["redo", "operation", "recovery"])
+        .with_hotbar(14, "U redo"),
+    KeyBinding::new(ActionId::Mark, "space", "mark/unmark selected revision")
+        .with_family(CommandFamily::Mark)
+        .with_aliases(&["selected", "revision", "toggle"])
+        .with_hotbar(9, "space mark"),
+    KeyBinding::new(
+        ActionId::ClearMarks,
+        "c",
+        "clear revision marks when marks exist",
+    )
+    .with_family(CommandFamily::Mark)
+    .with_aliases(&["clear", "unmark", "selected", "revision"])
+    .with_hotbar(11, "c clear"),
+    KeyBinding::new(ActionId::OpenCommandHistory, "C", "open command history")
+        .with_family(CommandFamily::History)
+        .with_aliases(&["commands", "history", "recent"]),
+    KeyBinding::new(ActionId::CommandMode, ":", "run jj command")
+        .with_family(CommandFamily::CommandMode)
+        .with_aliases(&["command", "prompt", "colon", "jj"]),
+    KeyBinding::new(ActionId::ViewOptions, "V", "open view options")
+        .with_family(CommandFamily::ViewOptions)
+        .with_aliases(&["view", "options", "template", "jj log"])
+        .with_hotbar(18, "V options"),
+    KeyBinding::new(ActionId::Refresh, "r", "refresh")
+        .with_family(CommandFamily::Refresh)
+        .with_hotbar(3, "r refresh"),
+    KeyBinding::new(ActionId::SwitchLogCommand, "H / L", "home command / jj log")
+        .with_family(CommandFamily::JjLog)
+        .with_aliases(&["home", "current screen"])
+        .with_hotbar(2, "H home  L log"),
+    KeyBinding::new(ActionId::Move, "j/k or arrows", "move selection")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["selection", "current row"])
+        .with_hotbar(13, "j/k move"),
+    KeyBinding::new(ActionId::LineScroll, "Ctrl-j/k", "scroll one line")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::Page, "b, Ctrl-f/b, PgUp/Dn", "page down/up")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["page", "pagedown", "pageup"]),
+    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::Expand, "right, l", "expand selected change")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::Collapse, "left, h", "collapse selected change")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+        .with_family(CommandFamily::Help)
+        .with_hotbar(1, "? help"),
+    KeyBinding::new(ActionId::Quit, "q", "quit")
+        .with_family(CommandFamily::Quit)
+        .with_hotbar(19, "q quit")
+        .hotbar_only(),
+];
+
+const DIFF_BINDINGS: &[KeyBinding] = &[
+    KeyBinding::new(ActionId::OpenFileList, "f", "open file list")
+        .with_family(CommandFamily::File)
+        .with_aliases(&["files", "paths", "jump", "file list"])
+        .with_hotbar(5, "f files"),
+    KeyBinding::new(ActionId::File, "[ / ]", "previous/next file").with_family(CommandFamily::File),
+    KeyBinding::new(ActionId::Hunk, "{ / }", "previous/next hunk").with_family(CommandFamily::Hunk),
+    KeyBinding::new(ActionId::FoldFile, "h / l", "fold/unfold current file")
+        .with_family(CommandFamily::Fold),
+    KeyBinding::new(
+        ActionId::FoldAll,
+        "Ctrl-left/right",
+        "fold/unfold all files",
+    )
+    .with_family(CommandFamily::Fold),
+    KeyBinding::new(ActionId::FoldHunk, "- / +", "fold/unfold current hunk")
+        .with_family(CommandFamily::Fold),
+    KeyBinding::new(ActionId::HorizontalScroll, "< / >", "horizontal scroll")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::Search, "/, n, N", "search, next, previous")
+        .with_family(CommandFamily::Search)
+        .with_aliases(&["find", "filter"]),
+    KeyBinding::new(ActionId::OpenCommandHistory, "C", "open command history")
+        .with_family(CommandFamily::History)
+        .with_aliases(&["commands", "history", "recent"]),
+    KeyBinding::new(ActionId::CommandMode, ":", "run jj command")
+        .with_family(CommandFamily::CommandMode)
+        .with_aliases(&["command", "prompt", "colon", "jj"]),
+    KeyBinding::new(ActionId::ViewOptions, "V", "open view options")
+        .with_family(CommandFamily::ViewOptions)
+        .with_aliases(&["view", "options", "display"])
+        .with_hotbar(2, "V options"),
+    KeyBinding::new(ActionId::Refresh, "r", "refresh")
+        .with_family(CommandFamily::Refresh)
+        .with_hotbar(3, "r refresh"),
+    KeyBinding::new(ActionId::Move, "j/k or arrows", "scroll one line")
+        .with_family(CommandFamily::Navigation)
+        .with_hotbar(4, "j/k line"),
+    KeyBinding::new(ActionId::LineScroll, "Ctrl-j/k", "scroll one line")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::Page, "space / b, Ctrl-f/b", "page down/up")
+        .with_family(CommandFamily::Navigation)
+        .with_hotbar(6, "space/b page"),
+    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::ReturnToLog, "H / L", "go back")
+        .with_family(CommandFamily::JjLog)
+        .with_aliases(&["back"]),
+    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+        .with_family(CommandFamily::Help)
+        .with_hotbar(1, "? help"),
+    KeyBinding::new(ActionId::Quit, "q", "quit")
+        .with_family(CommandFamily::Quit)
+        .with_hotbar(7, "q quit")
+        .hotbar_only(),
+];
+
+const INSPECTION_BINDINGS: &[KeyBinding] = &[
+    KeyBinding::new(ActionId::Search, "/, n, N", "search, next, previous")
+        .with_family(CommandFamily::Search)
+        .with_aliases(&["find", "filter", "details", "status"]),
+    KeyBinding::new(ActionId::OpenCommandHistory, "C", "open command history")
+        .with_family(CommandFamily::History)
+        .with_aliases(&["commands", "history", "recent"]),
+    KeyBinding::new(ActionId::CommandMode, ":", "run jj command")
+        .with_family(CommandFamily::CommandMode)
+        .with_aliases(&["command", "prompt", "colon", "jj"]),
+    KeyBinding::new(ActionId::ViewOptions, "V", "open view options")
+        .with_family(CommandFamily::ViewOptions)
+        .with_aliases(&["view", "options", "display"])
+        .with_hotbar(2, "V options"),
+    KeyBinding::new(ActionId::Refresh, "r", "refresh")
+        .with_family(CommandFamily::Refresh)
+        .with_hotbar(3, "r refresh"),
+    KeyBinding::new(ActionId::Move, "j/k or arrows", "scroll one line")
+        .with_family(CommandFamily::Navigation)
+        .with_hotbar(4, "j/k line"),
+    KeyBinding::new(ActionId::LineScroll, "Ctrl-j/k", "scroll one line")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::Page, "space / b, Ctrl-f/b", "page down/up")
+        .with_family(CommandFamily::Navigation)
+        .with_hotbar(5, "space/b page"),
+    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::ReturnToLog, "H / L", "go back")
+        .with_family(CommandFamily::JjLog)
+        .with_aliases(&["back"]),
+    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+        .with_family(CommandFamily::Help)
+        .with_hotbar(1, "? help"),
+    KeyBinding::new(ActionId::Quit, "q", "quit")
+        .with_family(CommandFamily::Quit)
+        .with_hotbar(6, "q quit")
+        .hotbar_only(),
+];
+
+const WORKSPACES_BINDINGS: &[KeyBinding] = &[
+    KeyBinding::new(ActionId::OpenLog, "l", "open selected workspace log")
+        .with_family(CommandFamily::JjLog)
+        .with_aliases(&["log", "workspace", "selected"])
+        .with_hotbar(3, "l log"),
+    KeyBinding::new(
+        ActionId::OpenStatus,
+        "enter, s",
+        "open selected workspace status",
+    )
+    .with_family(CommandFamily::JjStatus)
+    .with_aliases(&["status", "workspace", "selected"])
+    .with_hotbar(4, "s status"),
+    KeyBinding::new(ActionId::OpenDiff, "d", "open selected workspace diff")
+        .with_family(CommandFamily::JjDiff)
+        .with_aliases(&["diff", "workspace", "selected"])
+        .with_hotbar(5, "d diff"),
+    KeyBinding::new(
+        ActionId::UpdateStale,
+        "u",
+        "update selected stale workspace",
+    )
+    .with_family(CommandFamily::JjWorkspace)
+    .with_aliases(&["update", "stale", "workspace", "selected", "refresh"])
+    .with_hotbar(7, "u update-stale"),
+    KeyBinding::new(ActionId::OpenCommandHistory, "C", "open command history")
+        .with_family(CommandFamily::History)
+        .with_aliases(&["commands", "history", "recent"]),
+    KeyBinding::new(ActionId::CommandMode, ":", "run jj command")
+        .with_family(CommandFamily::CommandMode)
+        .with_aliases(&["command", "prompt", "colon", "jj"]),
+    KeyBinding::new(ActionId::ViewOptions, "V", "open view options")
+        .with_family(CommandFamily::ViewOptions)
+        .with_aliases(&["view", "options", "display"])
+        .with_hotbar(8, "V options"),
+    KeyBinding::new(ActionId::Refresh, "r", "refresh workspaces")
+        .with_family(CommandFamily::Refresh)
+        .with_aliases(&["reload", "workspace"])
+        .with_hotbar(2, "r refresh"),
+    KeyBinding::new(ActionId::Move, "j/k or arrows", "move selection")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["selection", "workspace", "current row"])
+        .with_hotbar(5, "j/k move"),
+    KeyBinding::new(ActionId::LineScroll, "Ctrl-j/k", "scroll one line")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(
+        ActionId::ReturnBack,
+        "Backspace, Esc, H/L",
+        "return to previous view",
+    )
+    .with_family(CommandFamily::Navigation)
+    .with_aliases(&["back", "return", "previous"])
+    .with_hotbar(9, "Esc back"),
+    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+        .with_family(CommandFamily::Help)
+        .with_hotbar(1, "? help"),
+    KeyBinding::new(ActionId::Quit, "q", "quit")
+        .with_family(CommandFamily::Quit)
+        .with_hotbar(10, "q quit")
+        .hotbar_only(),
+];
+
+const COMMAND_HISTORY_BINDINGS: &[KeyBinding] = &[
+    KeyBinding::new(
+        ActionId::OpenCommandDetails,
+        "enter",
+        "open command details",
+    )
+    .with_family(CommandFamily::History)
+    .with_aliases(&["details", "output", "stdout", "stderr", "argv"])
+    .with_hotbar(2, "enter details"),
+    KeyBinding::new(
+        ActionId::OpenOperation,
+        "o",
+        "open operation or operation log",
+    )
+    .with_family(CommandFamily::JjOperation)
+    .with_aliases(&["operation", "op log", "recovery", "selected command"])
+    .with_hotbar(6, "o operation"),
+    KeyBinding::new(ActionId::CopyCommand, "y", "copy selected command")
+        .with_family(CommandFamily::History)
+        .with_aliases(&["copy", "clipboard", "command", "argv"])
+        .with_hotbar(7, "y copy"),
+    KeyBinding::new(ActionId::Refresh, "r", "refresh history")
+        .with_family(CommandFamily::Refresh)
+        .with_hotbar(5, "r refresh"),
+    KeyBinding::new(ActionId::OpenCommandHistory, "C", "refresh command history")
+        .with_family(CommandFamily::History)
+        .with_aliases(&["commands", "history", "recent"]),
+    KeyBinding::new(ActionId::CommandMode, ":", "run jj command")
+        .with_family(CommandFamily::CommandMode)
+        .with_aliases(&["command", "prompt", "colon", "jj"]),
+    KeyBinding::new(ActionId::Move, "j/k or arrows", "move selection")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["selection", "command", "current row"])
+        .with_hotbar(3, "j/k move"),
+    KeyBinding::new(ActionId::Page, "space / b, Ctrl-f/b", "page down/up")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["page", "pagedown", "pageup"])
+        .with_hotbar(4, "space/b page"),
+    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(
+        ActionId::ReturnBack,
+        "Backspace, Esc",
+        "return to previous view",
+    )
+    .with_family(CommandFamily::Navigation)
+    .with_aliases(&["back", "return", "previous"])
+    .with_hotbar(8, "Esc back"),
+    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+        .with_family(CommandFamily::Help)
+        .with_hotbar(1, "? help"),
+    KeyBinding::new(ActionId::Quit, "q", "quit")
+        .with_family(CommandFamily::Quit)
+        .with_hotbar(9, "q quit")
+        .hotbar_only(),
+];
+
+const OPERATION_LOG_BINDINGS: &[KeyBinding] = &[
+    KeyBinding::new(ActionId::OpenShow, "enter", "open selected operation show")
+        .with_family(CommandFamily::JjOperation)
+        .with_aliases(&["show", "details", "inspect", "operation"])
+        .with_hotbar(2, "enter show"),
+    KeyBinding::new(ActionId::OpenDiff, "d", "open selected operation diff")
+        .with_family(CommandFamily::JjOperation)
+        .with_aliases(&["diff", "operation", "selected"])
+        .with_hotbar(3, "d diff"),
+    KeyBinding::new(ActionId::Refresh, "r", "refresh operation log")
+        .with_family(CommandFamily::Refresh)
+        .with_aliases(&["reload", "operation"])
+        .with_hotbar(6, "r refresh"),
+    KeyBinding::new(ActionId::CommandMode, ":", "run jj command")
+        .with_family(CommandFamily::CommandMode)
+        .with_aliases(&["command", "prompt", "colon", "jj"]),
+    KeyBinding::new(ActionId::Move, "j/k or arrows", "move selection")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["selection", "operation", "current row"])
+        .with_hotbar(4, "j/k move"),
+    KeyBinding::new(ActionId::Page, "space / b, Ctrl-f/b", "page down/up")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["page", "pagedown", "pageup"])
+        .with_hotbar(5, "space/b page"),
+    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(
+        ActionId::ReturnBack,
+        "Backspace, Esc",
+        "return to previous view",
+    )
+    .with_family(CommandFamily::Navigation)
+    .with_aliases(&["back", "return", "previous"])
+    .with_hotbar(7, "Esc back"),
+    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+        .with_family(CommandFamily::Help)
+        .with_hotbar(1, "? help"),
+    KeyBinding::new(ActionId::Quit, "q", "quit")
+        .with_family(CommandFamily::Quit)
+        .with_hotbar(8, "q quit")
+        .hotbar_only(),
+];
+
+/// Returns hotbar text for the current binding context.
+pub fn hotbar(context: BindingContext) -> String {
+    hotbar_items(context)
+        .into_iter()
+        .map(|item| item.label)
+        .collect::<Vec<_>>()
+        .join("  ")
+}
+
+/// Returns hotbar text that fits the available row width.
+pub fn adaptive_hotbar(context: BindingContext, width: u16) -> String {
+    let full_hotbar = hotbar(context);
+    let width = usize::from(width);
+    if width == 0 {
+        return String::new();
+    }
+    if visible_width(&full_hotbar) <= width {
+        return full_hotbar;
+    }
+
+    let help = pinned_label(context, CommandFamily::Help).unwrap_or("?");
+    let quit = pinned_label(context, CommandFamily::Quit).unwrap_or("q");
+
+    let optional = hotbar_items(context)
+        .into_iter()
+        .filter(|item| {
+            !matches!(
+                item.command_family,
+                Some(CommandFamily::Help | CommandFamily::Quit)
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut selected = Vec::new();
+    for index in 0..optional.len() {
+        selected.push(optional[index].label);
+        let omitted = optional.len().saturating_sub(selected.len());
+        let candidate = narrowed_hotbar(help, &selected, omitted, quit);
+        if visible_width(&candidate) > width {
+            selected.pop();
+            break;
+        }
+    }
+
+    let omitted = optional.len().saturating_sub(selected.len());
+    let candidate = narrowed_hotbar(help, &selected, omitted, quit);
+    if visible_width(&candidate) <= width {
+        return candidate;
+    }
+
+    let candidate = narrowed_hotbar(help, &[], optional.len(), quit);
+    if visible_width(&candidate) <= width {
+        return candidate;
+    }
+
+    let candidate = join_hotbar_labels(&["?", "...", "q"]);
+    if omitted > 0 && visible_width(&candidate) <= width {
+        return candidate;
+    }
+
+    let candidate = join_hotbar_labels(&["?", "q"]);
+    if visible_width(&candidate) <= width {
+        return candidate;
+    }
+
+    if width >= visible_width("? q") {
+        return "? q".to_owned();
+    }
+
+    fit_label(help, width)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct HotbarItem {
+    label: &'static str,
+    command_family: Option<CommandFamily>,
+}
+
+fn hotbar_items(context: BindingContext) -> Vec<HotbarItem> {
+    let mut hotbar = bindings(context)
+        .iter()
+        .filter_map(|binding| {
+            let label = binding.hotbar?;
+            let rank = binding.hotbar_rank?;
+            Some((rank, binding.command_family, label))
+        })
+        .collect::<Vec<_>>();
+    hotbar.sort_by_key(|(rank, _, _)| *rank);
+    hotbar
+        .into_iter()
+        .map(|(_, command_family, label)| HotbarItem {
+            label,
+            command_family,
+        })
+        .collect()
+}
+
+fn pinned_label(context: BindingContext, family: CommandFamily) -> Option<&'static str> {
+    hotbar_items(context)
+        .into_iter()
+        .find(|item| item.command_family == Some(family))
+        .map(|item| item.label)
+}
+
+fn narrowed_hotbar(
+    help: &'static str,
+    selected: &[&'static str],
+    omitted: usize,
+    quit: &'static str,
+) -> String {
+    let mut labels = Vec::with_capacity(selected.len().saturating_add(3));
+    labels.push(help);
+    labels.extend_from_slice(selected);
+    if omitted > 0 {
+        labels.push("...");
+    }
+    labels.push(quit);
+    join_hotbar_labels(&labels)
+}
+
+fn join_hotbar_labels(labels: &[&str]) -> String {
+    labels.join("  ")
+}
+
+fn visible_width(text: &str) -> usize {
+    text.chars().count()
+}
+
+fn fit_label(label: &str, width: usize) -> String {
+    label.chars().take(width).collect()
+}
+
+/// Returns the help overlay title for the current binding context.
+pub const fn help_title(context: BindingContext) -> &'static str {
+    match context {
+        BindingContext::Log => "Log keys",
+        BindingContext::Diff => "Diff keys",
+        BindingContext::Inspection => "Inspection keys",
+        BindingContext::Workspaces => "Workspaces keys",
+        BindingContext::CommandHistory => "Command History keys",
+        BindingContext::OperationLog => "Operation Log keys",
+    }
+}
+
+/// Returns generated help lines for the current binding context.
+pub fn help_lines(context: BindingContext) -> Vec<String> {
+    bindings(context)
+        .iter()
+        .filter(|binding| binding.show_in_help)
+        .map(|binding| binding.help_line())
+        .collect()
+}
+
+/// A searchable command-discovery row derived from visible keymap metadata.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DiscoveryRow {
+    /// Key text shown in the first column.
+    pub keys: &'static str,
+    /// Short action label shown in the second column.
+    pub action: &'static str,
+    /// Help text used for filtering and future detail displays.
+    pub help: &'static str,
+    /// Screen context where the row applies.
+    pub context: BindingContext,
+    /// Optional command or interaction family.
+    pub command_family: Option<CommandFamily>,
+    aliases: &'static [&'static str],
+}
+
+impl DiscoveryRow {
+    /// Returns the context label used for rendering and filtering.
+    #[must_use]
+    pub const fn context_label(self) -> &'static str {
+        context_label(self.context)
+    }
+
+    /// Returns the command family label used for rendering and filtering.
+    #[must_use]
+    pub const fn command_family_label(self) -> Option<&'static str> {
+        match self.command_family {
+            Some(family) => Some(family.label()),
+            None => None,
+        }
+    }
+
+    fn matches_token(self, token: &str) -> bool {
+        let token = token.to_lowercase();
+        self.keys.to_lowercase().contains(&token)
+            || self.action.to_lowercase().contains(&token)
+            || self.help.to_lowercase().contains(&token)
+            || self.context_label().to_lowercase().contains(&token)
+            || self
+                .command_family_label()
+                .is_some_and(|family| family.to_lowercase().contains(&token))
+            || self
+                .aliases
+                .iter()
+                .any(|alias| alias.to_lowercase().contains(&token))
+    }
+}
+
+/// Returns all discoverable rows for the current context.
+#[must_use]
+pub fn discovery_rows(context: BindingContext) -> Vec<DiscoveryRow> {
+    bindings(context)
+        .iter()
+        .filter(|binding| binding.show_in_discovery)
+        .map(|binding| DiscoveryRow {
+            keys: binding.keys,
+            action: binding.action.label(),
+            help: binding.help,
+            context,
+            command_family: binding.command_family,
+            aliases: binding.aliases,
+        })
+        .collect()
+}
+
+/// Returns context rows whose searchable fields match every query token.
+#[must_use]
+pub fn filter_discovery_rows(context: BindingContext, query: &str) -> Vec<DiscoveryRow> {
+    let tokens = query.split_whitespace().collect::<Vec<_>>();
+    discovery_rows(context)
+        .into_iter()
+        .filter(|row| tokens.iter().all(|token| row.matches_token(token)))
+        .collect()
+}
+
+/// Formats command-discovery popup lines for the current query and selected row.
+#[must_use]
+pub fn discovery_lines(context: BindingContext, query: &str, selected: usize) -> Vec<String> {
+    let rows = filter_discovery_rows(context, query);
+    let selected = selected.min(rows.len().saturating_sub(1));
+    let mut lines = vec![format!("? {query}")];
+
+    if rows.is_empty() {
+        lines.push("  no matching commands".to_owned());
+    } else {
+        lines.extend(rows.into_iter().enumerate().map(|(index, row)| {
+            let marker = if index == selected { ">" } else { " " };
+            let family = row.command_family_label().unwrap_or("");
+            format!(
+                "{marker} {:<18} {:<24} {:<10} {}",
+                row.keys,
+                row.action,
+                row.context_label(),
+                family
+            )
+        }));
+    }
+
+    lines.push(String::new());
+    lines.push("type to filter   j/k or arrows move   enter/esc close".to_owned());
+    lines
+}
+
+/// Returns the number of visible discovery rows for clamping selection state.
+#[must_use]
+pub fn filtered_discovery_len(context: BindingContext, query: &str) -> usize {
+    filter_discovery_rows(context, query).len()
+}
+
+const fn bindings(context: BindingContext) -> &'static [KeyBinding] {
+    match context {
+        BindingContext::Log => LOG_BINDINGS,
+        BindingContext::Diff => DIFF_BINDINGS,
+        BindingContext::Inspection => INSPECTION_BINDINGS,
+        BindingContext::Workspaces => WORKSPACES_BINDINGS,
+        BindingContext::CommandHistory => COMMAND_HISTORY_BINDINGS,
+        BindingContext::OperationLog => OPERATION_LOG_BINDINGS,
+    }
+}
+
+const fn context_label(context: BindingContext) -> &'static str {
+    match context {
+        BindingContext::Log => "log",
+        BindingContext::Diff => "diff",
+        BindingContext::Inspection => "inspection",
+        BindingContext::Workspaces => "workspaces",
+        BindingContext::CommandHistory => "history",
+        BindingContext::OperationLog => "operation log",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_hotbar_matches_current_status_text() {
+        assert_eq!(
+            hotbar(BindingContext::Log),
+            "? help  H home  L log  r refresh  enter show  d diff  m describe  v evolog  s status  space mark  o ops  c clear  u undo  j/k move  U redo  n new  a abandon  e edit  V options  q quit"
+        );
+    }
+
+    #[test]
+    fn diff_hotbar_matches_current_status_text() {
+        assert_eq!(
+            hotbar(BindingContext::Diff),
+            "? help  V options  r refresh  j/k line  f files  space/b page  q quit"
+        );
+    }
+
+    #[test]
+    fn inspection_hotbar_matches_current_status_text() {
+        assert_eq!(
+            hotbar(BindingContext::Inspection),
+            "? help  V options  r refresh  j/k line  space/b page  q quit"
+        );
+    }
+
+    #[test]
+    fn command_history_hotbar_matches_current_status_text() {
+        assert_eq!(
+            hotbar(BindingContext::CommandHistory),
+            "? help  enter details  j/k move  space/b page  r refresh  o operation  y copy  Esc back  q quit"
+        );
+    }
+
+    #[test]
+    fn operation_log_hotbar_matches_current_status_text() {
+        assert_eq!(
+            hotbar(BindingContext::OperationLog),
+            "? help  enter show  d diff  j/k move  space/b page  r refresh  Esc back  q quit"
+        );
+    }
+
+    #[test]
+    fn workspaces_hotbar_matches_current_status_text() {
+        assert_eq!(
+            hotbar(BindingContext::Workspaces),
+            "? help  r refresh  l log  s status  d diff  j/k move  u update-stale  V options  Esc back  q quit"
+        );
+    }
+
+    #[test]
+    fn adaptive_log_hotbar_keeps_full_text_when_it_fits() {
+        assert_eq!(
+            adaptive_hotbar(BindingContext::Log, 200),
+            hotbar(BindingContext::Log)
+        );
+    }
+
+    #[test]
+    fn adaptive_log_hotbar_keeps_primary_commands_at_betamax_width() {
+        let status = adaptive_hotbar(BindingContext::Log, 104);
+
+        assert!(status.chars().count() <= 104);
+        assert!(status.contains("? help"));
+        assert!(status.contains("q quit"));
+        assert!(status.contains("enter show"));
+        assert!(status.contains("d diff"));
+        assert!(status.contains("m describe"));
+        assert!(status.contains("v evolog"));
+        assert!(status.contains("s status"));
+        assert!(status.contains("..."));
+        assert!(!status.contains("space mark"));
+        assert!(!status.contains("n new"));
+        assert!(!status.contains("a abandon"));
+        assert!(!status.contains("e edit"));
+        assert!(!status.contains("j/k move"));
+    }
+
+    #[test]
+    fn adaptive_log_hotbar_preserves_rank_order() {
+        let status = adaptive_hotbar(BindingContext::Log, 75);
+
+        assert_eq!(
+            status,
+            "? help  H home  L log  r refresh  enter show  d diff  ...  q quit"
+        );
+    }
+
+    #[test]
+    fn adaptive_hotbar_prefers_help_at_tiny_width() {
+        assert_eq!(adaptive_hotbar(BindingContext::Log, 9), "?  ...  q");
+        assert_eq!(adaptive_hotbar(BindingContext::Log, 4), "?  q");
+        assert_eq!(adaptive_hotbar(BindingContext::Log, 3), "? q");
+        assert_eq!(adaptive_hotbar(BindingContext::Log, 1), "?");
+        assert_eq!(adaptive_hotbar(BindingContext::Log, 0), "");
+    }
+
+    #[test]
+    fn adaptive_diff_hotbar_keeps_action_affordances() {
+        let status = adaptive_hotbar(BindingContext::Diff, 51);
+
+        assert!(status.chars().count() <= 51);
+        assert_eq!(
+            status,
+            "? help  V options  r refresh  j/k line  ...  q quit"
+        );
+    }
+
+    #[test]
+    fn adaptive_inspection_hotbar_matches_diff_policy() {
+        let status = adaptive_hotbar(BindingContext::Inspection, 41);
+
+        assert!(status.chars().count() <= 41);
+        assert_eq!(status, "? help  V options  r refresh  ...  q quit");
+    }
+
+    #[test]
+    fn adaptive_hotbars_never_exceed_requested_width() {
+        for context in [
+            BindingContext::Log,
+            BindingContext::Diff,
+            BindingContext::Inspection,
+            BindingContext::Workspaces,
+            BindingContext::CommandHistory,
+            BindingContext::OperationLog,
+        ] {
+            for width in 0..=140 {
+                let status = adaptive_hotbar(context, width);
+                assert!(
+                    status.chars().count() <= usize::from(width),
+                    "{context:?} width {width}: {status}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn log_help_lines_match_current_overlay() {
+        assert_eq!(
+            help_lines(BindingContext::Log),
+            vec![
+                "enter                open selected-change show",
+                "d                    open selected-change diff",
+                "v                    open selected-change evolog",
+                "s                    open repository status",
+                "o                    open operation log",
+                "m                    describe selected revision",
+                "n                    preview jj new",
+                "e                    preview jj edit",
+                "a                    preview jj abandon",
+                "u                    preview jj undo",
+                "U                    preview jj redo",
+                "space                mark/unmark selected revision",
+                "c                    clear revision marks when marks exist",
+                "C                    open command history",
+                ":                    run jj command",
+                "V                    open view options",
+                "r                    refresh",
+                "H / L                home command / jj log",
+                "j/k or arrows        move selection",
+                "Ctrl-j/k             scroll one line",
+                "b, Ctrl-f/b, PgUp/Dn page down/up",
+                "g/G or Home/End      jump to top/bottom",
+                "right, l             expand selected change",
+                "left, h              collapse selected change",
+                "?, q, Esc            close help",
+            ]
+        );
+    }
+
+    #[test]
+    fn diff_help_lines_match_current_overlay() {
+        assert_eq!(
+            help_lines(BindingContext::Diff),
+            vec![
+                "f                    open file list",
+                "[ / ]                previous/next file",
+                "{ / }                previous/next hunk",
+                "h / l                fold/unfold current file",
+                "Ctrl-left/right      fold/unfold all files",
+                "- / +                fold/unfold current hunk",
+                "< / >                horizontal scroll",
+                "/, n, N              search, next, previous",
+                "C                    open command history",
+                ":                    run jj command",
+                "V                    open view options",
+                "r                    refresh",
+                "j/k or arrows        scroll one line",
+                "Ctrl-j/k             scroll one line",
+                "space / b, Ctrl-f/b  page down/up",
+                "g/G or Home/End      jump to top/bottom",
+                "H / L                go back",
+                "?, q, Esc            close help",
+            ]
+        );
+    }
+
+    #[test]
+    fn inspection_help_lines_match_current_overlay() {
+        assert_eq!(
+            help_lines(BindingContext::Inspection),
+            vec![
+                "/, n, N              search, next, previous",
+                "C                    open command history",
+                ":                    run jj command",
+                "V                    open view options",
+                "r                    refresh",
+                "j/k or arrows        scroll one line",
+                "Ctrl-j/k             scroll one line",
+                "space / b, Ctrl-f/b  page down/up",
+                "g/G or Home/End      jump to top/bottom",
+                "H / L                go back",
+                "?, q, Esc            close help",
+            ]
+        );
+    }
+
+    #[test]
+    fn workspaces_help_lines_match_current_overlay() {
+        assert_eq!(
+            help_lines(BindingContext::Workspaces),
+            vec![
+                "l                    open selected workspace log",
+                "enter, s             open selected workspace status",
+                "d                    open selected workspace diff",
+                "u                    update selected stale workspace",
+                "C                    open command history",
+                ":                    run jj command",
+                "V                    open view options",
+                "r                    refresh workspaces",
+                "j/k or arrows        move selection",
+                "Ctrl-j/k             scroll one line",
+                "Backspace, Esc, H/L  return to previous view",
+                "?, q, Esc            close help",
+            ]
+        );
+    }
+
+    #[test]
+    fn command_history_help_lines_match_current_overlay() {
+        assert_eq!(
+            help_lines(BindingContext::CommandHistory),
+            vec![
+                "enter                open command details",
+                "o                    open operation or operation log",
+                "y                    copy selected command",
+                "r                    refresh history",
+                "C                    refresh command history",
+                ":                    run jj command",
+                "j/k or arrows        move selection",
+                "space / b, Ctrl-f/b  page down/up",
+                "g/G or Home/End      jump to top/bottom",
+                "Backspace, Esc       return to previous view",
+                "?, q, Esc            close help",
+            ]
+        );
+    }
+
+    #[test]
+    fn operation_log_help_lines_match_current_overlay() {
+        assert_eq!(
+            help_lines(BindingContext::OperationLog),
+            vec![
+                "enter                open selected operation show",
+                "d                    open selected operation diff",
+                "r                    refresh operation log",
+                ":                    run jj command",
+                "j/k or arrows        move selection",
+                "space / b, Ctrl-f/b  page down/up",
+                "g/G or Home/End      jump to top/bottom",
+                "Backspace, Esc       return to previous view",
+                "?, q, Esc            close help",
+            ]
+        );
+    }
+
+    #[test]
+    fn hotbar_bindings_have_help() {
+        for context in [
+            BindingContext::Log,
+            BindingContext::Diff,
+            BindingContext::Inspection,
+            BindingContext::Workspaces,
+            BindingContext::CommandHistory,
+            BindingContext::OperationLog,
+        ] {
+            for binding in bindings(context) {
+                if binding.hotbar.is_some() {
+                    assert!(!binding.help.is_empty());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn discovery_filter_matches_all_tokens_case_insensitively() {
+        let rows = filter_discovery_rows(BindingContext::Log, "JJ SHOW");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].keys, "enter");
+        assert_eq!(rows[0].action, "Open show");
+    }
+
+    #[test]
+    fn discovery_filter_searches_view_options_aliases() {
+        let rows = filter_discovery_rows(BindingContext::Log, "template log");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].keys, "V");
+        assert_eq!(rows[0].command_family_label(), Some("view options"));
+
+        let rows = filter_discovery_rows(BindingContext::Log, "view options");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].keys, "V");
+    }
+
+    #[test]
+    fn log_discovery_finds_mark_and_clear_bindings() {
+        let mark_rows = filter_discovery_rows(BindingContext::Log, "space mark");
+        assert_eq!(mark_rows.len(), 1);
+        assert_eq!(mark_rows[0].keys, "space");
+        assert_eq!(mark_rows[0].command_family_label(), Some("mark"));
+
+        let clear_rows = filter_discovery_rows(BindingContext::Log, "clear marks");
+        assert_eq!(clear_rows.len(), 1);
+        assert_eq!(clear_rows[0].keys, "c");
+    }
+
+    #[test]
+    fn log_discovery_finds_evolog_binding() {
+        for query in [
+            "v",
+            "evolog",
+            "jj evolog",
+            "evolution history",
+            "selected change",
+        ] {
+            let rows = filter_discovery_rows(BindingContext::Log, query);
+            let evolog_row = rows
+                .iter()
+                .find(|row| row.keys == "v")
+                .copied()
+                .unwrap_or_else(|| panic!("missing evolog row for query {query:?}"));
+
+            assert_eq!(evolog_row.action, "Open evolog");
+            assert_eq!(evolog_row.command_family_label(), Some("jj evolog"));
+        }
+    }
+
+    #[test]
+    fn workspaces_discovery_finds_workspace_actions() {
+        let log_rows = filter_discovery_rows(BindingContext::Workspaces, "workspace log");
+        assert_eq!(log_rows.len(), 1);
+        assert_eq!(log_rows[0].keys, "l");
+        assert_eq!(log_rows[0].command_family_label(), Some("jj log"));
+
+        let status_rows = filter_discovery_rows(BindingContext::Workspaces, "workspace status");
+        assert_eq!(status_rows.len(), 1);
+        assert_eq!(status_rows[0].keys, "enter, s");
+        assert_eq!(status_rows[0].command_family_label(), Some("jj status"));
+
+        let back_rows = filter_discovery_rows(BindingContext::Workspaces, "back previous");
+        assert_eq!(back_rows.len(), 1);
+        assert_eq!(back_rows[0].keys, "Backspace, Esc, H/L");
+        assert_eq!(back_rows[0].context_label(), "workspaces");
+
+        let update_rows = filter_discovery_rows(BindingContext::Workspaces, "update stale");
+        assert_eq!(update_rows.len(), 1);
+        assert_eq!(update_rows[0].keys, "u");
+        assert_eq!(update_rows[0].command_family_label(), Some("jj workspace"));
+    }
+
+    #[test]
+    fn discovery_finds_command_history_entry_point() {
+        for context in [
+            BindingContext::Log,
+            BindingContext::Diff,
+            BindingContext::Inspection,
+            BindingContext::Workspaces,
+        ] {
+            let rows = filter_discovery_rows(context, "command history");
+
+            assert_eq!(rows.len(), 1, "{context:?}");
+            assert_eq!(rows[0].keys, "C");
+            assert_eq!(rows[0].command_family_label(), Some("history"));
+        }
+    }
+
+    #[test]
+    fn discovery_finds_colon_command_mode() {
+        for context in [
+            BindingContext::Log,
+            BindingContext::Diff,
+            BindingContext::Inspection,
+            BindingContext::Workspaces,
+            BindingContext::CommandHistory,
+            BindingContext::OperationLog,
+        ] {
+            let rows = filter_discovery_rows(context, "colon prompt");
+
+            assert_eq!(rows.len(), 1, "{context:?}");
+            assert_eq!(rows[0].keys, ":");
+            assert_eq!(rows[0].action, "Run jj command");
+            assert_eq!(rows[0].command_family_label(), Some("jj command"));
+        }
+    }
+
+    #[test]
+    fn command_history_discovery_finds_operation_route() {
+        for query in ["operation", "op log", "recovery selected command"] {
+            let rows = filter_discovery_rows(BindingContext::CommandHistory, query);
+
+            assert_eq!(rows.len(), 1, "{query}");
+            assert_eq!(rows[0].keys, "o");
+            assert_eq!(rows[0].action, "Open operation");
+            assert_eq!(rows[0].command_family_label(), Some("jj operation"));
+        }
+    }
+
+    #[test]
+    fn operation_log_discovery_finds_show_diff_and_refresh() {
+        let show_rows = filter_discovery_rows(BindingContext::OperationLog, "operation show");
+        assert_eq!(show_rows.len(), 1);
+        assert_eq!(show_rows[0].keys, "enter");
+        assert_eq!(show_rows[0].command_family_label(), Some("jj operation"));
+
+        let diff_rows = filter_discovery_rows(BindingContext::OperationLog, "operation diff");
+        assert_eq!(diff_rows.len(), 1);
+        assert_eq!(diff_rows[0].keys, "d");
+        assert_eq!(diff_rows[0].command_family_label(), Some("jj operation"));
+
+        let refresh_rows = filter_discovery_rows(BindingContext::OperationLog, "operation reload");
+        assert_eq!(refresh_rows.len(), 1);
+        assert_eq!(refresh_rows[0].keys, "r");
+        assert_eq!(refresh_rows[0].command_family_label(), Some("refresh"));
+    }
+
+    #[test]
+    fn discovery_filter_keeps_binding_order_without_scoring() {
+        let rows = filter_discovery_rows(BindingContext::Diff, "fold");
+        let keys = rows.iter().map(|row| row.keys).collect::<Vec<_>>();
+
+        assert_eq!(keys, vec!["h / l", "Ctrl-left/right", "- / +"]);
+    }
+
+    #[test]
+    fn discovery_lines_render_empty_state_for_no_results() {
+        assert_eq!(
+            discovery_lines(BindingContext::Inspection, "definitely-not-present", 99),
+            vec![
+                "? definitely-not-present",
+                "  no matching commands",
+                "",
+                "type to filter   j/k or arrows move   enter/esc close",
+            ]
+        );
+    }
+}

--- a/crates/jk-tui/src/lib.rs
+++ b/crates/jk-tui/src/lib.rs
@@ -1,16 +1,31 @@
 //! Ratatui views and interaction state for `jk`.
 //!
-//! The public surface is currently the log view in [`log_view`] and selected-change diff view in
-//! [`diff_view`]. They accept rendered snapshots from `jk-cli`, apply input actions, and render
-//! borderless views that keep `jj` output visually intact while adding title/status chrome and
-//! selected-row highlighting.
+//! The public surface is currently the log view in [`log_view`], selected-change diff view in
+//! [`diff_view`], and workspace list view in [`workspaces_view`]. They accept caller-provided
+//! snapshots, apply input actions, and render borderless views that keep `jj` output visually
+//! intact while adding title/status chrome and selected-row highlighting.
 
+pub mod command_history_view;
+pub mod command_preview_view;
 pub mod diff_view;
 pub mod log_view;
+pub mod operation_log_view;
+pub mod rendered_view;
+pub mod workspaces_view;
 
 mod ansi_text;
 mod chrome;
 mod diff_state;
+mod keymap;
 mod log_state;
 mod rendered_log;
+mod rendered_state;
 mod selected_row;
+
+/// Searchable command-discovery metadata and popup formatting.
+pub mod command_discovery {
+    pub use crate::keymap::{
+        BindingContext, CommandFamily, DiscoveryRow, discovery_lines, discovery_rows,
+        filter_discovery_rows, filtered_discovery_len,
+    };
+}

--- a/crates/jk-tui/src/log_state.rs
+++ b/crates/jk-tui/src/log_state.rs
@@ -9,6 +9,43 @@ use jk_core::{LogEntry, LogSnapshot};
 use crate::ansi_text::strip_ansi;
 use crate::chrome::title_or_default;
 
+/// Ordered revision marks keyed by stable change id.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct OrderedRevisionMarks {
+    change_ids: Vec<String>,
+}
+
+impl OrderedRevisionMarks {
+    fn toggle(&mut self, change_id: &str) {
+        if let Some(index) = self.index_for(change_id) {
+            self.change_ids.remove(index);
+        } else {
+            self.change_ids.push(change_id.to_owned());
+        }
+    }
+
+    fn clear(&mut self) -> bool {
+        let had_marks = !self.change_ids.is_empty();
+        self.change_ids.clear();
+        had_marks
+    }
+
+    fn retain_visible(&mut self, entries: &[LogEntry]) {
+        self.change_ids
+            .retain(|change_id| entries.iter().any(|entry| entry.change_id() == change_id));
+    }
+
+    fn index_for(&self, change_id: &str) -> Option<usize> {
+        self.change_ids
+            .iter()
+            .position(|marked| marked == change_id)
+    }
+
+    fn change_ids(&self) -> &[String] {
+        &self.change_ids
+    }
+}
+
 /// Semantic state behind the interactive log view.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct LogState {
@@ -19,6 +56,8 @@ pub struct LogState {
     expanded_change_id: Option<String>,
     scroll_offset: usize,
     viewport_height: usize,
+    follow_selection: bool,
+    marks: OrderedRevisionMarks,
 }
 
 impl LogState {
@@ -34,6 +73,8 @@ impl LogState {
             expanded_change_id: None,
             scroll_offset: 0,
             viewport_height: 10,
+            follow_selection: true,
+            marks: OrderedRevisionMarks::default(),
         }
     }
 
@@ -47,6 +88,7 @@ impl LogState {
         self.title = title_or_default(title);
         self.rendered = rendered;
         self.entries = entries;
+        self.marks.retain_visible(&self.entries);
         self.selected = selected_change_id
             .and_then(|change_id| {
                 self.entries
@@ -86,6 +128,19 @@ impl LogState {
     /// Returns the first rendered line currently visible in the viewport.
     pub const fn scroll_offset(&self) -> usize {
         self.scroll_offset
+    }
+
+    /// Scrolls one rendered line toward newer changes without changing selection.
+    pub const fn scroll_previous_line(&mut self) {
+        self.follow_selection = false;
+        self.scroll_offset = self.scroll_offset.saturating_sub(1);
+    }
+
+    /// Scrolls one rendered line toward older changes without changing selection.
+    pub fn scroll_next_line(&mut self) {
+        self.follow_selection = false;
+        self.scroll_offset = self.scroll_offset.saturating_add(1);
+        self.clamp_scroll_offset();
     }
 
     /// Returns whether the selected change currently owns inline details.
@@ -180,9 +235,59 @@ impl LogState {
         self.expanded_change_id = None;
     }
 
+    /// Toggles the selected change in the ordered revision marks.
+    pub fn toggle_selected_mark(&mut self) {
+        let Some(change_id) = self
+            .selected_entry()
+            .map(|entry| entry.change_id().to_owned())
+        else {
+            return;
+        };
+
+        self.marks.toggle(&change_id);
+    }
+
+    /// Clears all revision marks and returns whether anything changed.
+    pub fn clear_marks(&mut self) -> bool {
+        self.marks.clear()
+    }
+
+    /// Returns whether any revision marks are set.
+    pub fn has_marks(&self) -> bool {
+        !self.marks.change_ids().is_empty()
+    }
+
+    /// Returns marked change ids in insertion order.
+    pub fn marked_change_ids(&self) -> &[String] {
+        self.marks.change_ids()
+    }
+
+    /// Returns the selected change's zero-based mark index, if marked.
+    pub fn selected_mark_index(&self) -> Option<usize> {
+        self.selected_entry()
+            .and_then(|entry| self.mark_index_for_change_id(entry.change_id()))
+    }
+
+    /// Returns the zero-based mark index for a change id.
+    pub fn mark_index_for_change_id(&self, change_id: &str) -> Option<usize> {
+        self.marks.index_for(change_id)
+    }
+
+    /// Returns the rendered line for a visible change id.
+    pub fn rendered_line_for_change_id(&self, change_id: &str) -> Option<usize> {
+        self.entries
+            .iter()
+            .find(|entry| entry.change_id() == change_id)
+            .map(LogEntry::rendered_line)
+    }
+
     /// Updates viewport height and scrolls enough to keep selection visible.
     pub fn keep_selected_in_view(&mut self, height: usize) {
         self.viewport_height = height.max(1);
+        if !self.follow_selection {
+            self.clamp_scroll_offset();
+            return;
+        }
 
         let Some(selected_line) = self.selected_rendered_line() else {
             self.scroll_offset = 0;
@@ -195,8 +300,11 @@ impl LogState {
         }
 
         let last_visible = self.scroll_offset + height.saturating_sub(1);
-        if selected_line > last_visible {
-            self.scroll_offset = selected_line + 1 - height;
+        let selected_end_line = self.selected_entry_end_line().unwrap_or(selected_line);
+        if selected_end_line > last_visible {
+            let scroll_for_entry_end = selected_end_line + 1 - height;
+            self.scroll_offset = scroll_for_entry_end.min(selected_line);
+            self.clamp_scroll_offset();
         }
     }
 
@@ -230,6 +338,15 @@ impl LogState {
         self.selected_entry().map(LogEntry::rendered_line)
     }
 
+    /// Returns the final rendered line that belongs to the selected entry.
+    fn selected_entry_end_line(&self) -> Option<usize> {
+        let selected = self.selected?;
+        self.entries
+            .get(selected + 1)
+            .map(|entry| entry.rendered_line().saturating_sub(1))
+            .or_else(|| last_entry_line(&self.rendered))
+    }
+
     /// Scrolls upward when selection moves above the current viewport.
     fn keep_selected_visible(&mut self) {
         let Some(selected_line) = self.selected_rendered_line() else {
@@ -250,6 +367,7 @@ impl LogState {
 
         let was_expanded = self.selected_is_expanded();
         self.selected = Some(index);
+        self.follow_selection = true;
         self.apply_expansion_to_selected(was_expanded);
         self.keep_selected_visible();
     }
@@ -271,12 +389,7 @@ impl LogState {
             return;
         }
 
-        let max_scroll_offset = self
-            .rendered
-            .lines()
-            .count()
-            .saturating_sub(1)
-            .min(self.entries.last().map_or(0, LogEntry::rendered_line));
+        let max_scroll_offset = self.rendered.lines().count().saturating_sub(1);
         self.scroll_offset = self.scroll_offset.min(max_scroll_offset);
     }
 }
@@ -391,6 +504,107 @@ mod tests {
     }
 
     #[test]
+    fn toggle_selected_mark_adds_change_id_in_order() {
+        let mut state = LogState::new(snapshot(["aaa", "bbb", "ccc"]));
+
+        state.toggle_selected_mark();
+        state.select_next();
+        state.toggle_selected_mark();
+
+        assert_eq!(state.marked_change_ids(), ["aaa", "bbb"]);
+        assert_eq!(state.selected_mark_index(), Some(1));
+    }
+
+    #[test]
+    fn toggle_selected_mark_removes_existing_mark_and_closes_gap() {
+        let mut state = LogState::new(snapshot(["aaa", "bbb", "ccc"]));
+
+        state.toggle_selected_mark();
+        state.select_next();
+        state.toggle_selected_mark();
+        state.select_previous();
+        state.toggle_selected_mark();
+
+        assert_eq!(state.marked_change_ids(), ["bbb"]);
+        assert_eq!(state.mark_index_for_change_id("bbb"), Some(0));
+    }
+
+    #[test]
+    fn toggle_selected_mark_does_not_duplicate_change_id() {
+        let mut state = LogState::new(snapshot(["aaa", "bbb"]));
+
+        state.toggle_selected_mark();
+        state.toggle_selected_mark();
+        state.toggle_selected_mark();
+
+        assert_eq!(state.marked_change_ids(), ["aaa"]);
+    }
+
+    #[test]
+    fn clear_marks_empties_marks_and_reports_change() {
+        let mut state = LogState::new(snapshot(["aaa", "bbb"]));
+
+        assert!(!state.clear_marks());
+        state.toggle_selected_mark();
+        assert!(state.has_marks());
+
+        assert!(state.clear_marks());
+
+        assert!(!state.has_marks());
+        assert!(state.marked_change_ids().is_empty());
+    }
+
+    #[test]
+    fn refresh_preserves_marks_when_change_ids_still_exist() {
+        let mut state = LogState::new(snapshot(["aaa", "bbb", "ccc"]));
+        state.toggle_selected_mark();
+        state.select_next();
+        state.select_next();
+        state.toggle_selected_mark();
+
+        state.refresh(snapshot(["ccc", "xxx", "aaa"]));
+
+        assert_eq!(state.marked_change_ids(), ["aaa", "ccc"]);
+        assert_eq!(state.mark_index_for_change_id("aaa"), Some(0));
+        assert_eq!(state.mark_index_for_change_id("ccc"), Some(1));
+    }
+
+    #[test]
+    fn refresh_drops_marks_for_disappeared_changes() {
+        let mut state = LogState::new(snapshot(["aaa", "bbb", "ccc"]));
+        state.toggle_selected_mark();
+        state.select_next();
+        state.toggle_selected_mark();
+        state.select_next();
+        state.toggle_selected_mark();
+
+        state.refresh(snapshot(["ccc", "aaa"]));
+
+        assert_eq!(state.marked_change_ids(), ["aaa", "ccc"]);
+    }
+
+    #[test]
+    fn line_scroll_and_mark_toggle_do_not_change_selection_or_scroll() {
+        let mut state = LogState::new(snapshot(["aaa", "bbb", "ccc", "ddd"]));
+        state.select_next();
+        state.scroll_next_line();
+        let selected = state
+            .selected_entry()
+            .map(|entry| entry.change_id().to_owned());
+        let scroll_offset = state.scroll_offset();
+
+        state.toggle_selected_mark();
+
+        assert_eq!(
+            state
+                .selected_entry()
+                .map(|entry| entry.change_id().to_owned()),
+            selected
+        );
+        assert_eq!(state.scroll_offset(), scroll_offset);
+    }
+
+    #[test]
     fn toggle_expanded_ignores_entries_without_details() {
         let mut state = LogState::new(LogSnapshot::new(
             "@  aaa first\n○  bbb second\n",
@@ -425,6 +639,81 @@ mod tests {
         state.keep_selected_in_view(2);
 
         assert_eq!(state.scroll_offset(), 3);
+    }
+
+    #[test]
+    fn selected_multiline_entry_keeps_whole_message_visible_when_it_fits() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  aaa first\n│  first body\n○  bbb second\n│  second body\n│  more body\n◆  ccc third\n",
+            vec![
+                LogEntry::new("aaa", "111", "first").with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(2),
+                LogEntry::new("ccc", "333", "third").with_rendered_line(5),
+            ],
+        ));
+
+        state.select_next();
+        state.keep_selected_in_view(3);
+
+        assert_eq!(state.scroll_offset(), 2);
+    }
+
+    #[test]
+    fn selected_tall_entry_keeps_commit_row_and_body_visible() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  aaa first\n│  first body\n○  bbb second\n│  line one\n│  line two\n│  line three\n│  line four\n◆  ccc third\n",
+            vec![
+                LogEntry::new("aaa", "111", "first").with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(2),
+                LogEntry::new("ccc", "333", "third").with_rendered_line(7),
+            ],
+        ));
+
+        state.select_next();
+        state.keep_selected_in_view(3);
+
+        assert_eq!(state.scroll_offset(), 2);
+    }
+
+    #[test]
+    fn line_scroll_moves_view_without_changing_selection() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  aaa first\n│  first body\n○  bbb second\n│  second body\n◆  ccc third\n",
+            vec![
+                LogEntry::new("aaa", "111", "first").with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(2),
+                LogEntry::new("ccc", "333", "third").with_rendered_line(4),
+            ],
+        ));
+
+        state.scroll_next_line();
+        state.scroll_next_line();
+        state.scroll_previous_line();
+        state.keep_selected_in_view(2);
+
+        assert_eq!(state.scroll_offset(), 1);
+        assert_eq!(state.selected_entry().map(LogEntry::change_id), Some("aaa"));
+    }
+
+    #[test]
+    fn selection_movement_resumes_following_selection_after_line_scroll() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  aaa first\n│  first body\n○  bbb second\n│  second body\n◆  ccc third\n",
+            vec![
+                LogEntry::new("aaa", "111", "first").with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(2),
+                LogEntry::new("ccc", "333", "third").with_rendered_line(4),
+            ],
+        ));
+
+        state.scroll_next_line();
+        state.scroll_next_line();
+        state.keep_selected_in_view(2);
+        state.select_next();
+        state.keep_selected_in_view(2);
+
+        assert_eq!(state.selected_entry().map(LogEntry::change_id), Some("bbb"));
+        assert_eq!(state.scroll_offset(), 2);
     }
 
     #[test]

--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -8,9 +8,11 @@
 use jk_core::LogSnapshot;
 use ratatui::Frame;
 use ratatui::layout::Rect;
+use ratatui::prelude::{Color, Modifier, Style};
 use ratatui::widgets::Paragraph;
 
-use crate::chrome::{LOG_STATUS, ViewChrome, render_help_overlay};
+use crate::chrome::{ViewChrome, render_help_overlay};
+use crate::keymap::{BindingContext, adaptive_hotbar, help_lines, help_title};
 use crate::log_state::LogState;
 use crate::rendered_log::{ExpandedDetails, RenderedLog, rendered_text};
 use crate::selected_row::paint_selected_row;
@@ -50,6 +52,12 @@ pub enum LogAction {
 
     /// Move to the next visible change.
     Next,
+
+    /// Scroll one rendered line toward newer changes.
+    ScrollPreviousLine,
+
+    /// Scroll one rendered line toward older changes.
+    ScrollNextLine,
 
     /// Move one visible page toward older changes.
     PagePrevious,
@@ -98,6 +106,12 @@ pub enum LogAction {
 
     /// Collapse inline details for the selected change.
     CollapseExpanded,
+
+    /// Toggle the selected change in ordered revision marks.
+    ToggleMark,
+
+    /// Clear ordered revision marks.
+    ClearMarks,
 
     /// Refresh the log.
     Refresh,
@@ -155,11 +169,41 @@ impl LogView {
         self.status_message = Some(error.into());
     }
 
+    /// Shows a non-error status message without replacing the current log.
+    pub fn show_status(&mut self, status: impl Into<String>) {
+        self.status_message = Some(status.into());
+    }
+
     /// Returns the selected change identifier for follow-up inspection commands.
     pub fn selected_change_id(&self) -> Option<&str> {
         self.state
             .selected_entry()
             .map(jk_core::LogEntry::change_id)
+    }
+
+    /// Returns the selected change's full description for editing commands.
+    pub fn selected_description(&self) -> Option<&str> {
+        self.state
+            .selected_entry()
+            .map(jk_core::LogEntry::description)
+    }
+
+    /// Returns whether the log has ordered revision marks.
+    #[must_use]
+    pub fn has_marks(&self) -> bool {
+        self.state.has_marks()
+    }
+
+    /// Returns marked change ids in insertion order.
+    #[must_use]
+    pub fn marked_change_ids(&self) -> &[String] {
+        self.state.marked_change_ids()
+    }
+
+    /// Returns the selected change's zero-based mark index, if marked.
+    #[must_use]
+    pub fn selected_mark_index(&self) -> Option<usize> {
+        self.state.selected_mark_index()
     }
 
     /// Applies a single input action.
@@ -175,6 +219,14 @@ impl LogView {
             }
             LogAction::Next => {
                 self.state.select_next();
+                ActionResult::Continue
+            }
+            LogAction::ScrollPreviousLine => {
+                self.state.scroll_previous_line();
+                ActionResult::Continue
+            }
+            LogAction::ScrollNextLine => {
+                self.state.scroll_next_line();
                 ActionResult::Continue
             }
             LogAction::PagePrevious => {
@@ -211,6 +263,14 @@ impl LogView {
                 self.state.collapse_expanded();
                 ActionResult::Continue
             }
+            LogAction::ToggleMark => {
+                self.state.toggle_selected_mark();
+                ActionResult::Continue
+            }
+            LogAction::ClearMarks => {
+                self.state.clear_marks();
+                ActionResult::Continue
+            }
             LogAction::Refresh => ActionResult::Refresh,
             LogAction::Home => ActionResult::SwitchHome,
             LogAction::Log => ActionResult::SwitchLog,
@@ -236,16 +296,33 @@ impl LogView {
     /// Renders the log view.
     pub fn render(&mut self, frame: &mut Frame<'_>) {
         let area = frame.area();
-        self.render_area(frame, area);
+        self.render_area(frame, area, None);
     }
 
-    fn render_area(&mut self, frame: &mut Frame<'_>, area: Rect) {
+    /// Renders the log view with a caller-owned status line.
+    pub fn render_with_status(&mut self, frame: &mut Frame<'_>, status: &str) {
+        let area = frame.area();
+        self.render_area(frame, area, Some(status));
+    }
+
+    /// Renders the log view with a centered selector overlay.
+    pub fn render_with_selector(&mut self, frame: &mut Frame<'_>, title: &str, lines: &[String]) {
+        let area = frame.area();
+        self.render_area(frame, area, None);
+        let areas = ViewChrome::layout(area);
+        render_help_overlay(frame, areas.content, title, lines);
+    }
+
+    fn render_area(&mut self, frame: &mut Frame<'_>, area: Rect, status: Option<&str>) {
         let areas = ViewChrome::layout(area);
         let height = usize::from(areas.content.height);
         self.state.keep_selected_in_view(height);
 
-        let status = self.status_message.as_deref().unwrap_or(LOG_STATUS);
-        let chrome = ViewChrome::new(self.state.title(), status);
+        let status = status
+            .map(ToOwned::to_owned)
+            .or_else(|| self.status_message.clone())
+            .unwrap_or_else(|| adaptive_hotbar(BindingContext::Log, areas.status_width()));
+        let chrome = ViewChrome::new(self.state.title(), &status);
         chrome.render(frame, areas);
 
         let expanded_details = self
@@ -253,35 +330,78 @@ impl LogView {
             .expanded_insertion_line()
             .zip(self.state.expanded_details())
             .map(|(line, description)| ExpandedDetails::new(line, description));
-        let rendered =
+        let rendered_log =
             RenderedLog::new(self.state.rendered()).with_expanded_details(expanded_details);
-        let rendered = rendered.render_with_width(usize::from(areas.content.width));
+        let content_width = usize::from(areas.content.width);
+        let rendered = rendered_log.render_with_width(content_width);
         let text = rendered_text(&rendered);
         let scroll = u16::try_from(self.state.scroll_offset()).unwrap_or(u16::MAX);
         let paragraph = Paragraph::new(text).scroll((scroll, 0));
         frame.render_widget(paragraph, areas.content);
 
+        paint_mark_overlays(frame, areas.content, &self.state, &rendered_log);
         if let Some(line) = self.state.selected_rendered_line() {
             paint_selected_row(frame, areas.content, line, self.state.scroll_offset());
         }
 
         if self.help_visible {
-            render_help_overlay(frame, areas.content, "Log keys", LOG_HELP);
+            render_help_overlay(
+                frame,
+                areas.content,
+                help_title(BindingContext::Log),
+                &help_lines(BindingContext::Log),
+            );
         }
     }
 }
 
-const LOG_HELP: &[&str] = &[
-    "j/k or arrows        move selection",
-    "space / b, Ctrl-f/b  page down/up",
-    "g/G or Home/End      jump to top/bottom",
-    "enter, right, l      expand selected change",
-    "left, h              collapse selected change",
-    "d                    open selected-change diff",
-    "r                    refresh",
-    "H / L                home command / jj log",
-    "?, q, Esc            close help",
-];
+fn paint_mark_overlays(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &LogState,
+    rendered_log: &RenderedLog<'_>,
+) {
+    if area.is_empty() || area.width < 3 {
+        return;
+    }
+
+    let content_width = usize::from(area.width);
+    for change_id in state.marked_change_ids() {
+        let Some(mark_index) = state.mark_index_for_change_id(change_id) else {
+            continue;
+        };
+        let Some(rendered_line) = state.rendered_line_for_change_id(change_id) else {
+            continue;
+        };
+        let rendered_line = rendered_log.line_after_insertions(rendered_line, content_width);
+        let Some(visible_line) = rendered_line.checked_sub(state.scroll_offset()) else {
+            continue;
+        };
+        let Ok(visible_line) = u16::try_from(visible_line) else {
+            continue;
+        };
+        if visible_line >= area.height {
+            continue;
+        }
+
+        let label = format!("[{}]", mark_index + 1);
+        let label_width = u16::try_from(label.chars().count()).unwrap_or(u16::MAX);
+        if label_width > area.width {
+            continue;
+        }
+
+        let y = area.y + visible_line;
+        let x = area.right() - label_width;
+        frame.buffer_mut().set_string(
+            x,
+            y,
+            label,
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -330,6 +450,27 @@ mod tests {
     }
 
     #[test]
+    fn status_messages_replace_default_hotbar_until_refresh() {
+        let mut view = LogView::new(snapshot(["aaa"]));
+        view.show_status("u undo  U redo  o operation  C history");
+        let backend = TestBackend::new(56, 4);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+        assert!(buffer_line(terminal.backend().buffer(), 3).contains("u undo"));
+        assert!(buffer_line(terminal.backend().buffer(), 3).contains("C history"));
+
+        view.refresh(snapshot(["bbb"]));
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+        assert!(!buffer_line(terminal.backend().buffer(), 3).contains("u undo"));
+    }
+
+    #[test]
     fn empty_log_renders_chrome_without_selection() {
         let mut view = LogView::new(LogSnapshot::new("", Vec::new()).with_title("jj log"));
         let backend = TestBackend::new(48, 4);
@@ -350,7 +491,7 @@ mod tests {
     fn help_action_shows_log_specific_keys() {
         let mut view = LogView::new(snapshot(["aaa"]));
         let _ = view.apply(LogAction::ToggleHelp);
-        let backend = TestBackend::new(72, 16);
+        let backend = TestBackend::new(72, 32);
         let mut terminal = match Terminal::new(backend) {
             Ok(terminal) => terminal,
             Err(error) => match error {},
@@ -362,6 +503,13 @@ mod tests {
         let rendered = buffer_to_string(terminal.backend().buffer());
         assert!(rendered.contains("Log keys"));
         assert!(rendered.contains("d                    open selected-change diff"));
+        assert!(rendered.contains("m                    describe selected revision"));
+        assert!(rendered.contains("s                    open repository status"));
+        assert!(rendered.contains("n                    preview jj new"));
+        assert!(rendered.contains("e                    preview jj edit"));
+        assert!(rendered.contains("a                    preview jj abandon"));
+        assert!(rendered.contains("u                    preview jj undo"));
+        assert!(rendered.contains("U                    preview jj redo"));
         assert!(rendered.contains("?, q, Esc            close help"));
     }
 
@@ -482,6 +630,108 @@ mod tests {
         assert_eq!(buffer[(23, 2)].bg, Color::Rgb(12, 32, 38));
         assert_eq!(buffer[(35, 2)].bg, Color::Rgb(12, 32, 38));
         assert_eq!(buffer[(36, 2)].bg, Color::Reset);
+    }
+
+    #[test]
+    fn marked_rows_render_ordered_affordances() {
+        let mut view = LogView::new(snapshot(["aaa", "bbb", "ccc"]));
+        let _ = view.apply(LogAction::ToggleMark);
+        let _ = view.apply(LogAction::Next);
+        let _ = view.apply(LogAction::Next);
+        let _ = view.apply(LogAction::ToggleMark);
+        let backend = TestBackend::new(48, 6);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let buffer = terminal.backend().buffer();
+        assert!(buffer_line(buffer, 1).ends_with("[1]"));
+        assert!(!buffer_line(buffer, 2).contains('['));
+        assert!(buffer_line(buffer, 3).ends_with("[2]"));
+    }
+
+    #[test]
+    fn selected_marked_row_keeps_selected_background() {
+        let mut view = LogView::new(snapshot(["aaa", "bbb"]));
+        let _ = view.apply(LogAction::ToggleMark);
+        let backend = TestBackend::new(48, 5);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 1)].bg, Color::Rgb(82, 196, 192));
+        assert!(buffer_line(buffer, 1).contains("[1]"));
+    }
+
+    #[test]
+    fn marked_rows_after_expanded_details_render_on_shifted_line() {
+        let mut view = LogView::new(LogSnapshot::new(
+            "@  aaa first\n○  bbb second\n",
+            vec![
+                LogEntry::new("aaa", "111", "first\n\nbody")
+                    .with_details("body")
+                    .with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(1),
+            ],
+        ));
+        let _ = view.apply(LogAction::Next);
+        let _ = view.apply(LogAction::ToggleMark);
+        let _ = view.apply(LogAction::Previous);
+        let _ = view.apply(LogAction::ToggleExpanded);
+        let backend = TestBackend::new(64, 8);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let buffer = terminal.backend().buffer();
+        assert!(buffer_line(buffer, 5).contains("○  bbb second"));
+        assert!(buffer_line(buffer, 5).ends_with("[1]"));
+        assert!(!buffer_line(buffer, 1).contains("[1]"));
+    }
+
+    #[test]
+    fn clear_marks_removes_visible_affordances() {
+        let mut view = LogView::new(snapshot(["aaa", "bbb"]));
+        let _ = view.apply(LogAction::ToggleMark);
+        let _ = view.apply(LogAction::ClearMarks);
+        let backend = TestBackend::new(48, 5);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        assert!(!buffer_to_string(terminal.backend().buffer()).contains("[1]"));
+    }
+
+    #[test]
+    fn narrow_mark_overlay_rendering_does_not_panic() {
+        let mut view = LogView::new(snapshot(["aaa"]));
+        let _ = view.apply(LogAction::ToggleMark);
+        let backend = TestBackend::new(2, 4);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+
+        assert!(draw_result.is_ok());
     }
 
     #[test]

--- a/crates/jk-tui/src/operation_log_view.rs
+++ b/crates/jk-tui/src/operation_log_view.rs
@@ -1,0 +1,601 @@
+//! Provider-neutral operation log list view.
+//!
+//! Callers map operation history into [`OperationLogSnapshot`] rows, translate terminal input into
+//! [`OperationLogAction`], and handle returned [`OperationLogActionResult`] values for effects such
+//! as refresh, operation show, operation diff, back navigation, and quit.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::prelude::{Color, Line, Modifier, Span, Style, Text};
+use ratatui::widgets::Paragraph;
+
+use crate::chrome::{ViewChrome, render_help_overlay};
+use crate::keymap::{BindingContext, adaptive_hotbar, help_lines, help_title};
+use crate::selected_row::paint_subtle_selected_row;
+
+const DEFAULT_TITLE: &str = "jj op log";
+
+/// A provider-neutral snapshot of operation log rows.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct OperationLogSnapshot {
+    title: String,
+    rows: Vec<OperationLogRow>,
+}
+
+impl OperationLogSnapshot {
+    /// Creates an operation-log snapshot from display rows.
+    #[must_use]
+    pub fn new(rows: Vec<OperationLogRow>) -> Self {
+        Self {
+            title: DEFAULT_TITLE.to_owned(),
+            rows,
+        }
+    }
+
+    /// Sets the command context shown in the title bar.
+    #[must_use]
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Returns the title shown in the view chrome.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns rows in display order.
+    #[must_use]
+    pub fn rows(&self) -> &[OperationLogRow] {
+        &self.rows
+    }
+
+    fn current_index(&self) -> Option<usize> {
+        self.rows.iter().position(|row| row.current)
+    }
+
+    fn operation_index(&self, operation_id: &str) -> Option<usize> {
+        self.rows
+            .iter()
+            .position(|row| row.operation_id == operation_id)
+    }
+}
+
+/// One display row in the operation log.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperationLogRow {
+    /// Stable operation id used for follow-up actions and refresh selection.
+    pub operation_id: String,
+    /// Human-readable operation id, usually a short id.
+    pub display_id: String,
+    /// Human-readable operation description or title.
+    pub title: String,
+    /// Whether this row is the current operation.
+    pub current: bool,
+}
+
+impl OperationLogRow {
+    /// Creates an operation log row.
+    #[must_use]
+    pub fn new(
+        operation_id: impl Into<String>,
+        display_id: impl Into<String>,
+        title: impl Into<String>,
+        current: bool,
+    ) -> Self {
+        Self {
+            operation_id: operation_id.into(),
+            display_id: display_id.into(),
+            title: title.into(),
+            current,
+        }
+    }
+}
+
+/// The effect requested after applying an input action to the operation log view.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum OperationLogActionResult {
+    /// Continue running the application.
+    Continue,
+    /// Refresh the operation log from the data source.
+    Refresh,
+    /// Open `jj op show` for the selected operation id.
+    OperationShow {
+        /// Stable operation id selected for `jj op show`.
+        operation_id: String,
+    },
+    /// Open `jj op diff` for the selected operation id.
+    OperationDiff {
+        /// Stable operation id selected for `jj op diff`.
+        operation_id: String,
+    },
+    /// Return to the previous view.
+    ReturnBack,
+    /// Exit the application.
+    Quit,
+}
+
+/// Input actions understood by the operation log view.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum OperationLogAction {
+    /// Move to the previous operation.
+    Previous,
+    /// Move to the next operation.
+    Next,
+    /// Page toward newer operations.
+    PagePrevious,
+    /// Page toward older operations.
+    PageNext,
+    /// Move to the newest visible operation.
+    First,
+    /// Move to the oldest visible operation.
+    Last,
+    /// Refresh the operation log.
+    Refresh,
+    /// Open operation details for the selected operation.
+    OpenShow,
+    /// Open operation diff for the selected operation.
+    OpenDiff,
+    /// Toggle mode-specific help.
+    ToggleHelp,
+    /// Return to the previous view.
+    ReturnBack,
+    /// Quit the TUI.
+    Quit,
+}
+
+/// Interactive operation log list view.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct OperationLogView {
+    snapshot: OperationLogSnapshot,
+    selected: Option<usize>,
+    scroll_offset: usize,
+    help_visible: bool,
+}
+
+impl OperationLogView {
+    /// Creates an operation log view with the initial snapshot loaded.
+    #[must_use]
+    pub fn new(snapshot: OperationLogSnapshot) -> Self {
+        let selected = initial_selection(&snapshot);
+        Self {
+            snapshot,
+            selected,
+            scroll_offset: 0,
+            help_visible: false,
+        }
+    }
+
+    /// Replaces rows after a successful refresh.
+    ///
+    /// Selection is preserved by stable operation id when possible, then falls back to the current
+    /// operation row, then clamps to the nearest available row.
+    pub fn refresh(&mut self, snapshot: OperationLogSnapshot) {
+        let previous_operation_id = self.selected_row().map(|row| row.operation_id.clone());
+        let previous_selected = self.selected;
+        self.snapshot = snapshot;
+        self.selected = previous_operation_id
+            .as_deref()
+            .and_then(|operation_id| self.snapshot.operation_index(operation_id))
+            .or_else(|| self.snapshot.current_index())
+            .or_else(|| clamp_index(previous_selected, self.snapshot.rows.len()));
+        self.scroll_offset = clamp_scroll(self.scroll_offset, self.snapshot.rows.len());
+    }
+
+    /// Returns the selected row, if any.
+    #[must_use]
+    pub fn selected_row(&self) -> Option<&OperationLogRow> {
+        self.selected
+            .and_then(|index| self.snapshot.rows.get(index))
+    }
+
+    /// Returns the selected stable operation id, if any.
+    #[must_use]
+    pub fn selected_operation_id(&self) -> Option<&str> {
+        self.selected_row().map(|row| row.operation_id.as_str())
+    }
+
+    /// Applies a single input action.
+    #[must_use]
+    pub fn apply(&mut self, action: OperationLogAction) -> OperationLogActionResult {
+        match action {
+            OperationLogAction::Previous => {
+                self.select_previous();
+                OperationLogActionResult::Continue
+            }
+            OperationLogAction::Next => {
+                self.select_next();
+                OperationLogActionResult::Continue
+            }
+            OperationLogAction::PagePrevious => {
+                self.page_previous();
+                OperationLogActionResult::Continue
+            }
+            OperationLogAction::PageNext => {
+                self.page_next();
+                OperationLogActionResult::Continue
+            }
+            OperationLogAction::First => {
+                if !self.snapshot.rows.is_empty() {
+                    self.selected = Some(0);
+                }
+                OperationLogActionResult::Continue
+            }
+            OperationLogAction::Last => {
+                if !self.snapshot.rows.is_empty() {
+                    self.selected = Some(self.snapshot.rows.len() - 1);
+                }
+                OperationLogActionResult::Continue
+            }
+            OperationLogAction::Refresh => OperationLogActionResult::Refresh,
+            OperationLogAction::OpenShow => self.selected_operation_id().map_or(
+                OperationLogActionResult::Continue,
+                |operation_id| OperationLogActionResult::OperationShow {
+                    operation_id: operation_id.to_owned(),
+                },
+            ),
+            OperationLogAction::OpenDiff => self.selected_operation_id().map_or(
+                OperationLogActionResult::Continue,
+                |operation_id| OperationLogActionResult::OperationDiff {
+                    operation_id: operation_id.to_owned(),
+                },
+            ),
+            OperationLogAction::ToggleHelp => {
+                self.help_visible = !self.help_visible;
+                OperationLogActionResult::Continue
+            }
+            OperationLogAction::ReturnBack => OperationLogActionResult::ReturnBack,
+            OperationLogAction::Quit if self.help_visible => {
+                self.help_visible = false;
+                OperationLogActionResult::Continue
+            }
+            OperationLogAction::Quit => OperationLogActionResult::Quit,
+        }
+    }
+
+    /// Renders the operation log view.
+    pub fn render(&mut self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        self.render_area(frame, area, None);
+    }
+
+    /// Renders the operation log view with a temporary status-line override.
+    pub fn render_with_status(&mut self, frame: &mut Frame<'_>, status: &str) {
+        let area = frame.area();
+        self.render_area(frame, area, Some(status));
+    }
+
+    const fn select_previous(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        self.selected = Some(selected.saturating_sub(1));
+    }
+
+    fn select_next(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        let last = self.snapshot.rows.len().saturating_sub(1);
+        self.selected = Some(selected.saturating_add(1).min(last));
+    }
+
+    const fn page_previous(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        self.selected = Some(selected.saturating_sub(10));
+    }
+
+    fn page_next(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        let last = self.snapshot.rows.len().saturating_sub(1);
+        self.selected = Some(selected.saturating_add(10).min(last));
+    }
+
+    fn keep_selected_in_view(&mut self, height: usize) {
+        self.scroll_offset = clamp_scroll(self.scroll_offset, self.snapshot.rows.len());
+        let Some(selected) = self.selected else {
+            return;
+        };
+        if height == 0 {
+            return;
+        }
+        if selected < self.scroll_offset {
+            self.scroll_offset = selected;
+        } else if selected >= self.scroll_offset.saturating_add(height) {
+            self.scroll_offset = selected.saturating_add(1).saturating_sub(height);
+        }
+    }
+
+    fn render_area(&mut self, frame: &mut Frame<'_>, area: Rect, status_override: Option<&str>) {
+        let areas = ViewChrome::layout(area);
+        self.keep_selected_in_view(usize::from(areas.content.height));
+
+        let fallback_status = adaptive_hotbar(BindingContext::OperationLog, areas.status_width());
+        let status = status_override.unwrap_or(&fallback_status);
+        let chrome = ViewChrome::new(self.snapshot.title(), status);
+        chrome.render(frame, areas);
+
+        let paragraph = Paragraph::new(self.visible_text());
+        frame.render_widget(paragraph, areas.content);
+
+        if let Some(selected) = self.selected {
+            paint_subtle_selected_row(frame, areas.content, selected, self.scroll_offset);
+        }
+
+        if self.help_visible {
+            render_help_overlay(
+                frame,
+                areas.content,
+                help_title(BindingContext::OperationLog),
+                &help_lines(BindingContext::OperationLog),
+            );
+        }
+    }
+
+    fn visible_text(&self) -> Text<'_> {
+        if self.snapshot.rows.is_empty() {
+            return Text::from(vec![
+                Line::from(Span::styled(
+                    "No operations found.",
+                    Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                )),
+                Line::from(""),
+                Line::from("Press r to refresh."),
+            ]);
+        }
+
+        let rows = self
+            .snapshot
+            .rows
+            .iter()
+            .skip(self.scroll_offset)
+            .map(operation_line)
+            .collect::<Vec<_>>();
+        Text::from(rows)
+    }
+}
+
+fn operation_line(row: &OperationLogRow) -> Line<'_> {
+    let marker = if row.current { "*" } else { " " };
+    Line::from(vec![
+        Span::styled(
+            marker,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("{:<12}", row.display_id),
+            Style::new().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" "),
+        Span::raw(operation_title(row)),
+    ])
+}
+
+fn operation_title(row: &OperationLogRow) -> &str {
+    if row.title.trim().is_empty() {
+        "(no description)"
+    } else {
+        &row.title
+    }
+}
+
+fn initial_selection(snapshot: &OperationLogSnapshot) -> Option<usize> {
+    snapshot
+        .current_index()
+        .or_else(|| clamp_index(Some(0), snapshot.rows.len()))
+}
+
+fn clamp_index(index: Option<usize>, len: usize) -> Option<usize> {
+    let index = index?;
+    if len == 0 {
+        None
+    } else {
+        Some(index.min(len - 1))
+    }
+}
+
+fn clamp_scroll(scroll_offset: usize, len: usize) -> usize {
+    if len == 0 {
+        0
+    } else {
+        scroll_offset.min(len - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+
+    #[test]
+    fn selection_starts_on_current_operation() {
+        let view = OperationLogView::new(snapshot([
+            row("op1", "op1", "initial checkout", false),
+            row("op2", "op2", "describe change", true),
+            row("op3", "op3", "previous operation", false),
+        ]));
+
+        assert_eq!(view.selected_operation_id(), Some("op2"));
+    }
+
+    #[test]
+    fn refresh_preserves_selected_operation_by_id() {
+        let mut view = OperationLogView::new(snapshot([
+            row("op1", "op1", "initial checkout", true),
+            row("op2", "op2", "describe change", false),
+            row("op3", "op3", "previous operation", false),
+        ]));
+        let _ = view.apply(OperationLogAction::Next);
+
+        view.refresh(snapshot([
+            row("op4", "op4", "newer operation", true),
+            row("op2", "op2", "describe change", false),
+            row("op1", "op1", "initial checkout", false),
+        ]));
+
+        assert_eq!(view.selected_operation_id(), Some("op2"));
+    }
+
+    #[test]
+    fn refresh_falls_back_to_current_then_clamps() {
+        let mut view = OperationLogView::new(snapshot([
+            row("op1", "op1", "initial checkout", true),
+            row("op2", "op2", "describe change", false),
+            row("op3", "op3", "previous operation", false),
+        ]));
+        let _ = view.apply(OperationLogAction::Next);
+
+        view.refresh(snapshot([
+            row("op4", "op4", "new current", true),
+            row("op1", "op1", "initial checkout", false),
+        ]));
+
+        assert_eq!(view.selected_operation_id(), Some("op4"));
+
+        let mut view = OperationLogView::new(snapshot([
+            row("op1", "op1", "initial checkout", false),
+            row("op2", "op2", "describe change", false),
+            row("op3", "op3", "previous operation", false),
+        ]));
+        let _ = view.apply(OperationLogAction::Last);
+
+        view.refresh(snapshot([row("op4", "op4", "only operation", false)]));
+
+        assert_eq!(view.selected_operation_id(), Some("op4"));
+    }
+
+    #[test]
+    fn show_and_diff_results_carry_selected_operation_id() {
+        let mut view = OperationLogView::new(snapshot([
+            row("op1-full", "op1", "initial checkout", true),
+            row("op2-full", "op2", "describe change", false),
+        ]));
+        let _ = view.apply(OperationLogAction::Next);
+
+        assert_eq!(
+            view.apply(OperationLogAction::OpenShow),
+            OperationLogActionResult::OperationShow {
+                operation_id: "op2-full".to_owned(),
+            }
+        );
+        assert_eq!(
+            view.apply(OperationLogAction::OpenDiff),
+            OperationLogActionResult::OperationDiff {
+                operation_id: "op2-full".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn empty_snapshot_is_safe_and_renders_empty_state() {
+        let mut view = OperationLogView::new(OperationLogSnapshot::new(Vec::new()));
+
+        assert_eq!(view.selected_operation_id(), None);
+        assert_eq!(
+            view.apply(OperationLogAction::Previous),
+            OperationLogActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(OperationLogAction::Next),
+            OperationLogActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(OperationLogAction::OpenShow),
+            OperationLogActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(OperationLogAction::OpenDiff),
+            OperationLogActionResult::Continue
+        );
+
+        let backend = TestBackend::new(64, 6);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("No operations found."));
+        assert!(rendered.contains("Press r to refresh."));
+    }
+
+    #[test]
+    fn basic_render_contains_title_hotbar_marker_id_and_title() {
+        let mut view = OperationLogView::new(snapshot([
+            row("op1-full", "op1", "initial checkout", false),
+            row("op2-full", "op2", "describe change", true),
+        ]));
+        let backend = TestBackend::new(88, 6);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("jk jj op log"));
+        assert!(rendered.contains("* op2"));
+        assert!(rendered.contains("describe change"));
+        assert!(rendered.contains("enter show"));
+        assert!(rendered.contains("d diff"));
+        assert!(rendered.contains("Esc back"));
+    }
+
+    #[test]
+    fn help_overlay_uses_operation_log_keymap() {
+        let mut view =
+            OperationLogView::new(snapshot([row("op1-full", "op1", "initial checkout", true)]));
+        let _ = view.apply(OperationLogAction::ToggleHelp);
+        let backend = TestBackend::new(88, 12);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("Operation Log keys"));
+        assert!(rendered.contains("enter"));
+        assert!(rendered.contains("open selected operation show"));
+        assert!(rendered.contains('d'));
+        assert!(rendered.contains("open selected operation diff"));
+    }
+
+    fn snapshot<const N: usize>(rows: [OperationLogRow; N]) -> OperationLogSnapshot {
+        OperationLogSnapshot::new(rows.into())
+    }
+
+    fn row(operation_id: &str, display_id: &str, title: &str, current: bool) -> OperationLogRow {
+        OperationLogRow::new(operation_id, display_id, title, current)
+    }
+
+    fn buffer_to_string(buffer: &ratatui::buffer::Buffer) -> String {
+        let area = buffer.area;
+        let mut text = String::new();
+
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
+
+        text
+    }
+}

--- a/crates/jk-tui/src/rendered_log.rs
+++ b/crates/jk-tui/src/rendered_log.rs
@@ -48,6 +48,25 @@ impl<'a> RenderedLog<'a> {
         rendered
     }
 
+    /// Maps an original body line to its final rendered line after inserted details.
+    pub fn line_after_insertions(&self, line: usize, width: usize) -> usize {
+        let Some(details) = self.expanded_details else {
+            return line;
+        };
+        if details.after_line >= line {
+            return line;
+        }
+
+        let inserted_lines = self
+            .body
+            .lines()
+            .nth(details.after_line)
+            .map(expanded_prefix)
+            .map(|prefix| expanded_details_line_count(details.text, &prefix, width))
+            .unwrap_or_default();
+        line + inserted_lines
+    }
+
     /// Writes the body, inserting details after the configured rendered line.
     fn write_to(&self, rendered: &mut String, width: usize) {
         let Some(details) = self.expanded_details else {
@@ -97,6 +116,19 @@ fn write_expanded_details(rendered: &mut String, details: &str, prefix: &str, wi
     }
 
     write_expanded_line(rendered, prefix, "");
+}
+
+/// Counts the lines that [`write_expanded_details`] would insert.
+fn expanded_details_line_count(details: &str, prefix: &str, width: usize) -> usize {
+    let detail_lines = details.lines().map(|line| {
+        if line.is_empty() {
+            1
+        } else {
+            textwrap::wrap(line, wrap_options(detail_width(width, prefix))).len()
+        }
+    });
+
+    1 + detail_lines.sum::<usize>() + 1
 }
 
 /// Writes one inserted detail line with the graph prefix.
@@ -246,5 +278,14 @@ mod tests {
             rendered,
             "│ ○  aaa\n│ │  \n│ │  one two\n│ │  three\n│ │  four\n│ │  five\n│ │  \n"
         );
+    }
+
+    #[test]
+    fn maps_body_lines_after_inserted_details() {
+        let log = RenderedLog::new("@  aaa\n○  bbb\n")
+            .with_expanded_details(Some(ExpandedDetails::new(0, "one two three four five")));
+
+        assert_eq!(log.line_after_insertions(0, 16), 0);
+        assert_eq!(log.line_after_insertions(1, 16), 5);
     }
 }

--- a/crates/jk-tui/src/rendered_state.rs
+++ b/crates/jk-tui/src/rendered_state.rs
@@ -1,0 +1,212 @@
+//! State machine for generic rendered-output inspection.
+
+use jk_core::InspectionSnapshot;
+
+use crate::ansi_text::strip_ansi;
+use crate::chrome::title_or_default;
+
+/// Semantic state behind rendered read-only inspection output.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RenderedState {
+    title: String,
+    target: String,
+    rendered: String,
+    search: Option<SearchState>,
+    scroll_offset: usize,
+    viewport_height: usize,
+}
+
+impl RenderedState {
+    /// Creates state from a freshly loaded inspection snapshot.
+    pub fn new(snapshot: InspectionSnapshot) -> Self {
+        let (title, target, rendered) = snapshot.into_parts();
+        Self {
+            title: title_or_default(title),
+            target,
+            rendered,
+            search: None,
+            scroll_offset: 0,
+            viewport_height: 10,
+        }
+    }
+
+    /// Replaces rendered output while preserving the current search when practical.
+    pub fn refresh(&mut self, snapshot: InspectionSnapshot) {
+        let (title, target, rendered) = snapshot.into_parts();
+        self.title = title_or_default(title);
+        self.target = target;
+        self.rendered = rendered;
+        self.clamp_scroll_offset();
+        self.refresh_search_matches();
+    }
+
+    /// Returns the command context shown in the title bar.
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns the first rendered line currently visible in the viewport.
+    pub const fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    /// Sets the rendered viewport height and keeps scroll inside the body.
+    pub fn set_viewport_height(&mut self, height: usize) {
+        self.viewport_height = height;
+        self.clamp_scroll_offset();
+    }
+
+    /// Returns the rendered body or a fallback message for empty output/error states.
+    pub fn visible_body(&self, status_message: Option<&str>) -> String {
+        if !self.rendered.trim().is_empty() {
+            return self.rendered.clone();
+        }
+
+        if let Some(error) = status_message {
+            return format!(
+                "Unable to load inspection for {}.\n\n{error}\n\nPress r to retry or H/L to return to the log.\n",
+                self.target
+            );
+        }
+
+        format!(
+            "No output for {}.\n\nThe jj command produced no visible text.\n",
+            self.target
+        )
+    }
+
+    /// Scrolls one visible line toward the start of the output.
+    pub const fn scroll_previous_line(&mut self) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(1);
+    }
+
+    /// Scrolls one visible line toward the end of the output.
+    pub fn scroll_next_line(&mut self) {
+        self.scroll_offset = self.scroll_offset.saturating_add(1);
+        self.clamp_scroll_offset();
+    }
+
+    /// Scrolls one viewport toward the start of the output.
+    pub const fn select_page_previous(&mut self) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(self.viewport_height);
+    }
+
+    /// Scrolls one viewport toward the end of the output.
+    pub fn select_page_next(&mut self) {
+        self.scroll_offset = self.scroll_offset.saturating_add(self.viewport_height);
+        self.clamp_scroll_offset();
+    }
+
+    /// Moves to the first rendered line.
+    pub const fn select_first(&mut self) {
+        self.scroll_offset = 0;
+    }
+
+    /// Moves to the last visible page.
+    pub fn select_last(&mut self) {
+        self.scroll_offset = usize::MAX;
+        self.clamp_scroll_offset();
+    }
+
+    /// Searches visible rendered lines.
+    pub fn search(&mut self, query: &str, status_message: Option<&str>) {
+        let query = query.trim();
+        if query.is_empty() {
+            self.search = None;
+            return;
+        }
+
+        let matches = matching_lines(&self.visible_body(status_message), query);
+        let selected = (!matches.is_empty()).then_some(0);
+        self.search = Some(SearchState {
+            query: query.to_owned(),
+            matches,
+            selected,
+        });
+        self.scroll_to_selected_match();
+    }
+
+    /// Selects the next search match.
+    pub fn search_next(&mut self) {
+        let Some(search) = &mut self.search else {
+            return;
+        };
+        let Some(selected) = search.selected else {
+            return;
+        };
+        search.selected = Some((selected + 1).min(search.matches.len().saturating_sub(1)));
+        self.scroll_to_selected_match();
+    }
+
+    /// Selects the previous search match.
+    pub fn search_previous(&mut self) {
+        let Some(search) = &mut self.search else {
+            return;
+        };
+        let Some(selected) = search.selected else {
+            return;
+        };
+        search.selected = Some(selected.saturating_sub(1));
+        self.scroll_to_selected_match();
+    }
+
+    /// Returns status-line text for the current search, if any.
+    pub fn search_status(&self) -> Option<String> {
+        let search = self.search.as_ref()?;
+        Some(search.selected.map_or_else(
+            || format!("/{}  no matches", search.query),
+            |selected| {
+                format!(
+                    "/{}  {}/{}",
+                    search.query,
+                    selected + 1,
+                    search.matches.len()
+                )
+            },
+        ))
+    }
+
+    fn refresh_search_matches(&mut self) {
+        let Some(query) = self.search.as_ref().map(|search| search.query.clone()) else {
+            return;
+        };
+        self.search(&query, None);
+    }
+
+    fn scroll_to_selected_match(&mut self) {
+        let Some(line) = self.search.as_ref().and_then(SearchState::selected_line) else {
+            return;
+        };
+        self.scroll_offset = line;
+        self.clamp_scroll_offset();
+    }
+
+    fn clamp_scroll_offset(&mut self) {
+        let line_count = self.visible_body(None).lines().count();
+        let max_offset = line_count.saturating_sub(self.viewport_height.max(1));
+        self.scroll_offset = self.scroll_offset.min(max_offset);
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SearchState {
+    query: String,
+    matches: Vec<usize>,
+    selected: Option<usize>,
+}
+
+impl SearchState {
+    fn selected_line(&self) -> Option<usize> {
+        self.selected
+            .and_then(|index| self.matches.get(index).copied())
+    }
+}
+
+fn matching_lines(rendered: &str, query: &str) -> Vec<usize> {
+    let query = query.to_lowercase();
+    strip_ansi(rendered)
+        .lines()
+        .enumerate()
+        .filter_map(|(line, text)| text.to_lowercase().contains(&query).then_some(line))
+        .collect()
+}

--- a/crates/jk-tui/src/rendered_view.rs
+++ b/crates/jk-tui/src/rendered_view.rs
@@ -1,0 +1,345 @@
+//! Generic rendered-output inspection view.
+
+use jk_core::InspectionSnapshot;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::widgets::Paragraph;
+
+use crate::chrome::{ViewChrome, render_help_overlay};
+use crate::keymap::{BindingContext, adaptive_hotbar, help_lines, help_title};
+use crate::rendered_log::rendered_text;
+use crate::rendered_state::RenderedState;
+
+/// The effect requested after applying an input action to a rendered inspection view.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum RenderedActionResult {
+    /// Continue running the application.
+    Continue,
+
+    /// Refresh the rendered output from the data source.
+    Refresh,
+
+    /// Return to the previous view.
+    ReturnToLog,
+
+    /// Exit the application.
+    Quit,
+}
+
+/// Input actions understood by a rendered inspection view.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum RenderedAction {
+    /// Leave the view unchanged.
+    Ignore,
+
+    /// Scroll one line earlier.
+    ScrollPrevious,
+
+    /// Scroll one line later.
+    ScrollNext,
+
+    /// Scroll one visible page earlier.
+    PagePrevious,
+
+    /// Scroll one visible page later.
+    PageNext,
+
+    /// Move to the first rendered line.
+    First,
+
+    /// Move to the last visible page.
+    Last,
+
+    /// Search rendered lines for text.
+    Search(String),
+
+    /// Jump to the next search match.
+    SearchNext,
+
+    /// Jump to the previous search match.
+    SearchPrevious,
+
+    /// Toggle mode-specific help.
+    ToggleHelp,
+
+    /// Refresh the rendered output.
+    Refresh,
+
+    /// Return to the previous view.
+    ReturnToLog,
+
+    /// Quit the TUI.
+    Quit,
+}
+
+/// Interactive view for read-only `jj` output such as `show` and `status`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RenderedView {
+    state: RenderedState,
+    status_message: Option<String>,
+    help_visible: bool,
+}
+
+impl RenderedView {
+    /// Creates a view with the initial snapshot loaded.
+    #[must_use]
+    pub fn new(snapshot: InspectionSnapshot) -> Self {
+        Self {
+            state: RenderedState::new(snapshot),
+            status_message: None,
+            help_visible: false,
+        }
+    }
+
+    /// Creates a view that starts in an error state for an unloaded target.
+    #[must_use]
+    pub fn from_error(target: impl Into<String>, title: impl Into<String>, error: String) -> Self {
+        let snapshot = InspectionSnapshot::new(target, "").with_title(title);
+        let mut view = Self::new(snapshot);
+        view.show_error(error);
+        view
+    }
+
+    /// Replaces rendered output after a successful refresh.
+    pub fn refresh(&mut self, snapshot: InspectionSnapshot) {
+        self.state.refresh(snapshot);
+        self.status_message = None;
+    }
+
+    /// Shows an integration error without replacing the current body.
+    pub fn show_error(&mut self, error: impl Into<String>) {
+        self.status_message = Some(error.into());
+    }
+
+    /// Applies a single input action.
+    #[must_use]
+    pub fn apply(&mut self, action: RenderedAction) -> RenderedActionResult {
+        match action {
+            RenderedAction::Ignore => {}
+            RenderedAction::ScrollPrevious => {
+                self.state.scroll_previous_line();
+            }
+            RenderedAction::ScrollNext => {
+                self.state.scroll_next_line();
+            }
+            RenderedAction::PagePrevious => {
+                self.state.select_page_previous();
+            }
+            RenderedAction::PageNext => {
+                self.state.select_page_next();
+            }
+            RenderedAction::First => {
+                self.state.select_first();
+            }
+            RenderedAction::Last => {
+                self.state.select_last();
+            }
+            RenderedAction::Search(query) => {
+                self.state.search(&query, self.status_message.as_deref());
+            }
+            RenderedAction::SearchNext => {
+                self.state.search_next();
+            }
+            RenderedAction::SearchPrevious => {
+                self.state.search_previous();
+            }
+            RenderedAction::ToggleHelp => {
+                self.help_visible = !self.help_visible;
+            }
+            RenderedAction::Refresh => return RenderedActionResult::Refresh,
+            RenderedAction::ReturnToLog => return RenderedActionResult::ReturnToLog,
+            RenderedAction::Quit if self.help_visible => {
+                self.help_visible = false;
+            }
+            RenderedAction::Quit => return RenderedActionResult::Quit,
+        }
+        RenderedActionResult::Continue
+    }
+
+    /// Renders the inspection view.
+    pub fn render(&mut self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        self.render_area(frame, area, None);
+    }
+
+    /// Renders the inspection view with a temporary status-line override.
+    pub fn render_with_status(&mut self, frame: &mut Frame<'_>, status: &str) {
+        let area = frame.area();
+        self.render_area(frame, area, Some(status));
+    }
+
+    /// Renders the inspection view with a caller-owned centered overlay.
+    pub fn render_with_overlay(&mut self, frame: &mut Frame<'_>, title: &str, lines: &[String]) {
+        let area = frame.area();
+        self.render_area(frame, area, None);
+        let areas = ViewChrome::layout(area);
+        render_help_overlay(frame, areas.content, title, lines);
+    }
+
+    fn render_area(&mut self, frame: &mut Frame<'_>, area: Rect, status_override: Option<&str>) {
+        let areas = ViewChrome::layout(area);
+        self.state
+            .set_viewport_height(usize::from(areas.content.height));
+
+        let search_status = self.state.search_status();
+        let fallback_status = adaptive_hotbar(BindingContext::Inspection, areas.status_width());
+        let status = status_override
+            .or(self.status_message.as_deref())
+            .or(search_status.as_deref())
+            .unwrap_or(&fallback_status);
+        let chrome = ViewChrome::new(self.state.title(), status);
+        chrome.render(frame, areas);
+
+        let body = self.state.visible_body(self.status_message.as_deref());
+        let paragraph = Paragraph::new(rendered_text(&body)).scroll((
+            u16::try_from(self.state.scroll_offset()).unwrap_or(u16::MAX),
+            0,
+        ));
+        frame.render_widget(paragraph, areas.content);
+
+        if self.help_visible {
+            render_help_overlay(
+                frame,
+                areas.content,
+                help_title(BindingContext::Inspection),
+                &help_lines(BindingContext::Inspection),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+
+    #[test]
+    fn refresh_and_return_actions_request_outer_loop_effects() {
+        let mut view = RenderedView::new(snapshot("aaa", "first\n"));
+
+        assert_eq!(
+            view.apply(RenderedAction::Refresh),
+            RenderedActionResult::Refresh
+        );
+        assert_eq!(
+            view.apply(RenderedAction::ReturnToLog),
+            RenderedActionResult::ReturnToLog
+        );
+        assert_eq!(view.apply(RenderedAction::Quit), RenderedActionResult::Quit);
+    }
+
+    #[test]
+    fn refresh_errors_replace_status_without_replacing_body() {
+        let mut view = RenderedView::new(snapshot("aaa", "first line\n"));
+        view.show_error("jj failed");
+        let backend = TestBackend::new(48, 4);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("first line"));
+        assert!(buffer_line(terminal.backend().buffer(), 3).contains("jj failed"));
+
+        view.refresh(snapshot("aaa", "second line\n"));
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("second line"));
+        assert!(buffer_line(terminal.backend().buffer(), 3).contains("r refresh"));
+    }
+
+    #[test]
+    fn initial_error_renders_retryable_message() {
+        let mut view = RenderedView::from_error(
+            "missing",
+            "jj show missing",
+            "Revision missing doesn't exist".to_owned(),
+        );
+        let backend = TestBackend::new(72, 8);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("Unable to load inspection for missing."));
+        assert!(rendered.contains("Revision missing doesn't exist"));
+        assert!(rendered.contains("Press r to retry"));
+    }
+
+    #[test]
+    fn search_status_replaces_default_status_after_search() {
+        let mut view = RenderedView::new(snapshot("aaa", "alpha\nbeta\nalpha\n"));
+        let _ = view.apply(RenderedAction::Search("alpha".to_owned()));
+        let backend = TestBackend::new(64, 5);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        assert!(buffer_line(terminal.backend().buffer(), 4).contains("/alpha  1/2"));
+    }
+
+    #[test]
+    fn help_action_shows_inspection_specific_keys() {
+        let mut view = RenderedView::new(snapshot("aaa", "alpha\n"));
+        let _ = view.apply(RenderedAction::ToggleHelp);
+        let backend = TestBackend::new(72, 18);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("Inspection keys"));
+        assert!(rendered.contains("/, n, N              search, next, previous"));
+    }
+
+    fn snapshot(target: &str, rendered: &str) -> InspectionSnapshot {
+        InspectionSnapshot::new(target, rendered).with_title(format!("jj show {target}"))
+    }
+
+    fn buffer_to_string(buffer: &ratatui::buffer::Buffer) -> String {
+        let area = buffer.area;
+        let mut text = String::new();
+
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
+
+        text
+    }
+
+    fn buffer_line(buffer: &ratatui::buffer::Buffer, y: u16) -> String {
+        let area = buffer.area;
+        let mut text = String::new();
+
+        for x in area.left()..area.right() {
+            text.push_str(buffer[(x, y)].symbol());
+        }
+
+        text
+    }
+}

--- a/crates/jk-tui/src/workspaces_view.rs
+++ b/crates/jk-tui/src/workspaces_view.rs
@@ -1,0 +1,702 @@
+//! Public workspace list view and action contract.
+//!
+//! This module is provider-neutral. Callers map their workspace source into
+//! [`WorkspaceViewSnapshot`] rows, translate input into [`WorkspacesAction`], and handle returned
+//! [`WorkspacesActionResult`] values for effects such as refresh, status, diff, and navigation.
+
+use std::path::{Path, PathBuf};
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::prelude::{Color, Line, Modifier, Span, Style, Text};
+use ratatui::widgets::Paragraph;
+
+use crate::chrome::{ViewChrome, render_help_overlay};
+use crate::keymap::{BindingContext, adaptive_hotbar, help_lines, help_title};
+use crate::selected_row::paint_subtle_selected_row;
+
+const DEFAULT_TITLE: &str = "jj workspace list";
+
+/// A provider-neutral snapshot of known workspaces.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct WorkspaceViewSnapshot {
+    title: String,
+    rows: Vec<WorkspaceViewRow>,
+}
+
+impl WorkspaceViewSnapshot {
+    /// Creates a workspace snapshot from display rows.
+    #[must_use]
+    pub fn new(rows: Vec<WorkspaceViewRow>) -> Self {
+        Self {
+            title: DEFAULT_TITLE.to_owned(),
+            rows,
+        }
+    }
+
+    /// Sets the command context shown in the title bar.
+    #[must_use]
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = title.into();
+        self
+    }
+
+    /// Returns the human-readable command context for this view.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns the snapshot rows in display order.
+    #[must_use]
+    pub fn rows(&self) -> &[WorkspaceViewRow] {
+        &self.rows
+    }
+
+    fn current_index(&self) -> Option<usize> {
+        self.rows.iter().position(|row| row.current)
+    }
+
+    fn named_index(&self, name: &str) -> Option<usize> {
+        self.rows.iter().position(|row| row.name == name)
+    }
+}
+
+/// One display row in the workspace list.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceViewRow {
+    /// Workspace name.
+    pub name: String,
+    /// Workspace root path used for selected-workspace commands.
+    pub root: Option<PathBuf>,
+    /// Human-readable workspace root path.
+    pub root_display: String,
+    /// Whether this row is the current workspace.
+    pub current: bool,
+    /// Current working-copy change id, when known.
+    pub change_id: Option<String>,
+    /// Current working-copy commit id, when known.
+    pub commit_id: Option<String>,
+}
+
+impl WorkspaceViewRow {
+    /// Creates a workspace display row.
+    #[must_use]
+    pub fn new(name: impl Into<String>, root_display: impl Into<String>, current: bool) -> Self {
+        Self {
+            name: name.into(),
+            root: None,
+            root_display: root_display.into(),
+            current,
+            change_id: None,
+            commit_id: None,
+        }
+    }
+
+    /// Sets the row's workspace root path for follow-up commands.
+    #[must_use]
+    pub fn with_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.root = Some(root.into());
+        self
+    }
+
+    /// Returns the workspace root path used for follow-up commands.
+    #[must_use]
+    pub fn root(&self) -> Option<&Path> {
+        self.root.as_deref()
+    }
+
+    /// Sets the row's current working-copy change id.
+    #[must_use]
+    pub fn with_change_id(mut self, change_id: impl Into<String>) -> Self {
+        self.change_id = Some(change_id.into());
+        self
+    }
+
+    /// Sets the row's current working-copy commit id.
+    #[must_use]
+    pub fn with_commit_id(mut self, commit_id: impl Into<String>) -> Self {
+        self.commit_id = Some(commit_id.into());
+        self
+    }
+}
+
+/// The effect requested after applying an input action to the workspace view.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum WorkspacesActionResult {
+    /// Continue running the application.
+    Continue,
+    /// Refresh the workspace list from the data source.
+    Refresh,
+    /// Open log for the selected workspace.
+    OpenLog,
+    /// Open status for the selected workspace.
+    OpenStatus,
+    /// Open diff for the selected workspace.
+    OpenDiff,
+    /// Update stale metadata for the selected workspace.
+    UpdateStale,
+    /// Return to the previous view.
+    ReturnBack,
+    /// Open the view-options surface.
+    ViewOptions,
+    /// Exit the application.
+    Quit,
+}
+
+/// Input actions understood by the workspace view.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum WorkspacesAction {
+    /// Move to the previous workspace.
+    Previous,
+    /// Move to the next workspace.
+    Next,
+    /// Scroll one rendered line earlier.
+    ScrollPreviousLine,
+    /// Scroll one rendered line later.
+    ScrollNextLine,
+    /// Move to the first workspace.
+    First,
+    /// Move to the last workspace.
+    Last,
+    /// Refresh the workspace list.
+    Refresh,
+    /// Open log for the selected workspace.
+    OpenLog,
+    /// Open status for the selected workspace.
+    OpenStatus,
+    /// Open diff for the selected workspace.
+    OpenDiff,
+    /// Update stale metadata for the selected workspace.
+    UpdateStale,
+    /// Toggle mode-specific help.
+    ToggleHelp,
+    /// Return to the previous view.
+    ReturnBack,
+    /// Open the view-options surface.
+    ViewOptions,
+    /// Quit the TUI.
+    Quit,
+}
+
+/// Interactive workspace list view.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct WorkspacesView {
+    snapshot: WorkspaceViewSnapshot,
+    selected: Option<usize>,
+    scroll_offset: usize,
+    status_message: Option<String>,
+    help_visible: bool,
+}
+
+impl WorkspacesView {
+    /// Creates a workspace view with the initial snapshot loaded.
+    #[must_use]
+    pub fn new(snapshot: WorkspaceViewSnapshot) -> Self {
+        let selected = initial_selection(&snapshot);
+        Self {
+            snapshot,
+            selected,
+            scroll_offset: 0,
+            status_message: None,
+            help_visible: false,
+        }
+    }
+
+    /// Replaces rows after a successful refresh.
+    ///
+    /// Selection is preserved by workspace name when possible, then falls back to the current
+    /// workspace row, then clamps to the nearest available row.
+    pub fn refresh(&mut self, snapshot: WorkspaceViewSnapshot) {
+        let previous_name = self.selected_row().map(|row| row.name.clone());
+        let previous_selected = self.selected;
+        self.snapshot = snapshot;
+        self.selected = previous_name
+            .as_deref()
+            .and_then(|name| self.snapshot.named_index(name))
+            .or_else(|| self.snapshot.current_index())
+            .or_else(|| clamp_index(previous_selected, self.snapshot.rows.len()));
+        self.scroll_offset = clamp_scroll(self.scroll_offset, self.snapshot.rows.len());
+        self.status_message = None;
+    }
+
+    /// Shows a refresh or integration error without replacing the current rows.
+    pub fn show_error(&mut self, error: impl Into<String>) {
+        self.status_message = Some(error.into());
+    }
+
+    /// Shows a short status message without replacing the current rows.
+    pub fn show_status(&mut self, status: impl Into<String>) {
+        self.status_message = Some(status.into());
+    }
+
+    /// Returns the selected row, if any.
+    #[must_use]
+    pub fn selected_row(&self) -> Option<&WorkspaceViewRow> {
+        self.selected
+            .and_then(|index| self.snapshot.rows.get(index))
+    }
+
+    /// Returns the selected workspace name, if any.
+    #[must_use]
+    pub fn selected_workspace_name(&self) -> Option<&str> {
+        self.selected_row().map(|row| row.name.as_str())
+    }
+
+    /// Applies a single input action.
+    #[must_use]
+    pub fn apply(&mut self, action: WorkspacesAction) -> WorkspacesActionResult {
+        match action {
+            WorkspacesAction::Previous => {
+                self.select_previous();
+                WorkspacesActionResult::Continue
+            }
+            WorkspacesAction::Next => {
+                self.select_next();
+                WorkspacesActionResult::Continue
+            }
+            WorkspacesAction::ScrollPreviousLine => {
+                self.scroll_offset = self.scroll_offset.saturating_sub(1);
+                WorkspacesActionResult::Continue
+            }
+            WorkspacesAction::ScrollNextLine => {
+                self.scroll_offset = clamp_scroll(
+                    self.scroll_offset.saturating_add(1),
+                    self.snapshot.rows.len(),
+                );
+                WorkspacesActionResult::Continue
+            }
+            WorkspacesAction::First => {
+                if !self.snapshot.rows.is_empty() {
+                    self.selected = Some(0);
+                }
+                WorkspacesActionResult::Continue
+            }
+            WorkspacesAction::Last => {
+                if !self.snapshot.rows.is_empty() {
+                    self.selected = Some(self.snapshot.rows.len() - 1);
+                }
+                WorkspacesActionResult::Continue
+            }
+            WorkspacesAction::Refresh => WorkspacesActionResult::Refresh,
+            WorkspacesAction::OpenLog if self.selected.is_some() => WorkspacesActionResult::OpenLog,
+            WorkspacesAction::OpenStatus if self.selected.is_some() => {
+                WorkspacesActionResult::OpenStatus
+            }
+            WorkspacesAction::OpenDiff if self.selected.is_some() => {
+                WorkspacesActionResult::OpenDiff
+            }
+            WorkspacesAction::UpdateStale if self.selected.is_some() => {
+                WorkspacesActionResult::UpdateStale
+            }
+            WorkspacesAction::OpenLog
+            | WorkspacesAction::OpenStatus
+            | WorkspacesAction::OpenDiff
+            | WorkspacesAction::UpdateStale => WorkspacesActionResult::Continue,
+            WorkspacesAction::ToggleHelp => {
+                self.help_visible = !self.help_visible;
+                WorkspacesActionResult::Continue
+            }
+            WorkspacesAction::ReturnBack => WorkspacesActionResult::ReturnBack,
+            WorkspacesAction::ViewOptions => WorkspacesActionResult::ViewOptions,
+            WorkspacesAction::Quit if self.help_visible => {
+                self.help_visible = false;
+                WorkspacesActionResult::Continue
+            }
+            WorkspacesAction::Quit => WorkspacesActionResult::Quit,
+        }
+    }
+
+    /// Renders the workspace view.
+    pub fn render(&mut self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        self.render_area(frame, area, None);
+    }
+
+    /// Renders the workspace view with a temporary status-line override.
+    pub fn render_with_status(&mut self, frame: &mut Frame<'_>, status: &str) {
+        let area = frame.area();
+        self.render_area(frame, area, Some(status));
+    }
+
+    const fn select_previous(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        self.selected = Some(selected.saturating_sub(1));
+    }
+
+    fn select_next(&mut self) {
+        let Some(selected) = self.selected else {
+            return;
+        };
+        let last = self.snapshot.rows.len().saturating_sub(1);
+        self.selected = Some(selected.saturating_add(1).min(last));
+    }
+
+    fn keep_selected_in_view(&mut self, height: usize) {
+        self.scroll_offset = clamp_scroll(self.scroll_offset, self.snapshot.rows.len());
+        let Some(selected) = self.selected else {
+            return;
+        };
+        if height == 0 {
+            return;
+        }
+        if selected < self.scroll_offset {
+            self.scroll_offset = selected;
+        } else if selected >= self.scroll_offset.saturating_add(height) {
+            self.scroll_offset = selected.saturating_add(1).saturating_sub(height);
+        }
+    }
+
+    fn render_area(&mut self, frame: &mut Frame<'_>, area: Rect, status_override: Option<&str>) {
+        let areas = ViewChrome::layout(area);
+        self.keep_selected_in_view(usize::from(areas.content.height));
+
+        let fallback_status = adaptive_hotbar(BindingContext::Workspaces, areas.status_width());
+        let status = status_override
+            .or(self.status_message.as_deref())
+            .unwrap_or(&fallback_status);
+        let chrome = ViewChrome::new(self.snapshot.title(), status);
+        chrome.render(frame, areas);
+
+        let paragraph = Paragraph::new(self.visible_text());
+        frame.render_widget(paragraph, areas.content);
+
+        if let Some(selected) = self.selected {
+            paint_subtle_selected_row(frame, areas.content, selected, self.scroll_offset);
+        }
+
+        if self.help_visible {
+            render_help_overlay(
+                frame,
+                areas.content,
+                help_title(BindingContext::Workspaces),
+                &help_lines(BindingContext::Workspaces),
+            );
+        }
+    }
+
+    fn visible_text(&self) -> Text<'_> {
+        if self.snapshot.rows.is_empty() {
+            return Text::from(vec![
+                Line::from(Span::styled(
+                    "No workspaces found.",
+                    Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                )),
+                Line::from(""),
+                Line::from("Press r to refresh."),
+            ]);
+        }
+
+        let rows = self
+            .snapshot
+            .rows
+            .iter()
+            .skip(self.scroll_offset)
+            .map(workspace_line)
+            .collect::<Vec<_>>();
+        Text::from(rows)
+    }
+}
+
+fn workspace_line(row: &WorkspaceViewRow) -> Line<'_> {
+    let marker = if row.current { "*" } else { " " };
+    let summary = workspace_summary(row);
+    Line::from(vec![
+        Span::styled(
+            marker,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" "),
+        Span::styled(&row.name, Style::new().add_modifier(Modifier::BOLD)),
+        Span::raw("  "),
+        Span::raw(&row.root_display),
+        Span::raw(summary),
+    ])
+}
+
+fn workspace_summary(row: &WorkspaceViewRow) -> String {
+    match (&row.change_id, &row.commit_id) {
+        (Some(change_id), Some(commit_id)) => format!("  change {change_id}  commit {commit_id}"),
+        (Some(change_id), None) => format!("  change {change_id}"),
+        (None, Some(commit_id)) => format!("  commit {commit_id}"),
+        (None, None) => String::new(),
+    }
+}
+
+fn initial_selection(snapshot: &WorkspaceViewSnapshot) -> Option<usize> {
+    snapshot
+        .current_index()
+        .or_else(|| clamp_index(Some(0), snapshot.rows.len()))
+}
+
+fn clamp_index(index: Option<usize>, len: usize) -> Option<usize> {
+    let index = index?;
+    if len == 0 {
+        None
+    } else {
+        Some(index.min(len - 1))
+    }
+}
+
+fn clamp_scroll(scroll_offset: usize, len: usize) -> usize {
+    if len == 0 {
+        0
+    } else {
+        scroll_offset.min(len - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+
+    #[test]
+    fn selection_starts_on_current_workspace() {
+        let view = WorkspacesView::new(snapshot([
+            row("default", false),
+            row("dogfood", true),
+            row("docs", false),
+        ]));
+
+        assert_eq!(view.selected_workspace_name(), Some("dogfood"));
+    }
+
+    #[test]
+    fn refresh_preserves_selected_workspace_by_name() {
+        let mut view = WorkspacesView::new(snapshot([
+            row("default", true),
+            row("dogfood", false),
+            row("docs", false),
+        ]));
+        let _ = view.apply(WorkspacesAction::Next);
+
+        view.refresh(snapshot([
+            row("default", true),
+            row("other", false),
+            row("dogfood", false),
+        ]));
+
+        assert_eq!(view.selected_workspace_name(), Some("dogfood"));
+    }
+
+    #[test]
+    fn refresh_falls_back_to_current_then_clamps() {
+        let mut view = WorkspacesView::new(snapshot([
+            row("default", true),
+            row("dogfood", false),
+            row("docs", false),
+        ]));
+        let _ = view.apply(WorkspacesAction::Next);
+
+        view.refresh(snapshot([row("default", true), row("other", false)]));
+
+        assert_eq!(view.selected_workspace_name(), Some("default"));
+
+        let mut view = WorkspacesView::new(snapshot([
+            row("default", false),
+            row("dogfood", false),
+            row("docs", false),
+        ]));
+        let _ = view.apply(WorkspacesAction::Next);
+        let _ = view.apply(WorkspacesAction::Next);
+
+        view.refresh(snapshot([row("solo", false)]));
+
+        assert_eq!(view.selected_workspace_name(), Some("solo"));
+    }
+
+    #[test]
+    fn empty_snapshot_is_safe() {
+        let mut view = WorkspacesView::new(WorkspaceViewSnapshot::new(Vec::new()));
+
+        assert_eq!(view.selected_workspace_name(), None);
+        assert_eq!(
+            view.apply(WorkspacesAction::Previous),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::Next),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::OpenStatus),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::OpenLog),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::OpenDiff),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::UpdateStale),
+            WorkspacesActionResult::Continue
+        );
+
+        let backend = TestBackend::new(48, 6);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("No workspaces found."));
+        assert!(rendered.contains("Press r to refresh."));
+    }
+
+    #[test]
+    fn actions_return_expected_results() {
+        let mut view = WorkspacesView::new(snapshot([row("default", true)]));
+
+        assert_eq!(
+            view.apply(WorkspacesAction::Previous),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::Next),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::ScrollPreviousLine),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::ScrollNextLine),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::First),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(view.selected_workspace_name(), Some("default"));
+        assert_eq!(
+            view.apply(WorkspacesAction::Last),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(view.selected_workspace_name(), Some("default"));
+        assert_eq!(
+            view.apply(WorkspacesAction::Refresh),
+            WorkspacesActionResult::Refresh
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::OpenStatus),
+            WorkspacesActionResult::OpenStatus
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::OpenLog),
+            WorkspacesActionResult::OpenLog
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::OpenDiff),
+            WorkspacesActionResult::OpenDiff
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::UpdateStale),
+            WorkspacesActionResult::UpdateStale
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::ViewOptions),
+            WorkspacesActionResult::ViewOptions
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::ReturnBack),
+            WorkspacesActionResult::ReturnBack
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::Quit),
+            WorkspacesActionResult::Quit
+        );
+    }
+
+    #[test]
+    fn quit_closes_workspace_help_before_quitting() {
+        let mut view = WorkspacesView::new(snapshot([row("default", true)]));
+        let _ = view.apply(WorkspacesAction::ToggleHelp);
+
+        assert_eq!(
+            view.apply(WorkspacesAction::Quit),
+            WorkspacesActionResult::Continue
+        );
+        assert_eq!(
+            view.apply(WorkspacesAction::Quit),
+            WorkspacesActionResult::Quit
+        );
+    }
+
+    #[test]
+    fn basic_render_contains_title_current_marker_root_and_summary() {
+        let mut view = WorkspacesView::new(WorkspaceViewSnapshot::new(vec![
+            WorkspaceViewRow::new("default", "/repo/default", true)
+                .with_change_id("abc123")
+                .with_commit_id("def456"),
+        ]));
+        let backend = TestBackend::new(80, 5);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("jk jj workspace list"));
+        assert!(rendered.contains("* default"));
+        assert!(rendered.contains("/repo/default"));
+        assert!(rendered.contains("change abc123"));
+        assert!(rendered.contains("commit def456"));
+        assert!(rendered.contains("r refresh"));
+    }
+
+    #[test]
+    fn help_overlay_uses_workspace_bindings() {
+        let mut view = WorkspacesView::new(snapshot([row("default", true)]));
+        let _ = view.apply(WorkspacesAction::ToggleHelp);
+        let backend = TestBackend::new(72, 16);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        assert!(rendered.contains("Workspaces keys"));
+        assert!(rendered.contains("enter, s             open selected workspace status"));
+        assert!(rendered.contains("u                    update selected stale workspace"));
+    }
+
+    fn snapshot<const N: usize>(rows: [WorkspaceViewRow; N]) -> WorkspaceViewSnapshot {
+        WorkspaceViewSnapshot::new(rows.into())
+    }
+
+    fn row(name: &str, current: bool) -> WorkspaceViewRow {
+        WorkspaceViewRow::new(name, format!("/repo/{name}"), current)
+    }
+
+    fn buffer_to_string(buffer: &ratatui::buffer::Buffer) -> String {
+        let area = buffer.area;
+        let mut text = String::new();
+
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
+
+        text
+    }
+}

--- a/crates/jk/Cargo.toml
+++ b/crates/jk/Cargo.toml
@@ -22,6 +22,7 @@ clap.workspace = true
 color-eyre.workspace = true
 crossterm.workspace = true
 jk-cli = { path = "../jk-cli", version = "0.2.5" }
+jk-core = { path = "../jk-core", version = "0.2.5" }
 jk-tui = { path = "../jk-tui", version = "0.2.5" }
 ratatui.workspace = true
 tracing.workspace = true

--- a/crates/jk/README.md
+++ b/crates/jk/README.md
@@ -2,8 +2,9 @@
 
 `jk` is a jj-native terminal UI for [Jujutsu](https://github.com/jj-vcs/jj).
 
-It keeps a `jj` log-like view open today, lets you refresh in place, and adds interactive navigation
-for reviewing change descriptions and selected-change diffs.
+It keeps `jj` output as the source of truth and adds an interactive jj TUI around it: inspect
+changes, run safe command previews, review command history, and recover through operation views
+without losing terminal context.
 
 ![jk log view](https://www.joshka.net/jk-screenshots/assets/jk-log-v3.gif)
 
@@ -32,24 +33,38 @@ cargo install jk --locked
 
 ## Current Status
 
-The supported surface includes:
+`jk` currently focuses on the daily inspect-and-recover loop:
 
-- log view backed by `jj`;
-- manual refresh;
-- movement by change, page, and edge;
-- inline expansion of the selected change description;
-- selected-change diff inspection from the log or with `jk diff [REVISION]`;
-- diff search, file/hunk navigation, horizontal scrolling, and folding;
-- mode-specific help overlays;
-- retryable empty/error states for selected diffs.
+- inspect changes through log, show, diff, evolog, and status views;
+- review diffs with file/hunk navigation, folding, search, and View Options;
+- run direct `jj` commands from `:` command mode with captured output;
+- preview local mutations before describe, abandon, new, edit, undo, and redo;
+- inspect Command History, Operation Log, and sibling jj workspaces, including workspace-scoped
+  log/status/diff views.
+
+Current limitations:
+
+- command history is in-memory for the current `jk` session;
+- rebase, squash, split, restore, bookmarks, fetch, and push are still planned workflows;
+- direct `a`, `n`, and `e` mutation keys are dogfood shortcuts until the broader action menu exists.
+
+Use `?` inside the TUI for full screen-specific key help. The repository's
+[Using jk](https://github.com/joshka/jk/blob/main/docs/usage.md) guide has
+task-oriented examples for the current jk surface.
 
 ## Commands
 
 ```sh
 jk
 jk log
+jk log -T builtin_log_compact_full_description
 jk diff
-jk diff <revision>
+jk diff -r <revision>
+jk diff --from <revision> --to <revision>
+jk diff --stat
+jk show <revision>
+jk status
+jk workspaces
 jk -R /path/to/repo -n 20
 ```
 
@@ -63,8 +78,8 @@ The detailed roadmap lives in the repository docs:
 - [product plan](https://github.com/joshka/jk/blob/main/docs/product-plan.md);
 - [issue-sized roadmap](https://github.com/joshka/jk/blob/main/docs/roadmap.md).
 
-Near-term work preserves jj-rendered output while adding command-shaped inspection, `show`,
-`status`, command mode, command history, workspaces, command previews, and operation recovery.
+Near-term work stabilizes this dogfoodable jk TUI for release before adding rebase-specific
+behavior.
 
 See the repository README for the current status and development workflow.
 

--- a/crates/jk/src/actions.rs
+++ b/crates/jk/src/actions.rs
@@ -1,0 +1,214 @@
+use crossterm::event::{KeyCode, KeyEvent};
+use jk_cli::{
+    JjAbandon, JjDiff, JjEdit, JjEvolog, JjLog, JjNew, JjOperation, JjRecovery, JjShow, JjStatus,
+    JjWorkspaces, RecoveryCommand,
+};
+use jk_tui::log_view::LogAction;
+
+use crate::key::AppKey;
+use crate::state::{AppState, AppView, InputMode};
+use crate::{
+    AppLoop, SearchDirection, apply_action, apply_search_action, copy_selected_command,
+    edit_command_output, handle_back, open_abandon_preview, open_command_discovery,
+    open_command_history, open_command_history_operation, open_diff_file_list, open_edit_preview,
+    open_jj_command_mode, open_new_preview, open_operation_log, open_recovery_preview,
+    open_view_options, open_workspaces, push_selected_command_history_details,
+    push_selected_evolog, push_selected_operation_show, push_selected_show,
+    push_selected_workspace_status, push_status, update_selected_workspace_stale,
+};
+
+pub struct AppSources<'a> {
+    pub(crate) log: &'a mut JjLog,
+    pub(crate) diff: &'a JjDiff,
+    pub(crate) evolog: &'a JjEvolog,
+    pub(crate) show: &'a JjShow,
+    pub(crate) status: &'a JjStatus,
+    pub(crate) abandon: &'a JjAbandon,
+    pub(crate) new_change: &'a JjNew,
+    pub(crate) edit: &'a JjEdit,
+    pub(crate) operation: &'a JjOperation,
+    pub(crate) recovery: &'a JjRecovery,
+    pub(crate) workspaces: &'a JjWorkspaces,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DispatchResult {
+    Continue,
+    Quit,
+}
+
+pub fn dispatch_app_key(
+    state: &mut AppState,
+    sources: &mut AppSources<'_>,
+    key: KeyEvent,
+    app_key: AppKey,
+) -> DispatchResult {
+    if matches!(
+        state.views.active(),
+        AppView::Workspaces { .. } | AppView::CommandHistory { .. } | AppView::OperationLog { .. }
+    ) && matches!(key.code, KeyCode::Esc)
+    {
+        handle_back(state);
+        return DispatchResult::Continue;
+    }
+
+    let AppKey::Action(action) = app_key else {
+        dispatch_direct_app_key(state, sources, app_key);
+        return DispatchResult::Continue;
+    };
+
+    if matches!(app_key, AppKey::Action(LogAction::ToggleHelp)) {
+        open_command_discovery(state);
+        return DispatchResult::Continue;
+    }
+
+    if apply_action(
+        state,
+        sources.log,
+        sources.diff,
+        sources.evolog,
+        sources.show,
+        sources.status,
+        sources.operation,
+        sources.workspaces,
+        action,
+    ) == AppLoop::Quit
+    {
+        DispatchResult::Quit
+    } else {
+        DispatchResult::Continue
+    }
+}
+
+fn dispatch_direct_app_key(state: &mut AppState, sources: &mut AppSources<'_>, app_key: AppKey) {
+    match app_key {
+        AppKey::Back => {
+            handle_back(state);
+        }
+        AppKey::OpenShow => {
+            if matches!(state.views.active(), AppView::OperationLog { .. }) {
+                push_selected_operation_show(state, sources.operation);
+            } else if matches!(state.views.active(), AppView::Workspaces { .. }) {
+                push_selected_workspace_status(state, sources.workspaces);
+            } else if matches!(state.views.active(), AppView::CommandHistory { .. }) {
+                push_selected_command_history_details(state);
+            } else {
+                push_selected_show(state, sources.show);
+            }
+        }
+        AppKey::OpenEvolog => {
+            push_selected_evolog(state, sources.evolog);
+        }
+        AppKey::OpenStatus => {
+            if matches!(state.views.active(), AppView::Workspaces { .. }) {
+                push_selected_workspace_status(state, sources.workspaces);
+            } else {
+                push_status(state, sources.status);
+            }
+        }
+        AppKey::OpenWorkspaces => {
+            open_workspaces(state, sources.workspaces);
+        }
+        AppKey::OpenCommandHistory => {
+            open_command_history(state);
+        }
+        AppKey::OpenOperationLog => {
+            if matches!(state.views.active(), AppView::CommandHistory { .. }) {
+                open_command_history_operation(state, sources.operation);
+            } else {
+                open_operation_log(state, sources.operation);
+            }
+        }
+        AppKey::CopyCommand => {
+            copy_selected_command(state);
+        }
+        AppKey::StartUndo => {
+            if matches!(state.views.active(), AppView::Workspaces { .. }) {
+                update_selected_workspace_stale(state, sources.workspaces);
+            } else {
+                open_recovery_preview(state, sources.recovery, RecoveryCommand::Undo);
+            }
+        }
+        AppKey::StartRedo => {
+            open_recovery_preview(state, sources.recovery, RecoveryCommand::Redo);
+        }
+        AppKey::StartDescribe => {
+            crate::open_describe_message(state);
+        }
+        AppKey::StartAbandon => {
+            open_abandon_preview(state, sources.abandon);
+        }
+        AppKey::OpenViewOptions => {
+            if !matches!(state.views.active(), AppView::CommandHistory { .. }) {
+                open_view_options(state);
+            }
+        }
+        AppKey::StartCommandMode => {
+            open_jj_command_mode(state);
+        }
+        AppKey::EditCommandOutput => {
+            if matches!(state.views.active(), AppView::Log(_)) {
+                open_edit_preview(state, sources.edit);
+            } else {
+                edit_command_output(state);
+            }
+        }
+        AppKey::OpenDiffFileList => {
+            open_diff_file_list(state);
+        }
+        AppKey::StartSearch if active_view_supports_search(state) => {
+            state.modes.push(search_input_mode(state));
+        }
+        AppKey::SearchNext if matches!(state.views.active(), AppView::Log(_)) => {
+            open_new_preview(state, sources.new_change);
+        }
+        AppKey::SearchNext => {
+            apply_search_action(state, SearchDirection::Next);
+        }
+        AppKey::SearchPrevious => {
+            apply_search_action(state, SearchDirection::Previous);
+        }
+        AppKey::Action(_) | AppKey::Ignore | AppKey::StartSearch => {}
+    }
+}
+
+fn active_view_supports_search(state: &AppState) -> bool {
+    matches!(
+        state.views.active(),
+        AppView::Diff { .. }
+            | AppView::Show { .. }
+            | AppView::Evolog { .. }
+            | AppView::Status { .. }
+            | AppView::WorkspaceLog { .. }
+            | AppView::WorkspaceStatus { .. }
+            | AppView::WorkspaceDiff { .. }
+            | AppView::OperationShow { .. }
+            | AppView::OperationDiff { .. }
+            | AppView::CommandOutput { .. }
+            | AppView::CommandHistoryDetails { .. }
+    )
+}
+
+fn search_input_mode(state: &AppState) -> InputMode {
+    match state.views.active() {
+        AppView::Diff { .. } => InputMode::DiffSearch {
+            query: String::new(),
+        },
+        AppView::Show { .. }
+        | AppView::Evolog { .. }
+        | AppView::Status { .. }
+        | AppView::WorkspaceLog { .. }
+        | AppView::WorkspaceStatus { .. }
+        | AppView::WorkspaceDiff { .. }
+        | AppView::OperationShow { .. }
+        | AppView::OperationDiff { .. }
+        | AppView::CommandHistoryDetails { .. }
+        | AppView::CommandOutput { .. } => InputMode::InspectionSearch {
+            query: String::new(),
+        },
+        AppView::Log(_)
+        | AppView::Workspaces { .. }
+        | AppView::OperationLog { .. }
+        | AppView::CommandHistory { .. } => unreachable!("search support checked before call"),
+    }
+}

--- a/crates/jk/src/cli.rs
+++ b/crates/jk/src/cli.rs
@@ -1,0 +1,309 @@
+use std::path::{Path, PathBuf};
+
+use clap::{Parser, Subcommand};
+use jk_cli::{
+    DiffFormat, DiffQuery, JjAbandon, JjDescribe, JjDiff, JjEdit, JjEvolog, JjLog, JjLogCommand,
+    JjNew, JjOperation, JjRecovery, JjShow, JjStatus, JjWorkspaces, LogTemplateSelection,
+    ShowQuery, StatusQuery,
+};
+
+/// Command-line options for the first log-oriented `jk` surface.
+#[derive(Debug, Parser)]
+#[command(version, about)]
+pub struct Args {
+    /// Repository path to pass to jj.
+    #[arg(short = 'R', long = "repository")]
+    pub(crate) repository: Option<PathBuf>,
+
+    /// Maximum number of log entries to render for the default command.
+    #[arg(short = 'n', long)]
+    pub(crate) limit: Option<usize>,
+
+    /// View to open. If omitted, jk follows jj's configured default command.
+    #[command(subcommand)]
+    pub(crate) command: Option<Command>,
+}
+
+impl Args {
+    /// Builds the log source that matches the requested command-line view.
+    ///
+    /// Bare `jk` intentionally starts from jj's configured default command, while `jk log` forces
+    /// the explicit log command. The top-level limit applies to both forms unless the subcommand
+    /// provides a narrower value.
+    pub(crate) fn log_source(&self) -> JjLog {
+        let (command, limit, template) = match &self.command {
+            Some(Command::Log(log_args)) => (
+                JjLogCommand::Log,
+                log_args.limit.or(self.limit),
+                log_args.template.clone().map_or(
+                    LogTemplateSelection::Configured,
+                    LogTemplateSelection::Custom,
+                ),
+            ),
+            Some(
+                Command::Diff(_) | Command::Show(_) | Command::Status(_) | Command::Workspaces,
+            )
+            | None => (
+                JjLogCommand::ConfiguredDefault,
+                self.limit,
+                LogTemplateSelection::Configured,
+            ),
+        };
+
+        let source = JjLog::default()
+            .with_command(command)
+            .with_limit(limit)
+            .with_template(template);
+        self.with_repository(source)
+    }
+
+    /// Builds the diff source for selected-change inspection.
+    pub(crate) fn diff_source(&self) -> JjDiff {
+        self.with_repository(JjDiff::default())
+    }
+
+    /// Builds the show source for selected-change inspection.
+    pub(crate) fn show_source(&self) -> JjShow {
+        self.with_repository(JjShow::default())
+    }
+
+    /// Builds the evolog source for selected-change inspection.
+    pub(crate) fn evolog_source(&self) -> JjEvolog {
+        self.with_repository(JjEvolog::default())
+    }
+
+    /// Builds the status source for repository inspection.
+    pub(crate) fn status_source(&self) -> JjStatus {
+        self.with_repository(JjStatus::default())
+    }
+
+    /// Builds the describe source for selected-change mutation preview.
+    pub(crate) fn describe_source(&self) -> JjDescribe {
+        self.with_repository(JjDescribe::default())
+    }
+
+    /// Builds the abandon source for selected-change mutation preview.
+    pub(crate) fn abandon_source(&self) -> JjAbandon {
+        self.with_repository(JjAbandon::default())
+    }
+
+    /// Builds the new source for selected-change mutation preview.
+    pub(crate) fn new_source(&self) -> JjNew {
+        self.with_repository(JjNew::default())
+    }
+
+    /// Builds the edit source for selected-change mutation preview.
+    pub(crate) fn edit_source(&self) -> JjEdit {
+        self.with_repository(JjEdit::default())
+    }
+
+    /// Builds the operation source for operation log/show/diff inspection.
+    pub(crate) fn operation_source(&self) -> JjOperation {
+        self.with_repository(JjOperation::default())
+    }
+
+    /// Builds the recovery source for undo/redo mutation previews.
+    pub(crate) fn recovery_source(&self) -> JjRecovery {
+        self.with_repository(JjRecovery::default())
+    }
+
+    /// Builds the workspace source for workspace list and selected-workspace inspection.
+    pub(crate) fn workspaces_source(&self) -> JjWorkspaces {
+        self.with_repository(JjWorkspaces::default())
+    }
+
+    fn with_repository<T>(&self, source: T) -> T
+    where
+        T: WithRepository,
+    {
+        if let Some(repository) = self.repository.as_deref() {
+            source.with_repository(repository)
+        } else {
+            source
+        }
+    }
+}
+
+trait WithRepository: Sized {
+    fn with_repository(self, repository: &Path) -> Self;
+}
+
+macro_rules! impl_with_repository {
+    ($($source:ty),+ $(,)?) => {
+        $(
+            impl WithRepository for $source {
+                fn with_repository(self, repository: &Path) -> Self {
+                    <$source>::with_repository(self, repository)
+                }
+            }
+        )+
+    };
+}
+
+impl_with_repository!(
+    JjAbandon,
+    JjDescribe,
+    JjDiff,
+    JjEdit,
+    JjEvolog,
+    JjLog,
+    JjNew,
+    JjOperation,
+    JjRecovery,
+    JjShow,
+    JjStatus,
+    JjWorkspaces,
+);
+
+/// Top-level view commands supported by the binary.
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Show the jj log view.
+    Log(LogArgs),
+
+    /// Show the jj diff view for a revision.
+    Diff(DiffArgs),
+
+    /// Show one or more revisions.
+    Show(ShowArgs),
+
+    /// Show repository status.
+    Status(StatusArgs),
+
+    /// Show jj workspaces.
+    Workspaces,
+}
+
+/// Options for the explicit `jk log` command.
+#[derive(Debug, Parser)]
+pub struct LogArgs {
+    /// Maximum number of log entries to render.
+    #[arg(short = 'n', long)]
+    limit: Option<usize>,
+
+    /// Rendered jj log template to pass to the explicit log command.
+    #[arg(short = 'T', long = "template", value_name = "TEMPLATE")]
+    pub(crate) template: Option<String>,
+}
+
+/// Options for the explicit `jk diff` command.
+#[derive(Debug, Parser)]
+pub struct DiffArgs {
+    /// Compatibility sugar for `jk diff -r REV`.
+    #[arg(value_name = "REV", conflicts_with_all = ["revision", "from", "to"])]
+    compatibility_revision: Option<String>,
+
+    /// Revision to diff against its parent.
+    #[arg(short = 'r', long = "revision", value_name = "REV", conflicts_with_all = ["from", "to"])]
+    revision: Option<String>,
+
+    /// Starting revision for a two-revision diff.
+    #[arg(
+        long,
+        value_name = "FROM",
+        requires = "to",
+        conflicts_with = "revision"
+    )]
+    from: Option<String>,
+
+    /// Ending revision for a two-revision diff.
+    #[arg(
+        long,
+        value_name = "TO",
+        requires = "from",
+        conflicts_with = "revision"
+    )]
+    to: Option<String>,
+
+    /// Render `jj diff --stat`.
+    #[arg(long, conflicts_with_all = ["summary", "types", "name_only", "git", "color_words"])]
+    stat: bool,
+
+    /// Render `jj diff --summary`.
+    #[arg(short = 's', long, conflicts_with_all = ["stat", "types", "name_only", "git", "color_words"])]
+    summary: bool,
+
+    /// Render `jj diff --types`.
+    #[arg(long, conflicts_with_all = ["stat", "summary", "name_only", "git", "color_words"])]
+    types: bool,
+
+    /// Render `jj diff --name-only`.
+    #[arg(long, conflicts_with_all = ["stat", "summary", "types", "git", "color_words"])]
+    name_only: bool,
+
+    /// Render `jj diff --git`.
+    #[arg(long, conflicts_with_all = ["stat", "summary", "types", "name_only", "color_words"])]
+    git: bool,
+
+    /// Render `jj diff --color-words`.
+    #[arg(long, conflicts_with_all = ["stat", "summary", "types", "name_only", "git"])]
+    color_words: bool,
+}
+
+impl DiffArgs {
+    pub(crate) fn query(&self) -> DiffQuery {
+        let format = self.format();
+
+        if let (Some(from), Some(to)) = (&self.from, &self.to) {
+            return DiffQuery::FromTo {
+                from: from.clone(),
+                to: to.clone(),
+                format,
+            };
+        }
+
+        let rev = self
+            .revision
+            .as_ref()
+            .or(self.compatibility_revision.as_ref())
+            .cloned()
+            .unwrap_or_else(|| "@".to_owned());
+        DiffQuery::Revision { rev, format }
+    }
+
+    const fn format(&self) -> DiffFormat {
+        if self.summary {
+            DiffFormat::Summary
+        } else if self.stat {
+            DiffFormat::Stat
+        } else if self.types {
+            DiffFormat::Types
+        } else if self.name_only {
+            DiffFormat::NameOnly
+        } else if self.git {
+            DiffFormat::Git
+        } else if self.color_words {
+            DiffFormat::ColorWords
+        } else {
+            DiffFormat::Patch
+        }
+    }
+}
+
+/// Options for the explicit `jk show` command.
+#[derive(Debug, Parser)]
+pub struct ShowArgs {
+    /// Revisions to show.
+    #[arg(value_name = "REV", required = true)]
+    revs: Vec<String>,
+}
+
+impl ShowArgs {
+    pub(crate) fn query(&self) -> ShowQuery {
+        ShowQuery::new(self.revs.clone())
+    }
+}
+
+/// Options for the explicit `jk status` command.
+#[derive(Debug, Parser)]
+pub struct StatusArgs {
+    /// Filesets to pass to jj status.
+    #[arg(value_name = "FILESET")]
+    filesets: Vec<String>,
+}
+
+impl StatusArgs {
+    pub(crate) fn query(&self) -> StatusQuery {
+        StatusQuery::new(self.filesets.clone())
+    }
+}

--- a/crates/jk/src/clipboard.rs
+++ b/crates/jk/src/clipboard.rs
@@ -1,0 +1,64 @@
+use std::io::{self, Write};
+
+pub fn copy_command_line(command_line: &str) -> String {
+    match write_terminal_clipboard(command_line) {
+        Ok(()) => "copied command".to_owned(),
+        Err(error) => format!("copy failed: {error}"),
+    }
+}
+
+fn write_terminal_clipboard(text: &str) -> io::Result<()> {
+    let sequence = osc52_sequence(text);
+    let mut stdout = io::stdout();
+    stdout.write_all(sequence.as_bytes())?;
+    stdout.flush()
+}
+
+fn osc52_sequence(text: &str) -> String {
+    format!("\u{1b}]52;c;{}\u{7}", base64_encode(text.as_bytes()))
+}
+
+fn base64_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut encoded = String::with_capacity(bytes.len().div_ceil(3) * 4);
+
+    for chunk in bytes.chunks(3) {
+        let first = chunk[0];
+        let second = *chunk.get(1).unwrap_or(&0);
+        let third = *chunk.get(2).unwrap_or(&0);
+        let value = (u32::from(first) << 16) | (u32::from(second) << 8) | u32::from(third);
+
+        encoded.push(TABLE[((value >> 18) & 0x3f) as usize] as char);
+        encoded.push(TABLE[((value >> 12) & 0x3f) as usize] as char);
+        if chunk.len() > 1 {
+            encoded.push(TABLE[((value >> 6) & 0x3f) as usize] as char);
+        } else {
+            encoded.push('=');
+        }
+        if chunk.len() > 2 {
+            encoded.push(TABLE[(value & 0x3f) as usize] as char);
+        } else {
+            encoded.push('=');
+        }
+    }
+
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_encode_handles_padding() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"j"), "ag==");
+        assert_eq!(base64_encode(b"jj"), "amo=");
+        assert_eq!(base64_encode(b"jj undo"), "amogdW5kbw==");
+    }
+
+    #[test]
+    fn osc52_sequence_wraps_encoded_clipboard_payload() {
+        assert_eq!(osc52_sequence("jj undo"), "\u{1b}]52;c;amogdW5kbw==\u{7}");
+    }
+}

--- a/crates/jk/src/command_history.rs
+++ b/crates/jk/src/command_history.rs
@@ -1,0 +1,179 @@
+use jk_cli::{
+    JjCommandRunner, JjOperation, OperationQuery, RecordingJjCommandRunner, SystemJjCommandRunner,
+};
+use jk_core::{CommandHistory, CommandSource, SourceAction, SourceView};
+use jk_tui::command_history_view::{
+    CommandHistoryAction, CommandHistoryActionResult, CommandHistorySnapshot, CommandHistoryView,
+};
+use jk_tui::rendered_view::RenderedView;
+
+use crate::AppTransition;
+use crate::operation_log::operation_log_snapshot;
+use crate::refresh::{
+    OperationRenderedKind, operation_rendered_transition_with_runner, refresh_operation_log,
+};
+use crate::state::{AppState, AppView};
+
+pub fn open_command_history(state: &mut AppState) {
+    let snapshot = command_history_snapshot(&state.history);
+    if let AppView::CommandHistory { view } = state.views.active_mut() {
+        view.refresh(snapshot);
+        return;
+    }
+
+    let view = CommandHistoryView::new_focused_on_latest_operation(snapshot);
+    state.views.push(AppView::CommandHistory { view });
+}
+
+pub fn command_history_snapshot(history: &CommandHistory) -> CommandHistorySnapshot {
+    CommandHistorySnapshot::from_records(history.records())
+}
+
+pub fn push_selected_command_history_details(state: &mut AppState) {
+    let action = {
+        let AppView::CommandHistory { view } = state.views.active_mut() else {
+            return;
+        };
+        view.apply(CommandHistoryAction::OpenDetails)
+    };
+
+    if let CommandHistoryActionResult::OpenDetails { details } = action {
+        state.views.push(AppView::CommandHistoryDetails {
+            view: RenderedView::new(details.into_snapshot()),
+        });
+    }
+}
+
+pub fn open_command_history_operation(state: &mut AppState, operation_source: &JjOperation) {
+    open_command_history_operation_with_runner(state, operation_source, SystemJjCommandRunner);
+}
+
+pub fn open_command_history_operation_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    operation_source: &JjOperation,
+    runner: R,
+) {
+    let action = {
+        let AppView::CommandHistory { view } = state.views.active_mut() else {
+            return;
+        };
+        view.apply(CommandHistoryAction::OpenOperation)
+    };
+
+    match action {
+        CommandHistoryActionResult::OpenOperation { operation_id } => {
+            let query = OperationQuery::show(operation_id);
+            let transition = operation_rendered_transition_with_runner(
+                &mut state.history,
+                operation_source,
+                query,
+                SourceView::CommandHistory,
+                SourceAction::OperationShow,
+                OperationRenderedKind::Show,
+                runner,
+            );
+            if let AppTransition::Push(view) = transition {
+                state.views.push(view);
+            }
+        }
+        CommandHistoryActionResult::OpenOperationLog => {
+            open_operation_log_from_with_runner(
+                state,
+                operation_source,
+                CommandSource::new(SourceView::CommandHistory, SourceAction::OperationLog),
+                runner,
+            );
+        }
+        CommandHistoryActionResult::Continue
+        | CommandHistoryActionResult::Refresh
+        | CommandHistoryActionResult::ReturnBack
+        | CommandHistoryActionResult::Quit => {}
+        _ => {}
+    }
+}
+
+pub fn open_operation_log(state: &mut AppState, operation_source: &JjOperation) {
+    open_operation_log_from(
+        state,
+        operation_source,
+        CommandSource::new(SourceView::Log, SourceAction::OperationLog),
+    );
+}
+
+pub fn open_operation_log_from(
+    state: &mut AppState,
+    operation_source: &JjOperation,
+    source: CommandSource,
+) {
+    open_operation_log_from_with_runner(state, operation_source, source, SystemJjCommandRunner);
+}
+
+pub fn open_operation_log_from_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    operation_source: &JjOperation,
+    source: CommandSource,
+    runner: R,
+) {
+    if matches!(state.views.active(), AppView::OperationLog { .. }) {
+        let AppState { views, history, .. } = state;
+        if let AppView::OperationLog { view } = views.active_mut() {
+            refresh_operation_log(view, history, operation_source);
+        }
+        return;
+    }
+
+    let mut runner = RecordingJjCommandRunner::new(runner, &mut state.history, source);
+    let query = OperationQuery::log();
+    match operation_source.load_query_with_runner(&query, &mut runner) {
+        Ok(snapshot) => {
+            let view = jk_tui::operation_log_view::OperationLogView::new(operation_log_snapshot(
+                snapshot.title(),
+                snapshot.rendered(),
+            ));
+            state.views.push(AppView::OperationLog { view });
+        }
+        Err(error) => {
+            if let AppView::Log(log) = state.views.active_mut() {
+                log.show_error(error.to_string());
+            }
+        }
+    }
+}
+
+pub fn apply_command_history_action(
+    view: &mut CommandHistoryView,
+    history: &CommandHistory,
+    action: jk_tui::log_view::LogAction,
+) -> AppTransition {
+    let history_action = match action {
+        jk_tui::log_view::LogAction::Previous => CommandHistoryAction::Previous,
+        jk_tui::log_view::LogAction::Next => CommandHistoryAction::Next,
+        jk_tui::log_view::LogAction::ScrollPreviousLine => CommandHistoryAction::Previous,
+        jk_tui::log_view::LogAction::ScrollNextLine => CommandHistoryAction::Next,
+        jk_tui::log_view::LogAction::PagePrevious => CommandHistoryAction::PagePrevious,
+        jk_tui::log_view::LogAction::PageNext | jk_tui::log_view::LogAction::ToggleMark => {
+            CommandHistoryAction::PageNext
+        }
+        jk_tui::log_view::LogAction::First => CommandHistoryAction::First,
+        jk_tui::log_view::LogAction::Last => CommandHistoryAction::Last,
+        jk_tui::log_view::LogAction::Refresh => CommandHistoryAction::Refresh,
+        jk_tui::log_view::LogAction::ToggleHelp => CommandHistoryAction::ToggleHelp,
+        jk_tui::log_view::LogAction::Quit => CommandHistoryAction::Quit,
+        _ => return AppTransition::Continue,
+    };
+
+    match view.apply(history_action) {
+        CommandHistoryActionResult::Refresh => view.refresh(command_history_snapshot(history)),
+        CommandHistoryActionResult::OpenDetails { details } => {
+            return AppTransition::Push(AppView::CommandHistoryDetails {
+                view: RenderedView::new(details.into_snapshot()),
+            });
+        }
+        CommandHistoryActionResult::ReturnBack => return AppTransition::PopView,
+        CommandHistoryActionResult::Quit => return AppTransition::Quit,
+        CommandHistoryActionResult::Continue => {}
+        _ => {}
+    }
+
+    AppTransition::Continue
+}

--- a/crates/jk/src/command_mode.rs
+++ b/crates/jk/src/command_mode.rs
@@ -1,0 +1,240 @@
+use std::io;
+use std::path::Path;
+use std::process::Output;
+
+use jk_core::{ExecutionMode, InspectionSnapshot, JjCommandSpec, RefreshPlan, SafetyClass};
+
+pub fn command_mode_spec(argv: Vec<String>, repository: Option<&Path>) -> JjCommandSpec {
+    let mut spec = JjCommandSpec::render_read_only(argv)
+        .with_mode(ExecutionMode::CommandMode)
+        .with_safety(SafetyClass::LocalMetadata)
+        .with_refresh_plan(RefreshPlan::None);
+    if let Some(repository) = repository {
+        spec = spec.with_repository(repository);
+    }
+    let title = format!(": {}", spec.preview());
+    spec.with_title(title)
+}
+
+pub fn jj_command_lines(input: &str, error: Option<&str>) -> Vec<String> {
+    let mut lines = vec![format!(": {input}")];
+    if let Some(error) = error {
+        lines.push(format!("error: {error}"));
+    }
+    lines.push(String::new());
+    lines.push("enter run   Ctrl-u clear   backspace edit   esc cancel".to_owned());
+    lines
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum QuoteMode {
+    Single,
+    Double,
+}
+
+pub fn parse_jj_command_args(input: &str) -> std::result::Result<Vec<String>, String> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut in_arg = false;
+    let mut chars = input.chars();
+
+    while let Some(character) = chars.next() {
+        match quote {
+            Some(QuoteMode::Single) => {
+                if character == '\'' {
+                    quote = None;
+                } else {
+                    current.push(character);
+                    in_arg = true;
+                }
+            }
+            Some(QuoteMode::Double) => match character {
+                '"' => quote = None,
+                '\\' => {
+                    let Some(next) = chars.next() else {
+                        return Err("dangling escape".to_owned());
+                    };
+                    current.push(next);
+                    in_arg = true;
+                }
+                _ => {
+                    current.push(character);
+                    in_arg = true;
+                }
+            },
+            None => match character {
+                character if character.is_whitespace() => {
+                    if in_arg {
+                        args.push(std::mem::take(&mut current));
+                        in_arg = false;
+                    }
+                }
+                '\'' => {
+                    quote = Some(QuoteMode::Single);
+                    in_arg = true;
+                }
+                '"' => {
+                    quote = Some(QuoteMode::Double);
+                    in_arg = true;
+                }
+                '\\' => {
+                    let Some(next) = chars.next() else {
+                        return Err("dangling escape".to_owned());
+                    };
+                    current.push(next);
+                    in_arg = true;
+                }
+                _ => {
+                    current.push(character);
+                    in_arg = true;
+                }
+            },
+        }
+    }
+
+    match quote {
+        Some(QuoteMode::Single) => Err("unterminated single quote".to_owned()),
+        Some(QuoteMode::Double) => Err("unterminated double quote".to_owned()),
+        None => {
+            if in_arg {
+                args.push(current);
+            }
+            Ok(args)
+        }
+    }
+}
+
+pub fn command_mode_snapshot(
+    command_line: &str,
+    result: std::result::Result<&Output, &io::Error>,
+) -> InspectionSnapshot {
+    let rendered = command_mode_rendered(command_line, result);
+    InspectionSnapshot::new(command_line, rendered).with_title(command_line)
+}
+
+pub fn command_mode_rendered(
+    command_line: &str,
+    result: std::result::Result<&Output, &io::Error>,
+) -> String {
+    let mut rendered = String::new();
+    rendered.push_str(&format!("Command: {command_line}\n"));
+    match result {
+        Ok(output) => {
+            rendered.push_str(&format!("Status: {}\n", exit_status_label(output)));
+            push_command_stream(&mut rendered, "Stdout", &output.stdout);
+            push_command_stream(&mut rendered, "Stderr", &output.stderr);
+        }
+        Err(error) => {
+            rendered.push_str("Status: spawn error\n");
+            rendered.push_str(&format!("Spawn error: {error}\n"));
+            push_command_stream(&mut rendered, "Stdout", &[]);
+            push_command_stream(&mut rendered, "Stderr", &[]);
+        }
+    }
+    rendered.push_str("\nActions: e edit/retry command   : run another jj command\n");
+    rendered
+}
+
+fn exit_status_label(output: &Output) -> String {
+    if output.status.success() {
+        return "success".to_owned();
+    }
+
+    output
+        .status
+        .code()
+        .map_or_else(|| "failed".to_owned(), |code| format!("exit {code}"))
+}
+
+fn push_command_stream(rendered: &mut String, label: &str, bytes: &[u8]) {
+    rendered.push_str(&format!("\n{label}:\n"));
+    let text = String::from_utf8_lossy(bytes);
+    if text.is_empty() {
+        rendered.push_str("<empty>\n");
+    } else {
+        rendered.push_str(&text);
+        if !text.ends_with('\n') {
+            rendered.push('\n');
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn output(code: i32, stdout: &str, stderr: &str) -> Output {
+        Output {
+            status: exit_status(code),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn exit_status(code: i32) -> std::process::ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+
+        std::process::ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(not(unix))]
+    fn exit_status(code: i32) -> std::process::ExitStatus {
+        std::process::Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+            .args(if cfg!(windows) {
+                vec!["/C".into(), format!("exit {code}").into()]
+            } else {
+                vec!["-c".into(), format!("exit {code}").into()]
+            })
+            .status()
+            .expect("exit status fixture")
+    }
+
+    #[test]
+    fn parser_handles_quotes_and_escapes() {
+        assert_eq!(
+            parse_jj_command_args("status").expect("valid args"),
+            vec!["status"]
+        );
+        assert_eq!(
+            parse_jj_command_args("describe -m 'two words' @").expect("valid args"),
+            vec!["describe", "-m", "two words", "@"]
+        );
+        assert_eq!(
+            parse_jj_command_args("log -r \"description(\\\"done\\\")\"").expect("valid args"),
+            vec!["log", "-r", "description(\"done\")"]
+        );
+    }
+
+    #[test]
+    fn parser_reports_incomplete_quotes() {
+        assert_eq!(
+            parse_jj_command_args("describe -m 'unfinished"),
+            Err("unterminated single quote".to_owned())
+        );
+        assert_eq!(
+            parse_jj_command_args("log \\"),
+            Err("dangling escape".to_owned())
+        );
+    }
+
+    #[test]
+    fn rendered_output_shows_edit_retry_hint() {
+        let result = output(0, "clean\n", "");
+        let rendered = command_mode_rendered("jj status", Ok(&result));
+
+        assert!(rendered.contains("Actions: e edit/retry command"));
+    }
+
+    #[test]
+    fn rendered_output_preserves_failure_stderr() {
+        let result = output(1, "", "bad revset\n");
+        let rendered = command_mode_rendered("jj log -r bad", Ok(&result));
+
+        assert!(rendered.contains("Command: jj log -r bad"));
+        assert!(rendered.contains("Status: exit 1"));
+        assert!(rendered.contains("Stdout:\n<empty>"));
+        assert!(rendered.contains("Stderr:\nbad revset"));
+    }
+}

--- a/crates/jk/src/key.rs
+++ b/crates/jk/src/key.rs
@@ -13,6 +13,54 @@ pub enum AppKey {
     /// Dispatch this action to the active view.
     Action(LogAction),
 
+    /// Open the selected revision show/details view.
+    OpenShow,
+
+    /// Open the selected revision evolution log.
+    OpenEvolog,
+
+    /// Open repository status.
+    OpenStatus,
+
+    /// Open the workspace list.
+    OpenWorkspaces,
+
+    /// Open the command-history list.
+    OpenCommandHistory,
+
+    /// Open the operation log list.
+    OpenOperationLog,
+
+    /// Copy the current command line.
+    CopyCommand,
+
+    /// Preview and run `jj undo`.
+    StartUndo,
+
+    /// Preview and run `jj redo`.
+    StartRedo,
+
+    /// Start an inline describe mutation for the selected revision.
+    StartDescribe,
+
+    /// Preview abandoning the selected revision.
+    StartAbandon,
+
+    /// Open view-scoped display and template options.
+    OpenViewOptions,
+
+    /// Start the `:` prompt for an arbitrary jj command.
+    StartCommandMode,
+
+    /// Preview `jj edit` from the log or reopen command-output input.
+    EditCommandOutput,
+
+    /// Open the current diff file list.
+    OpenDiffFileList,
+
+    /// Close the active mode or return to the previous view.
+    Back,
+
     /// Start a search prompt in views that support search.
     StartSearch,
 
@@ -41,11 +89,19 @@ impl AppKey {
 
         match key {
             KeyEvent {
+                code: KeyCode::Backspace,
+                ..
+            } => Self::Back,
+            KeyEvent {
                 code: KeyCode::Char('q') | KeyCode::Esc,
                 ..
             } => Self::Action(LogAction::Quit),
             KeyEvent {
-                code: KeyCode::Right | KeyCode::Enter,
+                code: KeyCode::Enter,
+                ..
+            } => Self::OpenShow,
+            KeyEvent {
+                code: KeyCode::Right,
                 ..
             } => Self::Action(LogAction::ToggleExpanded),
             KeyEvent {
@@ -67,11 +123,11 @@ impl AppKey {
             KeyEvent {
                 code: KeyCode::PageDown,
                 ..
-            }
-            | KeyEvent {
+            } => Self::Action(LogAction::PageNext),
+            KeyEvent {
                 code: KeyCode::Char(' '),
                 ..
-            } => Self::Action(LogAction::PageNext),
+            } => Self::Action(LogAction::ToggleMark),
             KeyEvent {
                 code: KeyCode::Home,
                 ..
@@ -92,11 +148,26 @@ impl AppKey {
 const fn action_for_character_key(character: char) -> Option<AppKey> {
     match character {
         'q' => Some(AppKey::Action(LogAction::Quit)),
+        ':' => Some(AppKey::StartCommandMode),
         'r' => Some(AppKey::Action(LogAction::Refresh)),
         'H' => Some(AppKey::Action(LogAction::Home)),
         'L' => Some(AppKey::Action(LogAction::Log)),
+        'V' => Some(AppKey::OpenViewOptions),
+        'W' => Some(AppKey::OpenWorkspaces),
+        'C' => Some(AppKey::OpenCommandHistory),
+        'e' => Some(AppKey::EditCommandOutput),
+        'f' => Some(AppKey::OpenDiffFileList),
+        'o' => Some(AppKey::OpenOperationLog),
+        'y' => Some(AppKey::CopyCommand),
+        'u' => Some(AppKey::StartUndo),
+        'U' => Some(AppKey::StartRedo),
+        'm' => Some(AppKey::StartDescribe),
+        'a' => Some(AppKey::StartAbandon),
+        'v' => Some(AppKey::OpenEvolog),
         'l' => Some(AppKey::Action(LogAction::ToggleExpanded)),
         'd' => Some(AppKey::Action(LogAction::OpenDiff)),
+        'c' => Some(AppKey::Action(LogAction::ClearMarks)),
+        's' => Some(AppKey::OpenStatus),
         '?' => Some(AppKey::Action(LogAction::ToggleHelp)),
         '/' => Some(AppKey::StartSearch),
         'n' => Some(AppKey::SearchNext),
@@ -124,6 +195,8 @@ const fn action_for_control_key(code: KeyCode) -> AppKey {
     match code {
         KeyCode::Char('b') => AppKey::Action(LogAction::PagePrevious),
         KeyCode::Char('f') => AppKey::Action(LogAction::PageNext),
+        KeyCode::Char('k') => AppKey::Action(LogAction::ScrollPreviousLine),
+        KeyCode::Char('j') => AppKey::Action(LogAction::ScrollNextLine),
         KeyCode::Left => AppKey::Action(LogAction::FoldAll),
         KeyCode::Right => AppKey::Action(LogAction::UnfoldAll),
         _ => AppKey::Ignore,
@@ -135,10 +208,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn enter_toggles_expanded_details() {
+    fn enter_opens_show_details() {
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
-            AppKey::Action(LogAction::ToggleExpanded)
+            AppKey::OpenShow
         );
     }
 
@@ -179,10 +252,138 @@ mod tests {
     }
 
     #[test]
+    fn uppercase_v_opens_view_options() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('V'), KeyModifiers::NONE)),
+            AppKey::OpenViewOptions
+        );
+    }
+
+    #[test]
+    fn colon_starts_command_mode() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::NONE)),
+            AppKey::StartCommandMode
+        );
+    }
+
+    #[test]
+    fn uppercase_w_opens_workspaces() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('W'), KeyModifiers::NONE)),
+            AppKey::OpenWorkspaces
+        );
+    }
+
+    #[test]
+    fn uppercase_c_opens_command_history() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('C'), KeyModifiers::NONE)),
+            AppKey::OpenCommandHistory
+        );
+    }
+
+    #[test]
+    fn lowercase_o_opens_operation_log() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE)),
+            AppKey::OpenOperationLog
+        );
+    }
+
+    #[test]
+    fn lowercase_y_copies_command() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE)),
+            AppKey::CopyCommand
+        );
+    }
+
+    #[test]
+    fn lowercase_e_starts_edit_or_command_output_retry() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE)),
+            AppKey::EditCommandOutput
+        );
+    }
+
+    #[test]
+    fn lowercase_f_opens_diff_file_list() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE)),
+            AppKey::OpenDiffFileList
+        );
+    }
+
+    #[test]
+    fn lowercase_u_starts_undo_preview() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::NONE)),
+            AppKey::StartUndo
+        );
+    }
+
+    #[test]
+    fn uppercase_u_starts_redo_preview() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('U'), KeyModifiers::NONE)),
+            AppKey::StartRedo
+        );
+    }
+
+    #[test]
+    fn uppercase_t_is_unbound_after_view_options_migration() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('T'), KeyModifiers::NONE)),
+            AppKey::Ignore
+        );
+    }
+
+    #[test]
+    fn lowercase_v_opens_evolog() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE)),
+            AppKey::OpenEvolog
+        );
+    }
+
+    #[test]
+    fn lowercase_m_starts_describe() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE)),
+            AppKey::StartDescribe
+        );
+    }
+
+    #[test]
+    fn lowercase_a_starts_abandon_preview() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE)),
+            AppKey::StartAbandon
+        );
+    }
+
+    #[test]
     fn lowercase_d_opens_selected_diff() {
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE)),
             AppKey::Action(LogAction::OpenDiff)
+        );
+    }
+
+    #[test]
+    fn lowercase_c_clears_log_marks() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)),
+            AppKey::Action(LogAction::ClearMarks)
+        );
+    }
+
+    #[test]
+    fn lowercase_s_opens_status() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE)),
+            AppKey::OpenStatus
         );
     }
 
@@ -207,6 +408,14 @@ mod tests {
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('N'), KeyModifiers::NONE)),
             AppKey::SearchPrevious
+        );
+    }
+
+    #[test]
+    fn backspace_maps_to_back() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+            AppKey::Back
         );
     }
 
@@ -293,12 +502,16 @@ mod tests {
             AppKey::Action(LogAction::PageNext)
         );
         assert_eq!(
-            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE)),
-            AppKey::Action(LogAction::PageNext)
-        );
-        assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::SHIFT)),
             AppKey::Action(LogAction::PagePrevious)
+        );
+    }
+
+    #[test]
+    fn space_toggles_log_mark() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE)),
+            AppKey::Action(LogAction::ToggleMark)
         );
     }
 
@@ -319,6 +532,18 @@ mod tests {
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE)),
             AppKey::Action(LogAction::Last)
+        );
+    }
+
+    #[test]
+    fn control_j_and_k_scroll_log_by_line() {
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL)),
+            AppKey::Action(LogAction::ScrollNextLine)
+        );
+        assert_eq!(
+            AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL)),
+            AppKey::Action(LogAction::ScrollPreviousLine)
         );
     }
 }

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -4,129 +4,169 @@
 //! events and backend-neutral TUI actions. The product behavior is intentionally delegated to
 //! `jk-cli` and `jk-tui` so the binary stays a thin orchestration layer.
 
-use std::path::PathBuf;
+#![allow(
+    clippy::large_enum_variant,
+    clippy::nursery,
+    clippy::pedantic,
+    clippy::too_many_arguments
+)]
+#![cfg_attr(test, allow(clippy::expect_used))]
 
-use clap::{Parser, Subcommand};
+use std::io::{self, IsTerminal};
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
 use color_eyre::Result;
+use color_eyre::eyre::eyre;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::style::force_color_output;
-use jk_cli::{JjDiff, JjLog, JjLogCommand};
+#[cfg(test)]
+use jk_cli::RecoveryCommand;
+use jk_cli::{
+    AbandonQuery, DescribeQuery, DiffFormat, DiffQuery, EditQuery, EvologQuery, JjAbandon,
+    JjCommandRunner, JjDescribe, JjDiff, JjEdit, JjEvolog, JjLog, JjLogCommand, JjNew, JjOperation,
+    JjRecovery, JjShow, JjStatus, JjWorkspaces, LogTemplateSelection, NewQuery, OperationQuery,
+    RecordingJjCommandRunner, ShowQuery, StatusQuery, SystemJjCommandRunner,
+    WorkspaceInspectionQuery,
+};
+use jk_core::{CommandHistory, CommandSource, SourceAction, SourceView};
+use jk_tui::command_discovery::{BindingContext, filtered_discovery_len};
+use jk_tui::command_history_view::{CommandHistoryAction, CommandHistoryActionResult};
+#[cfg(test)]
+use jk_tui::command_history_view::{CommandHistorySnapshot, CommandHistoryView};
 use jk_tui::diff_view::{DiffAction, DiffActionResult, DiffView};
+#[cfg(test)]
+use jk_tui::log_view::LogAction;
 use jk_tui::log_view::{ActionResult, LogView};
+use jk_tui::operation_log_view::{OperationLogAction, OperationLogActionResult, OperationLogView};
+use jk_tui::rendered_view::{RenderedAction, RenderedActionResult, RenderedView};
+#[cfg(test)]
+use jk_tui::workspaces_view::WorkspaceViewSnapshot;
+use jk_tui::workspaces_view::{WorkspacesActionResult, WorkspacesView};
 
+mod actions;
+mod cli;
+mod clipboard;
+mod command_history;
+mod command_mode;
 mod key;
+mod menus;
+mod mutation_preview;
+mod mutations;
+mod operation_log;
+mod refresh;
+mod rendering;
+mod root_views;
+mod runner;
+mod state;
+#[cfg(test)]
+mod test_support;
+mod workspace_routes;
+mod workspaces;
 
+use actions::{AppSources, DispatchResult, dispatch_app_key};
+use cli::{Args, Command};
+use clipboard::copy_command_line;
+use command_history::{apply_command_history_action, open_command_history};
+#[cfg(test)]
+pub(crate) use command_history::{
+    command_history_snapshot, open_command_history_operation_with_runner,
+};
+pub(crate) use command_history::{
+    open_command_history_operation, open_operation_log, push_selected_command_history_details,
+};
+use command_mode::{command_mode_snapshot, command_mode_spec, parse_jj_command_args};
 use key::AppKey;
-
-/// Command-line options for the first log-oriented `jk` surface.
-#[derive(Debug, Parser)]
-#[command(version, about)]
-struct Args {
-    /// Repository path to pass to jj.
-    #[arg(short = 'R', long = "repository")]
-    repository: Option<PathBuf>,
-
-    /// Maximum number of log entries to render for the default command.
-    #[arg(short = 'n', long)]
-    limit: Option<usize>,
-
-    /// View to open. If omitted, jk follows jj's configured default command.
-    #[command(subcommand)]
-    command: Option<Command>,
-}
-
-/// Top-level view commands supported by the binary.
-#[derive(Debug, Subcommand)]
-enum Command {
-    /// Show the jj log view.
-    Log(LogArgs),
-
-    /// Show the jj diff view for a revision.
-    Diff(DiffArgs),
-}
-
-/// Options for the explicit `jk log` command.
-#[derive(Debug, Parser)]
-struct LogArgs {
-    /// Maximum number of log entries to render.
-    #[arg(short = 'n', long)]
-    limit: Option<usize>,
-}
-
-/// Options for the explicit `jk diff` command.
-#[derive(Debug, Parser)]
-struct DiffArgs {
-    /// Revision to diff against its parent.
-    #[arg(default_value = "@")]
-    revision: String,
-}
+use menus::{
+    MenuDirection, ViewOptionRow, clamp_command_discovery_selection, view_option_rows,
+    wrapped_selection,
+};
+#[cfg(test)]
+use menus::{diff_file_list_lines, view_options_lines};
+use mutation_preview::{PendingCommandPreview, selected_new_parents};
+#[cfg(test)]
+use mutations::confirm_command_preview_with_runner;
+use mutations::{confirm_command_preview, open_recovery_preview};
+#[cfg(test)]
+use refresh::show_log_template_load_error;
+use refresh::{
+    OperationRenderedKind, apply_log_template_selection, operation_rendered_transition,
+    refresh_diff, refresh_evolog, refresh_log, refresh_operation_log, refresh_operation_rendered,
+    refresh_show, refresh_status, refresh_workspace_inspection, refresh_workspaces,
+    switch_log_command,
+};
+use rendering::render_app;
+use root_views::{
+    root_diff_view, root_log_view, root_show_view, root_status_view, root_workspaces_view,
+};
+pub(crate) use runner::recording_runner;
+#[cfg(test)]
+use state::ViewStack;
+use state::{AppState, AppView, InputMode, InputModeResult, ModeStack};
+use workspace_routes::{
+    WorkspaceInspectionKind, open_workspaces, push_selected_workspace_diff,
+    push_selected_workspace_log, push_selected_workspace_status, push_status,
+    update_selected_workspace_stale,
+};
+#[cfg(test)]
+use workspace_routes::{
+    open_workspaces_with_runner, push_selected_workspace_log_with_runner, push_status_with_runner,
+    push_workspace_view,
+};
+use workspaces::{workspace_action_for_log_action, workspace_inspection_action_for_log_action};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
     tracing_subscriber::fmt::init();
     let args = Args::parse();
-    let source = log_source(&args);
-    let diff_source = diff_source(&args);
-    let app = if let Some(Command::Diff(diff_args)) = &args.command {
-        let snapshot = diff_source.load(&diff_args.revision);
-        let diff = match snapshot {
-            Ok(snapshot) => DiffView::new(snapshot),
-            Err(error) => DiffView::from_error(
-                diff_args.revision.clone(),
-                format!("jj diff -r {}", diff_args.revision),
-                error.to_string(),
-            ),
-        };
-        AppView::Diff {
-            log: None,
-            diff: Box::new(diff),
+    let source = args.log_source();
+    let diff_source = args.diff_source();
+    let evolog_source = args.evolog_source();
+    let show_source = args.show_source();
+    let status_source = args.status_source();
+    let describe_source = args.describe_source();
+    let abandon_source = args.abandon_source();
+    let new_source = args.new_source();
+    let edit_source = args.edit_source();
+    let operation_source = args.operation_source();
+    let recovery_source = args.recovery_source();
+    let workspaces_source = args.workspaces_source();
+    let mut history = CommandHistory::default();
+    let app = match &args.command {
+        Some(Command::Diff(diff_args)) => {
+            let query = diff_args.query();
+            root_diff_view(&diff_source, query, &mut history)
         }
-    } else {
-        let entries = source.load()?;
-        AppView::Log(LogView::new(entries))
+        Some(Command::Show(show_args)) => {
+            let query = show_args.query();
+            root_show_view(&show_source, query, &mut history)
+        }
+        Some(Command::Status(status_args)) => {
+            let query = status_args.query();
+            root_status_view(&status_source, query, &mut history)
+        }
+        Some(Command::Workspaces) => root_workspaces_view(&workspaces_source, &mut history),
+        Some(Command::Log(_)) | None => root_log_view(&source, &mut history)?,
     };
 
-    run_terminal(app, source, &diff_source)?;
+    run_terminal(
+        app,
+        source,
+        &diff_source,
+        &evolog_source,
+        &show_source,
+        &status_source,
+        &describe_source,
+        &abandon_source,
+        &new_source,
+        &edit_source,
+        &operation_source,
+        &recovery_source,
+        &workspaces_source,
+        args.repository,
+        history,
+    )?;
     Ok(())
-}
-
-/// Builds the log source that matches the requested command-line view.
-///
-/// Bare `jk` intentionally starts from jj's configured default command, while `jk log` forces the
-/// explicit log command. The top-level limit applies to both forms unless the subcommand provides a
-/// narrower value.
-fn log_source(args: &Args) -> JjLog {
-    let (command, limit) = match &args.command {
-        Some(Command::Log(log_args)) => (JjLogCommand::Log, log_args.limit.or(args.limit)),
-        Some(Command::Diff(_)) | None => (JjLogCommand::ConfiguredDefault, args.limit),
-    };
-
-    let source = JjLog::default().with_command(command).with_limit(limit);
-    if let Some(repository) = &args.repository {
-        source.with_repository(repository)
-    } else {
-        source
-    }
-}
-
-/// Builds the diff source for selected-change inspection.
-fn diff_source(args: &Args) -> JjDiff {
-    let source = JjDiff::default();
-    if let Some(repository) = &args.repository {
-        source.with_repository(repository)
-    } else {
-        source
-    }
-}
-
-/// Active top-level application view.
-#[derive(Debug)]
-enum AppView {
-    Log(LogView),
-    Diff {
-        log: Option<LogView>,
-        diff: Box<DiffView>,
-    },
 }
 
 /// Owns the terminal event loop for the current jj-native application.
@@ -134,59 +174,72 @@ enum AppView {
 /// The view remains responsible for state transitions and rendering. This loop only translates
 /// terminal events, performs I/O requested by the view, and redraws when input or terminal resize
 /// events can change the screen.
-fn run_terminal(mut app: AppView, mut source: JjLog, diff_source: &JjDiff) -> Result<()> {
+fn run_terminal(
+    app: AppView,
+    mut source: JjLog,
+    diff_source: &JjDiff,
+    evolog_source: &JjEvolog,
+    show_source: &JjShow,
+    status_source: &JjStatus,
+    describe_source: &JjDescribe,
+    abandon_source: &JjAbandon,
+    new_source: &JjNew,
+    edit_source: &JjEdit,
+    operation_source: &JjOperation,
+    recovery_source: &JjRecovery,
+    workspaces_source: &JjWorkspaces,
+    command_repository: Option<PathBuf>,
+    history: CommandHistory,
+) -> Result<()> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(eyre!("jk requires an interactive terminal"));
+    }
+
     // jj should keep configured colors even when the parent process was run by an agent or tool
     // that exports NO_COLOR.
     force_color_output(true);
-    let mut terminal = ratatui::try_init().inspect_err(|_| ratatui::restore())?;
+    let mut terminal = ratatui::try_init()?;
     let _terminal_restore = TerminalRestore;
     let mut needs_redraw = true;
-    let mut input_mode = InputMode::Normal;
+    let mut state = AppState::with_history(app, history);
 
     loop {
         if needs_redraw {
-            terminal.draw(|frame| match &mut app {
-                AppView::Log(log) => log.render(frame),
-                AppView::Diff { diff, .. } => match &input_mode {
-                    InputMode::Normal => diff.render(frame),
-                    InputMode::DiffSearch { query } => {
-                        let status = format!("/{query}");
-                        diff.render_with_status(frame, &status);
-                    }
-                },
-            })?;
+            terminal.draw(|frame| render_app(frame, &mut state, source.template()))?;
             needs_redraw = false;
         }
 
         match event::read()? {
             Event::Key(key) => {
-                if handle_input_mode(&mut app, &mut input_mode, key) == InputModeResult::Handled {
+                if handle_input_mode(
+                    &mut state,
+                    &mut source,
+                    diff_source,
+                    describe_source,
+                    command_repository.as_deref(),
+                    key,
+                ) == InputModeResult::Handled
+                {
                     needs_redraw = true;
                     continue;
                 }
 
-                let AppKey::Action(action) = AppKey::from_crossterm(key) else {
-                    match AppKey::from_crossterm(key) {
-                        AppKey::StartSearch if matches!(app, AppView::Diff { .. }) => {
-                            input_mode = InputMode::DiffSearch {
-                                query: String::new(),
-                            };
-                            needs_redraw = true;
-                        }
-                        AppKey::SearchNext => {
-                            apply_diff_search_action(&mut app, DiffAction::SearchNext);
-                            needs_redraw = true;
-                        }
-                        AppKey::SearchPrevious => {
-                            apply_diff_search_action(&mut app, DiffAction::SearchPrevious);
-                            needs_redraw = true;
-                        }
-                        _ => {}
-                    }
-                    continue;
+                let app_key = AppKey::from_crossterm(key);
+                let mut sources = AppSources {
+                    log: &mut source,
+                    diff: diff_source,
+                    evolog: evolog_source,
+                    show: show_source,
+                    status: status_source,
+                    abandon: abandon_source,
+                    new_change: new_source,
+                    edit: edit_source,
+                    operation: operation_source,
+                    recovery: recovery_source,
+                    workspaces: workspaces_source,
                 };
-
-                if apply_action(&mut app, &mut source, diff_source, action) == AppLoop::Quit {
+                if dispatch_app_key(&mut state, &mut sources, key, app_key) == DispatchResult::Quit
+                {
                     break;
                 }
                 needs_redraw = true;
@@ -201,27 +254,38 @@ fn run_terminal(mut app: AppView, mut source: JjLog, diff_source: &JjDiff) -> Re
     Ok(())
 }
 
-/// Transient input modes owned by the terminal loop.
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum InputMode {
-    Normal,
-    DiffSearch { query: String },
-}
-
-/// Whether an input-mode handler consumed a key event.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum InputModeResult {
-    Handled,
-    Unhandled,
-}
-
 /// Handles key input while a prompt-like mode is active.
 fn handle_input_mode(
-    app: &mut AppView,
-    input_mode: &mut InputMode,
+    state: &mut AppState,
+    source: &mut JjLog,
+    diff_source: &JjDiff,
+    describe_source: &JjDescribe,
+    command_repository: Option<&Path>,
     key: KeyEvent,
 ) -> InputModeResult {
-    let InputMode::DiffSearch { query } = input_mode else {
+    if matches!(state.modes.active(), Some(InputMode::ViewOptions { .. })) {
+        return handle_view_options_mode(state, source, diff_source, key);
+    }
+    if matches!(state.modes.active(), Some(InputMode::DiffFileList { .. })) {
+        return handle_diff_file_list_mode(state, key);
+    }
+    if matches!(state.modes.active(), Some(InputMode::LogTemplate { .. })) {
+        return handle_template_mode(state, source, key);
+    }
+    if matches!(
+        state.modes.active(),
+        Some(InputMode::CommandDiscovery { .. })
+    ) {
+        return handle_command_discovery_mode(state, key);
+    }
+    if matches!(state.modes.active(), Some(InputMode::CommandPreview { .. })) {
+        return handle_command_preview_mode(state, source, key);
+    }
+    if matches!(state.modes.active(), Some(InputMode::JjCommand { .. })) {
+        return handle_jj_command_mode(state, command_repository, key);
+    }
+
+    let Some(mode) = state.modes.active_mut() else {
         return InputModeResult::Unhandled;
     };
 
@@ -229,22 +293,61 @@ fn handle_input_mode(
         KeyEvent {
             code: KeyCode::Esc, ..
         } => {
-            *input_mode = InputMode::Normal;
+            state.modes.pop();
             InputModeResult::Handled
         }
         KeyEvent {
             code: KeyCode::Enter,
             ..
         } => {
-            apply_diff_search_action(app, DiffAction::Search(query.clone()));
-            *input_mode = InputMode::Normal;
+            let action = match mode {
+                InputMode::DiffSearch { query } => SearchSubmit::Diff(query.clone()),
+                InputMode::InspectionSearch { query } => SearchSubmit::Inspection(query.clone()),
+                InputMode::DescribeMessage { rev, message } => {
+                    if message.trim().is_empty() {
+                        return InputModeResult::Handled;
+                    }
+                    let preview = describe_source
+                        .spec_for(&DescribeQuery::new(rev.clone(), message.clone()))
+                        .command_preview();
+                    state.modes.pop();
+                    state.modes.push(InputMode::CommandPreview {
+                        pending: PendingCommandPreview::describe(preview),
+                    });
+                    return InputModeResult::Handled;
+                }
+                InputMode::ViewOptions { .. } => unreachable!(),
+                InputMode::DiffFileList { .. } => unreachable!(),
+                InputMode::CommandDiscovery { .. } => unreachable!(),
+                InputMode::CommandPreview { .. } => unreachable!(),
+                InputMode::JjCommand { .. } => unreachable!(),
+                InputMode::LogTemplate { .. } => unreachable!(),
+            };
+            state.modes.pop();
+            apply_search_submit(state, action);
             InputModeResult::Handled
         }
         KeyEvent {
             code: KeyCode::Backspace,
             ..
         } => {
-            query.pop();
+            if let InputMode::DescribeMessage { message, .. } = mode
+                && !message.is_empty()
+            {
+                message.pop();
+                return InputModeResult::Handled;
+            }
+            state.modes.pop();
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Char('u'),
+            modifiers,
+            ..
+        } if modifiers == KeyModifiers::CONTROL => {
+            if let InputMode::DescribeMessage { message, .. } = mode {
+                message.clear();
+            }
             InputModeResult::Handled
         }
         KeyEvent {
@@ -252,53 +355,941 @@ fn handle_input_mode(
             modifiers,
             ..
         } if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
-            query.push(character);
+            match mode {
+                InputMode::DiffSearch { query } | InputMode::InspectionSearch { query } => {
+                    query.push(character);
+                }
+                InputMode::DescribeMessage { message, .. } => {
+                    message.push(character);
+                }
+                InputMode::ViewOptions { .. } => unreachable!(),
+                InputMode::DiffFileList { .. } => unreachable!(),
+                InputMode::CommandDiscovery { .. } => unreachable!(),
+                InputMode::CommandPreview { .. } => unreachable!(),
+                InputMode::JjCommand { .. } => unreachable!(),
+                InputMode::LogTemplate { .. } => unreachable!(),
+            }
             InputModeResult::Handled
         }
         _ => InputModeResult::Handled,
     }
 }
 
-/// Applies a search-only diff action when the active view supports it.
-fn apply_diff_search_action(app: &mut AppView, action: DiffAction) {
-    if let AppView::Diff { diff, .. } = app {
-        let _ = diff.apply(action);
+fn handle_command_discovery_mode(state: &mut AppState, key: KeyEvent) -> InputModeResult {
+    match key {
+        KeyEvent {
+            code: KeyCode::Esc | KeyCode::Enter,
+            ..
+        } => {
+            state.modes.pop();
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Char('q' | '?'),
+            modifiers,
+            ..
+        } if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
+            state.modes.pop();
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Backspace,
+            ..
+        } => {
+            let should_close = match state.modes.active_mut() {
+                Some(InputMode::CommandDiscovery {
+                    query, selected, ..
+                }) if query.is_empty() => {
+                    *selected = 0;
+                    true
+                }
+                Some(InputMode::CommandDiscovery {
+                    context,
+                    query,
+                    selected,
+                }) => {
+                    query.pop();
+                    clamp_command_discovery_selection(*context, query, selected);
+                    false
+                }
+                _ => false,
+            };
+            if should_close {
+                state.modes.pop();
+            }
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Up, ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('k'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            move_command_discovery_selection(state, MenuDirection::Previous);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Down,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('j'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            move_command_discovery_selection(state, MenuDirection::Next);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Char(character),
+            modifiers,
+            ..
+        } if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
+            if let Some(InputMode::CommandDiscovery {
+                context,
+                query,
+                selected,
+            }) = state.modes.active_mut()
+            {
+                query.push(character);
+                clamp_command_discovery_selection(*context, query, selected);
+            }
+            InputModeResult::Handled
+        }
+        _ => InputModeResult::Handled,
     }
+}
+
+fn handle_command_preview_mode(
+    state: &mut AppState,
+    source: &mut JjLog,
+    key: KeyEvent,
+) -> InputModeResult {
+    match key {
+        KeyEvent {
+            code: KeyCode::Esc | KeyCode::Backspace,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('q'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            state.modes.pop();
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Enter,
+            ..
+        } => {
+            let Some(InputMode::CommandPreview { pending }) = state.modes.pop() else {
+                return InputModeResult::Handled;
+            };
+            confirm_command_preview(state, source, pending);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Char('y'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            copy_pending_command(state);
+            InputModeResult::Handled
+        }
+        _ => InputModeResult::Handled,
+    }
+}
+
+fn handle_jj_command_mode(
+    state: &mut AppState,
+    repository: Option<&Path>,
+    key: KeyEvent,
+) -> InputModeResult {
+    match key {
+        KeyEvent {
+            code: KeyCode::Esc, ..
+        } => {
+            state.modes.pop();
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Backspace,
+            ..
+        } => {
+            let should_close = match state.modes.active_mut() {
+                Some(InputMode::JjCommand { input, error }) if input.is_empty() => {
+                    *error = None;
+                    true
+                }
+                Some(InputMode::JjCommand { input, error }) => {
+                    input.pop();
+                    *error = None;
+                    false
+                }
+                _ => false,
+            };
+            if should_close {
+                state.modes.pop();
+            }
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Enter,
+            ..
+        } => {
+            submit_jj_command_mode(state, repository);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Char('u'),
+            modifiers,
+            ..
+        } if modifiers == KeyModifiers::CONTROL => {
+            if let Some(InputMode::JjCommand { input, error }) = state.modes.active_mut() {
+                input.clear();
+                *error = None;
+            }
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Char(character),
+            modifiers,
+            ..
+        } if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
+            if let Some(InputMode::JjCommand { input, error }) = state.modes.active_mut() {
+                input.push(character);
+                *error = None;
+            }
+            InputModeResult::Handled
+        }
+        _ => InputModeResult::Handled,
+    }
+}
+
+fn open_jj_command_mode(state: &mut AppState) {
+    open_jj_command_mode_with_input(state, String::new());
+}
+
+fn open_jj_command_mode_with_input(state: &mut AppState, input: String) {
+    state
+        .modes
+        .push(InputMode::JjCommand { input, error: None });
+}
+
+fn edit_command_output(state: &mut AppState) {
+    let AppView::CommandOutput { input, .. } = state.views.active() else {
+        return;
+    };
+    open_jj_command_mode_with_input(state, input.clone());
+}
+
+fn submit_jj_command_mode(state: &mut AppState, repository: Option<&Path>) {
+    let input = match state.modes.active() {
+        Some(InputMode::JjCommand { input, .. }) => input.clone(),
+        _ => return,
+    };
+
+    match run_jj_command_mode_with_runner(state, repository, &input, SystemJjCommandRunner) {
+        Ok(()) => {
+            state.modes.pop();
+        }
+        Err(error) => {
+            if let Some(InputMode::JjCommand {
+                error: active_error,
+                ..
+            }) = state.modes.active_mut()
+            {
+                *active_error = Some(error);
+            }
+        }
+    }
+}
+
+fn run_jj_command_mode_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    repository: Option<&Path>,
+    input: &str,
+    runner: R,
+) -> std::result::Result<(), String> {
+    let mut argv = parse_jj_command_args(input)?;
+    if argv.first().is_some_and(|arg| arg == "jj") {
+        argv.remove(0);
+    }
+    if argv.is_empty() {
+        return Err("type a jj command after :".to_owned());
+    }
+
+    let spec = command_mode_spec(argv, repository);
+    let command_line = spec.command_preview().command_line;
+    let mut runner = RecordingJjCommandRunner::new(
+        runner,
+        &mut state.history,
+        CommandSource::new(
+            SourceView::Other("command mode".to_owned()),
+            SourceAction::UserJjCommand,
+        )
+        .with_key(":"),
+    );
+    let result = runner.run(&spec);
+    let snapshot = command_mode_snapshot(&command_line, result.as_ref());
+    state.views.push(AppView::CommandOutput {
+        view: RenderedView::new(snapshot),
+        input: input.trim().to_owned(),
+    });
+    Ok(())
+}
+
+fn open_describe_message(state: &mut AppState) {
+    let AppView::Log(log) = state.views.active_mut() else {
+        return;
+    };
+    let Some(rev) = log.selected_change_id().map(ToOwned::to_owned) else {
+        log.show_error("No revision selected");
+        return;
+    };
+    let message = log.selected_description().unwrap_or_default().to_owned();
+
+    state
+        .modes
+        .push(InputMode::DescribeMessage { rev, message });
+}
+
+fn open_abandon_preview(state: &mut AppState, abandon_source: &JjAbandon) {
+    let AppView::Log(log) = state.views.active_mut() else {
+        return;
+    };
+    let Some(rev) = log.selected_change_id().map(ToOwned::to_owned) else {
+        log.show_error("No revision selected");
+        return;
+    };
+
+    let preview = abandon_source
+        .spec_for(&AbandonQuery::new(rev))
+        .command_preview();
+    state.modes.push(InputMode::CommandPreview {
+        pending: PendingCommandPreview::abandon(preview),
+    });
+}
+
+fn open_new_preview(state: &mut AppState, new_source: &JjNew) {
+    let AppView::Log(log) = state.views.active_mut() else {
+        return;
+    };
+    let parents = selected_new_parents(log);
+    if parents.is_empty() {
+        log.show_error("No parent revision selected");
+        return;
+    }
+
+    let preview = new_source
+        .spec_for(&NewQuery::new(parents))
+        .command_preview();
+    state.modes.push(InputMode::CommandPreview {
+        pending: PendingCommandPreview::new_change(preview),
+    });
+}
+
+fn open_edit_preview(state: &mut AppState, edit_source: &JjEdit) {
+    let AppView::Log(log) = state.views.active_mut() else {
+        return;
+    };
+    let Some(rev) = log.selected_change_id().map(ToOwned::to_owned) else {
+        log.show_error("No revision selected");
+        return;
+    };
+
+    let preview = edit_source.spec_for(&EditQuery::new(rev)).command_preview();
+    state.modes.push(InputMode::CommandPreview {
+        pending: PendingCommandPreview::edit(preview),
+    });
+}
+
+fn copy_pending_command(state: &mut AppState) {
+    let Some(InputMode::CommandPreview { pending }) = state.modes.active_mut() else {
+        return;
+    };
+    let status = copy_command_line(&pending.preview.command_line);
+    pending.copy_status = Some(status);
+}
+
+fn copy_selected_command(state: &mut AppState) {
+    let Some(action) = selected_command_copy_action(state) else {
+        return;
+    };
+
+    let status = match action {
+        CommandHistoryActionResult::CopyCommand { command_line } => {
+            copy_command_line(&command_line)
+        }
+        _ => return,
+    };
+    if let AppView::CommandHistory { view } = state.views.active_mut() {
+        view.show_status(status);
+    }
+}
+
+fn selected_command_copy_action(state: &mut AppState) -> Option<CommandHistoryActionResult> {
+    let AppView::CommandHistory { view } = state.views.active_mut() else {
+        return None;
+    };
+    Some(view.apply(CommandHistoryAction::CopyCommand))
+}
+
+fn handle_view_options_mode(
+    state: &mut AppState,
+    source: &JjLog,
+    diff_source: &JjDiff,
+    key: KeyEvent,
+) -> InputModeResult {
+    match key {
+        KeyEvent {
+            code: KeyCode::Esc | KeyCode::Backspace,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('q'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            state.modes.pop();
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Up, ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('k'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            move_view_options_selection(state, MenuDirection::Previous);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Down,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('j'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            move_view_options_selection(state, MenuDirection::Next);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Enter,
+            ..
+        } => {
+            let selected = selected_view_option(state);
+            state.modes.pop();
+            match selected {
+                Some(ViewOptionRow::LogTemplate) => {
+                    open_template_selector(&mut state.modes, source);
+                }
+                Some(ViewOptionRow::DiffFormat(format)) => {
+                    apply_diff_format_option(state, diff_source, format);
+                }
+                Some(ViewOptionRow::Placeholder) | None => {}
+            }
+            InputModeResult::Handled
+        }
+        _ => InputModeResult::Handled,
+    }
+}
+
+fn handle_diff_file_list_mode(state: &mut AppState, key: KeyEvent) -> InputModeResult {
+    match key {
+        KeyEvent {
+            code: KeyCode::Esc | KeyCode::Backspace,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('q'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            state.modes.pop();
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Up, ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('k'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            move_diff_file_list_selection(state, MenuDirection::Previous);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Down,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('j'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            move_diff_file_list_selection(state, MenuDirection::Next);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Enter,
+            ..
+        } => {
+            apply_diff_file_list_selection(state);
+            InputModeResult::Handled
+        }
+        _ => InputModeResult::Handled,
+    }
+}
+
+fn open_diff_file_list(state: &mut AppState) {
+    let AppView::Diff { view, .. } = state.views.active() else {
+        return;
+    };
+    let selected = view.selected_file_index().unwrap_or_default();
+    state.modes.push(InputMode::DiffFileList { selected });
+}
+
+fn move_diff_file_list_selection(state: &mut AppState, direction: MenuDirection) {
+    let row_count = active_diff_file_count(state);
+    let Some(InputMode::DiffFileList { selected }) = state.modes.active_mut() else {
+        return;
+    };
+    if row_count == 0 {
+        *selected = 0;
+        return;
+    }
+
+    *selected = wrapped_selection(*selected, row_count, direction);
+}
+
+fn active_diff_file_count(state: &AppState) -> usize {
+    match state.views.active() {
+        AppView::Diff { view, .. } => view.file_count(),
+        _ => 0,
+    }
+}
+
+fn apply_diff_file_list_selection(state: &mut AppState) {
+    let selected = match state.modes.active() {
+        Some(InputMode::DiffFileList { selected }) => *selected,
+        _ => return,
+    };
+    state.modes.pop();
+
+    let AppView::Diff { view, .. } = state.views.active_mut() else {
+        return;
+    };
+    view.select_file_index(selected);
+}
+
+fn apply_diff_format_option(state: &mut AppState, diff_source: &JjDiff, format: DiffFormat) {
+    apply_diff_format_option_with_runner(state, diff_source, format, SystemJjCommandRunner);
+}
+
+fn apply_diff_format_option_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    diff_source: &JjDiff,
+    format: DiffFormat,
+    runner: R,
+) {
+    let new_query = match state.views.active() {
+        AppView::Diff { query, .. } => query.with_format(format),
+        _ => return,
+    };
+
+    let mut runner = RecordingJjCommandRunner::new(
+        runner,
+        &mut state.history,
+        CommandSource::new(SourceView::Diff, SourceAction::Refresh),
+    );
+    let result = diff_source.load_query_with_runner(&new_query, &mut runner);
+
+    let AppView::Diff { view, query } = state.views.active_mut() else {
+        return;
+    };
+    match result {
+        Ok(snapshot) => {
+            *query = new_query;
+            view.refresh(snapshot);
+        }
+        Err(error) => view.show_error(error.to_string()),
+    }
+}
+
+fn open_command_discovery(state: &mut AppState) {
+    let context = active_binding_context(state);
+    state.modes.push(InputMode::CommandDiscovery {
+        context,
+        query: String::new(),
+        selected: 0,
+    });
+}
+
+fn open_view_options(state: &mut AppState) {
+    if matches!(state.views.active(), AppView::CommandHistory { .. }) {
+        return;
+    }
+
+    state.modes.push(InputMode::ViewOptions {
+        context: active_binding_context(state),
+        selected: active_view_option_index(state),
+    });
+}
+
+fn active_view_option_index(state: &AppState) -> usize {
+    match state.views.active() {
+        AppView::Diff { query, .. } => view_option_rows(BindingContext::Diff)
+            .iter()
+            .position(|row| *row == ViewOptionRow::DiffFormat(query.format()))
+            .unwrap_or_default(),
+        _ => 0,
+    }
+}
+
+fn active_binding_context(state: &AppState) -> BindingContext {
+    match state.views.active() {
+        AppView::Log(_) => BindingContext::Log,
+        AppView::Diff { .. } => BindingContext::Diff,
+        AppView::Show { .. }
+        | AppView::Evolog { .. }
+        | AppView::Status { .. }
+        | AppView::WorkspaceLog { .. }
+        | AppView::WorkspaceStatus { .. }
+        | AppView::WorkspaceDiff { .. }
+        | AppView::OperationShow { .. }
+        | AppView::OperationDiff { .. }
+        | AppView::CommandOutput { .. }
+        | AppView::CommandHistoryDetails { .. } => BindingContext::Inspection,
+        AppView::Workspaces { .. } => BindingContext::Workspaces,
+        AppView::CommandHistory { .. } => BindingContext::CommandHistory,
+        AppView::OperationLog { .. } => BindingContext::OperationLog,
+    }
+}
+
+fn move_command_discovery_selection(state: &mut AppState, direction: MenuDirection) {
+    let Some(InputMode::CommandDiscovery {
+        context,
+        query,
+        selected,
+    }) = state.modes.active_mut()
+    else {
+        return;
+    };
+    let row_count = filtered_discovery_len(*context, query);
+    if row_count == 0 {
+        *selected = 0;
+        return;
+    }
+
+    *selected = wrapped_selection(*selected, row_count, direction);
+}
+
+fn move_view_options_selection(state: &mut AppState, direction: MenuDirection) {
+    let Some(InputMode::ViewOptions { context, selected }) = state.modes.active_mut() else {
+        return;
+    };
+    let row_count = view_option_rows(*context).len();
+    if row_count == 0 {
+        *selected = 0;
+        return;
+    }
+
+    *selected = wrapped_selection(*selected, row_count, direction);
+}
+
+fn selected_view_option(state: &AppState) -> Option<ViewOptionRow> {
+    let Some(InputMode::ViewOptions { context, selected }) = state.modes.active() else {
+        return None;
+    };
+    view_option_rows(*context).get(*selected).copied()
+}
+
+fn handle_template_mode(
+    state: &mut AppState,
+    source: &mut JjLog,
+    key: KeyEvent,
+) -> InputModeResult {
+    match key {
+        KeyEvent {
+            code: KeyCode::Esc | KeyCode::Backspace,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('q'),
+            ..
+        } => {
+            state.modes.pop();
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Up, ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('k'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            move_template_selection(state, MenuDirection::Previous);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Down,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::Char('j'),
+            modifiers: KeyModifiers::NONE,
+            ..
+        } => {
+            move_template_selection(state, MenuDirection::Next);
+            InputModeResult::Handled
+        }
+        KeyEvent {
+            code: KeyCode::Enter,
+            ..
+        } => {
+            let template = selected_template(state);
+            state.modes.pop();
+            if let Some(template) = template {
+                apply_log_template_selection(state, source, template);
+            }
+            InputModeResult::Handled
+        }
+        _ => InputModeResult::Handled,
+    }
+}
+
+fn move_template_selection(state: &mut AppState, direction: MenuDirection) {
+    let Some(InputMode::LogTemplate { options, selected }) = state.modes.active_mut() else {
+        return;
+    };
+    if options.is_empty() {
+        *selected = 0;
+        return;
+    }
+
+    *selected = wrapped_selection(*selected, options.len(), direction);
+}
+
+fn selected_template(state: &AppState) -> Option<LogTemplateSelection> {
+    let Some(InputMode::LogTemplate { options, selected }) = state.modes.active() else {
+        return None;
+    };
+    options.get(*selected).cloned()
+}
+
+enum SearchSubmit {
+    Diff(String),
+    Inspection(String),
+}
+
+#[derive(Clone, Copy)]
+enum SearchDirection {
+    Next,
+    Previous,
+}
+
+fn apply_search_submit(state: &mut AppState, action: SearchSubmit) {
+    match (state.views.active_mut(), action) {
+        (AppView::Diff { view, .. }, SearchSubmit::Diff(query)) => {
+            let _ = view.apply(DiffAction::Search(query));
+        }
+        (AppView::Show { view, .. }, SearchSubmit::Inspection(query)) => {
+            let _ = view.apply(RenderedAction::Search(query));
+        }
+        (AppView::Evolog { view, .. }, SearchSubmit::Inspection(query)) => {
+            let _ = view.apply(RenderedAction::Search(query));
+        }
+        (AppView::Status { view, .. }, SearchSubmit::Inspection(query)) => {
+            let _ = view.apply(RenderedAction::Search(query));
+        }
+        (
+            AppView::WorkspaceStatus { view, .. }
+            | AppView::WorkspaceLog { view, .. }
+            | AppView::WorkspaceDiff { view, .. }
+            | AppView::OperationShow { view, .. }
+            | AppView::OperationDiff { view, .. }
+            | AppView::CommandOutput { view, .. }
+            | AppView::CommandHistoryDetails { view },
+            SearchSubmit::Inspection(query),
+        ) => {
+            let _ = view.apply(RenderedAction::Search(query));
+        }
+        _ => {}
+    }
+}
+
+/// Applies a search navigation action when the active view supports it.
+fn apply_search_action(state: &mut AppState, direction: SearchDirection) {
+    match state.views.active_mut() {
+        AppView::Diff { view, .. } => {
+            let action = match direction {
+                SearchDirection::Next => DiffAction::SearchNext,
+                SearchDirection::Previous => DiffAction::SearchPrevious,
+            };
+            let _ = view.apply(action);
+        }
+        AppView::Show { view, .. } => {
+            let action = match direction {
+                SearchDirection::Next => RenderedAction::SearchNext,
+                SearchDirection::Previous => RenderedAction::SearchPrevious,
+            };
+            let _ = view.apply(action);
+        }
+        AppView::Evolog { view, .. } => {
+            let action = match direction {
+                SearchDirection::Next => RenderedAction::SearchNext,
+                SearchDirection::Previous => RenderedAction::SearchPrevious,
+            };
+            let _ = view.apply(action);
+        }
+        AppView::Status { view, .. } => {
+            let action = match direction {
+                SearchDirection::Next => RenderedAction::SearchNext,
+                SearchDirection::Previous => RenderedAction::SearchPrevious,
+            };
+            let _ = view.apply(action);
+        }
+        AppView::WorkspaceStatus { view, .. }
+        | AppView::WorkspaceLog { view, .. }
+        | AppView::WorkspaceDiff { view, .. }
+        | AppView::OperationShow { view, .. }
+        | AppView::OperationDiff { view, .. }
+        | AppView::CommandOutput { view, .. }
+        | AppView::CommandHistoryDetails { view } => {
+            let action = match direction {
+                SearchDirection::Next => RenderedAction::SearchNext,
+                SearchDirection::Previous => RenderedAction::SearchPrevious,
+            };
+            let _ = view.apply(action);
+        }
+        AppView::Log(_)
+        | AppView::Workspaces { .. }
+        | AppView::CommandHistory { .. }
+        | AppView::OperationLog { .. } => {}
+    }
+}
+
+/// Closes the active mode, or returns to the previous view when possible.
+fn handle_back(state: &mut AppState) {
+    if state.modes.pop().is_some() {
+        return;
+    }
+
+    state.views.pop();
 }
 
 /// Applies an action to the active view and performs any requested I/O.
 fn apply_action(
-    app: &mut AppView,
+    state: &mut AppState,
     source: &mut JjLog,
     diff_source: &JjDiff,
+    evolog_source: &JjEvolog,
+    show_source: &JjShow,
+    status_source: &JjStatus,
+    operation_source: &JjOperation,
+    workspaces_source: &JjWorkspaces,
     action: jk_tui::log_view::LogAction,
 ) -> AppLoop {
-    let transition = match app {
-        AppView::Log(log) => apply_log_action(log, source, diff_source, action),
-        AppView::Diff { diff, .. } => apply_diff_action(diff, diff_source, action),
+    let transition = {
+        let AppState { views, history, .. } = state;
+        match views.active_mut() {
+            AppView::Log(log) => apply_log_action(log, history, source, diff_source, action),
+            AppView::Diff { view, query } => {
+                apply_diff_action(view, query, history, diff_source, action)
+            }
+            AppView::Show { view, query } => {
+                apply_show_action(view, query, history, show_source, action)
+            }
+            AppView::Evolog { view, query } => {
+                apply_evolog_action(view, query, history, evolog_source, action)
+            }
+            AppView::Status { view, query } => {
+                apply_status_action(view, query, history, status_source, action)
+            }
+            AppView::Workspaces { view } => {
+                apply_workspaces_action(view, history, workspaces_source, action)
+            }
+            AppView::CommandHistory { view } => apply_command_history_action(view, history, action),
+            AppView::CommandHistoryDetails { view } => apply_static_rendered_action(view, action),
+            AppView::CommandOutput { view, .. } => apply_static_rendered_action(view, action),
+            AppView::OperationLog { view } => {
+                apply_operation_log_action(view, history, operation_source, action)
+            }
+            AppView::WorkspaceStatus { view, query } => apply_workspace_inspection_action(
+                view,
+                query,
+                history,
+                workspaces_source,
+                WorkspaceInspectionKind::Status,
+                action,
+            ),
+            AppView::WorkspaceLog { view, query } => apply_workspace_inspection_action(
+                view,
+                query,
+                history,
+                workspaces_source,
+                WorkspaceInspectionKind::Log,
+                action,
+            ),
+            AppView::WorkspaceDiff { view, query } => apply_workspace_inspection_action(
+                view,
+                query,
+                history,
+                workspaces_source,
+                WorkspaceInspectionKind::Diff,
+                action,
+            ),
+            AppView::OperationShow { view, query } => apply_operation_rendered_action(
+                view,
+                query,
+                history,
+                operation_source,
+                SourceView::OperationShow,
+                action,
+            ),
+            AppView::OperationDiff { view, query } => apply_operation_rendered_action(
+                view,
+                query,
+                history,
+                operation_source,
+                SourceView::OperationDiff,
+                action,
+            ),
+        }
     };
 
     match transition {
         AppTransition::Continue => AppLoop::Continue,
-        AppTransition::OpenDiff(diff) => {
-            let previous = std::mem::replace(app, AppView::Log(LogView::default()));
-            if let AppView::Log(log) = previous {
-                *app = AppView::Diff {
-                    log: Some(log),
-                    diff,
-                };
-            }
+        AppTransition::Push(view) => {
+            state.views.push(view);
             AppLoop::Continue
         }
-        AppTransition::ReturnToLog => {
-            let previous = std::mem::replace(app, AppView::Log(LogView::default()));
-            if let AppView::Diff { log, diff } = previous {
-                if let Some(log) = log {
-                    *app = AppView::Log(log);
-                } else {
-                    *app = AppView::Diff { log: None, diff };
-                }
-            }
+        AppTransition::PopView => {
+            state.views.pop();
+            AppLoop::Continue
+        }
+        AppTransition::PushSelectedWorkspaceStatus => {
+            push_selected_workspace_status(state, workspaces_source);
+            AppLoop::Continue
+        }
+        AppTransition::PushSelectedWorkspaceLog => {
+            push_selected_workspace_log(state, workspaces_source);
+            AppLoop::Continue
+        }
+        AppTransition::PushSelectedWorkspaceDiff => {
+            push_selected_workspace_diff(state, workspaces_source);
+            AppLoop::Continue
+        }
+        AppTransition::OpenViewOptions => {
+            open_view_options(state);
             AppLoop::Continue
         }
         AppTransition::Quit => AppLoop::Quit,
@@ -308,16 +1299,24 @@ fn apply_action(
 /// Applies an action while the log view is active.
 fn apply_log_action(
     log: &mut LogView,
+    history: &mut CommandHistory,
     source: &mut JjLog,
     diff_source: &JjDiff,
     action: jk_tui::log_view::LogAction,
 ) -> AppTransition {
     match log.apply(action) {
-        ActionResult::Refresh => refresh_log(log, source),
-        ActionResult::SwitchHome => {
-            switch_log_command(log, source, JjLogCommand::ConfiguredDefault);
+        ActionResult::Refresh => {
+            refresh_log(
+                log,
+                history,
+                source,
+                CommandSource::new(SourceView::Log, SourceAction::Refresh),
+            );
         }
-        ActionResult::SwitchLog => switch_log_command(log, source, JjLogCommand::Log),
+        ActionResult::SwitchHome => {
+            switch_log_command(log, history, source, JjLogCommand::ConfiguredDefault);
+        }
+        ActionResult::SwitchLog => switch_log_command(log, history, source, JjLogCommand::Log),
         ActionResult::Quit => return AppTransition::Quit,
         _ => {}
     }
@@ -327,10 +1326,18 @@ fn apply_log_action(
             return AppTransition::Continue;
         };
 
-        match diff_source.load(&change_id) {
+        let query = DiffQuery::Revision {
+            rev: change_id,
+            format: DiffFormat::Patch,
+        };
+        let mut runner = recording_runner(
+            history,
+            CommandSource::new(SourceView::Log, SourceAction::OpenDiff),
+        );
+        match diff_source.load_query_with_runner(&query, &mut runner) {
             Ok(snapshot) => {
                 let diff = DiffView::new(snapshot);
-                return AppTransition::OpenDiff(Box::new(diff));
+                return AppTransition::Push(AppView::Diff { view: diff, query });
             }
             Err(error) => log.show_error(error.to_string()),
         }
@@ -339,17 +1346,297 @@ fn apply_log_action(
     AppTransition::Continue
 }
 
+fn push_selected_show(state: &mut AppState, show_source: &JjShow) {
+    let change_id = {
+        let AppView::Log(log) = state.views.active_mut() else {
+            return;
+        };
+        let Some(change_id) = log.selected_change_id().map(ToOwned::to_owned) else {
+            return;
+        };
+        change_id
+    };
+
+    let query = ShowQuery::from(change_id);
+    let mut runner = recording_runner(
+        &mut state.history,
+        CommandSource::new(SourceView::Log, SourceAction::OpenShow),
+    );
+    match show_source.load_query_with_runner(&query, &mut runner) {
+        Ok(snapshot) => {
+            state.views.push(AppView::Show {
+                view: RenderedView::new(snapshot),
+                query,
+            });
+        }
+        Err(error) => {
+            if let AppView::Log(log) = state.views.active_mut() {
+                log.show_error(error.to_string());
+            }
+        }
+    }
+}
+
+fn push_selected_evolog(state: &mut AppState, evolog_source: &JjEvolog) {
+    let change_id = {
+        let AppView::Log(log) = state.views.active_mut() else {
+            return;
+        };
+        let Some(change_id) = log.selected_change_id().map(ToOwned::to_owned) else {
+            return;
+        };
+        change_id
+    };
+
+    let query = EvologQuery::from(change_id);
+    let mut runner = recording_runner(
+        &mut state.history,
+        CommandSource::new(SourceView::Log, SourceAction::OpenEvolog),
+    );
+    match evolog_source.load_query_with_runner(&query, &mut runner) {
+        Ok(snapshot) => push_evolog_view(state, query, RenderedView::new(snapshot)),
+        Err(error) => {
+            if let AppView::Log(log) = state.views.active_mut() {
+                log.show_error(error.to_string());
+            }
+        }
+    }
+}
+
+fn push_evolog_view(state: &mut AppState, query: EvologQuery, view: RenderedView) {
+    if !matches!(state.views.active(), AppView::Log(_)) {
+        return;
+    }
+
+    state.views.push(AppView::Evolog { view, query });
+}
+
+fn push_selected_operation_show(state: &mut AppState, operation_source: &JjOperation) {
+    let operation_id = {
+        let AppView::OperationLog { view } = state.views.active_mut() else {
+            return;
+        };
+        let Some(operation_id) = view.selected_operation_id().map(ToOwned::to_owned) else {
+            return;
+        };
+        operation_id
+    };
+    let query = OperationQuery::show(operation_id);
+    let transition = operation_rendered_transition(
+        &mut state.history,
+        operation_source,
+        query,
+        SourceView::OperationLog,
+        SourceAction::OperationShow,
+        OperationRenderedKind::Show,
+    );
+    if let AppTransition::Push(view) = transition {
+        state.views.push(view);
+    }
+}
+
+/// Applies an action while the operation log is active.
+fn apply_operation_log_action(
+    view: &mut OperationLogView,
+    history: &mut CommandHistory,
+    operation_source: &JjOperation,
+    action: jk_tui::log_view::LogAction,
+) -> AppTransition {
+    let operation_action = match action {
+        jk_tui::log_view::LogAction::Previous => OperationLogAction::Previous,
+        jk_tui::log_view::LogAction::Next => OperationLogAction::Next,
+        jk_tui::log_view::LogAction::ScrollPreviousLine => OperationLogAction::Previous,
+        jk_tui::log_view::LogAction::ScrollNextLine => OperationLogAction::Next,
+        jk_tui::log_view::LogAction::PagePrevious => OperationLogAction::PagePrevious,
+        jk_tui::log_view::LogAction::PageNext | jk_tui::log_view::LogAction::ToggleMark => {
+            OperationLogAction::PageNext
+        }
+        jk_tui::log_view::LogAction::First => OperationLogAction::First,
+        jk_tui::log_view::LogAction::Last => OperationLogAction::Last,
+        jk_tui::log_view::LogAction::Refresh => OperationLogAction::Refresh,
+        jk_tui::log_view::LogAction::OpenDiff => OperationLogAction::OpenDiff,
+        jk_tui::log_view::LogAction::ToggleHelp => OperationLogAction::ToggleHelp,
+        jk_tui::log_view::LogAction::Quit => OperationLogAction::Quit,
+        jk_tui::log_view::LogAction::Home
+        | jk_tui::log_view::LogAction::Log
+        | jk_tui::log_view::LogAction::CollapseExpanded => OperationLogAction::ReturnBack,
+        _ => return AppTransition::Continue,
+    };
+
+    match view.apply(operation_action) {
+        OperationLogActionResult::Refresh => refresh_operation_log(view, history, operation_source),
+        OperationLogActionResult::OperationShow { operation_id } => {
+            let query = OperationQuery::show(operation_id);
+            return operation_rendered_transition(
+                history,
+                operation_source,
+                query,
+                SourceView::OperationLog,
+                SourceAction::OperationShow,
+                OperationRenderedKind::Show,
+            );
+        }
+        OperationLogActionResult::OperationDiff { operation_id } => {
+            let query = OperationQuery::diff(operation_id);
+            return operation_rendered_transition(
+                history,
+                operation_source,
+                query,
+                SourceView::OperationLog,
+                SourceAction::OperationDiff,
+                OperationRenderedKind::Diff,
+            );
+        }
+        OperationLogActionResult::ReturnBack => return AppTransition::PopView,
+        OperationLogActionResult::Quit => return AppTransition::Quit,
+        OperationLogActionResult::Continue => {}
+        _ => {}
+    }
+
+    AppTransition::Continue
+}
+
+/// Applies an action while the workspace list is active.
+fn apply_workspaces_action(
+    view: &mut WorkspacesView,
+    history: &mut CommandHistory,
+    workspaces_source: &JjWorkspaces,
+    action: jk_tui::log_view::LogAction,
+) -> AppTransition {
+    match view.apply(workspace_action_for_log_action(action)) {
+        WorkspacesActionResult::Refresh => refresh_workspaces(view, history, workspaces_source),
+        WorkspacesActionResult::OpenLog => {
+            return AppTransition::PushSelectedWorkspaceLog;
+        }
+        WorkspacesActionResult::OpenStatus => {
+            return AppTransition::PushSelectedWorkspaceStatus;
+        }
+        WorkspacesActionResult::OpenDiff => {
+            return AppTransition::PushSelectedWorkspaceDiff;
+        }
+        WorkspacesActionResult::ReturnBack => return AppTransition::PopView,
+        WorkspacesActionResult::ViewOptions => return AppTransition::OpenViewOptions,
+        WorkspacesActionResult::Quit => return AppTransition::Quit,
+        WorkspacesActionResult::Continue => {}
+        _ => {}
+    }
+
+    AppTransition::Continue
+}
+
+/// Applies an action while selected-workspace status or diff is active.
+fn apply_workspace_inspection_action(
+    view: &mut RenderedView,
+    query: &WorkspaceInspectionQuery,
+    history: &mut CommandHistory,
+    workspaces_source: &JjWorkspaces,
+    kind: WorkspaceInspectionKind,
+    action: jk_tui::log_view::LogAction,
+) -> AppTransition {
+    match view.apply(workspace_inspection_action_for_log_action(action)) {
+        RenderedActionResult::Refresh => {
+            refresh_workspace_inspection(view, query, history, workspaces_source, kind);
+        }
+        RenderedActionResult::ReturnToLog => return AppTransition::PopView,
+        RenderedActionResult::Quit => return AppTransition::Quit,
+        RenderedActionResult::Continue => {}
+        _ => {}
+    }
+
+    AppTransition::Continue
+}
+
+/// Applies an action while operation show or operation diff is active.
+fn apply_operation_rendered_action(
+    view: &mut RenderedView,
+    query: &OperationQuery,
+    history: &mut CommandHistory,
+    operation_source: &JjOperation,
+    source_view: SourceView,
+    action: jk_tui::log_view::LogAction,
+) -> AppTransition {
+    let rendered_action = match action {
+        jk_tui::log_view::LogAction::Previous => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::Next => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::ScrollPreviousLine => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::ScrollNextLine => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::PagePrevious => RenderedAction::PagePrevious,
+        jk_tui::log_view::LogAction::PageNext => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ToggleMark => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ClearMarks => RenderedAction::Ignore,
+        jk_tui::log_view::LogAction::First => RenderedAction::First,
+        jk_tui::log_view::LogAction::Last => RenderedAction::Last,
+        jk_tui::log_view::LogAction::ToggleHelp => RenderedAction::ToggleHelp,
+        jk_tui::log_view::LogAction::Refresh => RenderedAction::Refresh,
+        jk_tui::log_view::LogAction::Quit => RenderedAction::Quit,
+        _ => RenderedAction::ReturnToLog,
+    };
+
+    match view.apply(rendered_action) {
+        RenderedActionResult::Refresh => {
+            refresh_operation_rendered(view, query, history, operation_source, source_view);
+        }
+        RenderedActionResult::ReturnToLog => return AppTransition::PopView,
+        RenderedActionResult::Quit => return AppTransition::Quit,
+        RenderedActionResult::Continue => {}
+        _ => {}
+    }
+
+    AppTransition::Continue
+}
+
+/// Applies an action while a static rendered in-memory view is active.
+fn apply_static_rendered_action(
+    view: &mut RenderedView,
+    action: jk_tui::log_view::LogAction,
+) -> AppTransition {
+    let rendered_action = match action {
+        jk_tui::log_view::LogAction::Previous => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::Next => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::ScrollPreviousLine => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::ScrollNextLine => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::PagePrevious => RenderedAction::PagePrevious,
+        jk_tui::log_view::LogAction::PageNext => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ToggleMark => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ClearMarks => RenderedAction::Ignore,
+        jk_tui::log_view::LogAction::First => RenderedAction::First,
+        jk_tui::log_view::LogAction::Last => RenderedAction::Last,
+        jk_tui::log_view::LogAction::ToggleHelp => RenderedAction::ToggleHelp,
+        jk_tui::log_view::LogAction::Refresh => RenderedAction::Refresh,
+        jk_tui::log_view::LogAction::Quit => RenderedAction::Quit,
+        _ => RenderedAction::ReturnToLog,
+    };
+
+    match view.apply(rendered_action) {
+        RenderedActionResult::Refresh => {
+            view.show_error("Command details are retained in memory; refresh Command History.");
+        }
+        RenderedActionResult::ReturnToLog => return AppTransition::PopView,
+        RenderedActionResult::Quit => return AppTransition::Quit,
+        RenderedActionResult::Continue => {}
+        _ => {}
+    }
+
+    AppTransition::Continue
+}
+
 /// Applies an action while the diff view is active.
 fn apply_diff_action(
     diff: &mut DiffView,
+    query: &DiffQuery,
+    history: &mut CommandHistory,
     diff_source: &JjDiff,
     action: jk_tui::log_view::LogAction,
 ) -> AppTransition {
     let diff_action = match action {
         jk_tui::log_view::LogAction::Previous => DiffAction::ScrollPrevious,
         jk_tui::log_view::LogAction::Next => DiffAction::ScrollNext,
+        jk_tui::log_view::LogAction::ScrollPreviousLine => DiffAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::ScrollNextLine => DiffAction::ScrollNext,
         jk_tui::log_view::LogAction::PagePrevious => DiffAction::PagePrevious,
         jk_tui::log_view::LogAction::PageNext => DiffAction::PageNext,
+        jk_tui::log_view::LogAction::ToggleMark => DiffAction::PageNext,
+        jk_tui::log_view::LogAction::ClearMarks => DiffAction::Ignore,
         jk_tui::log_view::LogAction::First => DiffAction::First,
         jk_tui::log_view::LogAction::Last => DiffAction::Last,
         jk_tui::log_view::LogAction::PreviousFile => DiffAction::PreviousFile,
@@ -372,9 +1659,114 @@ fn apply_diff_action(
     };
 
     match diff.apply(diff_action) {
-        DiffActionResult::Refresh => refresh_diff(diff, diff_source),
-        DiffActionResult::ReturnToLog => return AppTransition::ReturnToLog,
+        DiffActionResult::Refresh => refresh_diff(diff, query, history, diff_source),
+        DiffActionResult::ReturnToLog => return AppTransition::PopView,
         DiffActionResult::Quit => return AppTransition::Quit,
+        _ => {}
+    }
+
+    AppTransition::Continue
+}
+
+/// Applies an action while a rendered inspection view is active.
+fn apply_show_action(
+    view: &mut RenderedView,
+    query: &ShowQuery,
+    history: &mut CommandHistory,
+    show_source: &JjShow,
+    action: jk_tui::log_view::LogAction,
+) -> AppTransition {
+    let rendered_action = match action {
+        jk_tui::log_view::LogAction::Previous => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::Next => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::ScrollPreviousLine => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::ScrollNextLine => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::PagePrevious => RenderedAction::PagePrevious,
+        jk_tui::log_view::LogAction::PageNext => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ToggleMark => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ClearMarks => RenderedAction::Ignore,
+        jk_tui::log_view::LogAction::First => RenderedAction::First,
+        jk_tui::log_view::LogAction::Last => RenderedAction::Last,
+        jk_tui::log_view::LogAction::ToggleHelp => RenderedAction::ToggleHelp,
+        jk_tui::log_view::LogAction::Refresh => RenderedAction::Refresh,
+        jk_tui::log_view::LogAction::Quit => RenderedAction::Quit,
+        _ => RenderedAction::ReturnToLog,
+    };
+
+    match view.apply(rendered_action) {
+        RenderedActionResult::Refresh => refresh_show(view, query, history, show_source),
+        RenderedActionResult::ReturnToLog => return AppTransition::PopView,
+        RenderedActionResult::Quit => return AppTransition::Quit,
+        _ => {}
+    }
+
+    AppTransition::Continue
+}
+
+/// Applies an action while an evolution-log view is active.
+fn apply_evolog_action(
+    view: &mut RenderedView,
+    query: &EvologQuery,
+    history: &mut CommandHistory,
+    evolog_source: &JjEvolog,
+    action: jk_tui::log_view::LogAction,
+) -> AppTransition {
+    let rendered_action = match action {
+        jk_tui::log_view::LogAction::Previous => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::Next => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::ScrollPreviousLine => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::ScrollNextLine => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::PagePrevious => RenderedAction::PagePrevious,
+        jk_tui::log_view::LogAction::PageNext => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ToggleMark => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ClearMarks => RenderedAction::Ignore,
+        jk_tui::log_view::LogAction::First => RenderedAction::First,
+        jk_tui::log_view::LogAction::Last => RenderedAction::Last,
+        jk_tui::log_view::LogAction::ToggleHelp => RenderedAction::ToggleHelp,
+        jk_tui::log_view::LogAction::Refresh => RenderedAction::Refresh,
+        jk_tui::log_view::LogAction::Quit => RenderedAction::Quit,
+        _ => RenderedAction::ReturnToLog,
+    };
+
+    match view.apply(rendered_action) {
+        RenderedActionResult::Refresh => refresh_evolog(view, query, history, evolog_source),
+        RenderedActionResult::ReturnToLog => return AppTransition::PopView,
+        RenderedActionResult::Quit => return AppTransition::Quit,
+        _ => {}
+    }
+
+    AppTransition::Continue
+}
+
+/// Applies an action while a repository status view is active.
+fn apply_status_action(
+    view: &mut RenderedView,
+    query: &StatusQuery,
+    history: &mut CommandHistory,
+    status_source: &JjStatus,
+    action: jk_tui::log_view::LogAction,
+) -> AppTransition {
+    let rendered_action = match action {
+        jk_tui::log_view::LogAction::Previous => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::Next => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::ScrollPreviousLine => RenderedAction::ScrollPrevious,
+        jk_tui::log_view::LogAction::ScrollNextLine => RenderedAction::ScrollNext,
+        jk_tui::log_view::LogAction::PagePrevious => RenderedAction::PagePrevious,
+        jk_tui::log_view::LogAction::PageNext => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ToggleMark => RenderedAction::PageNext,
+        jk_tui::log_view::LogAction::ClearMarks => RenderedAction::Ignore,
+        jk_tui::log_view::LogAction::First => RenderedAction::First,
+        jk_tui::log_view::LogAction::Last => RenderedAction::Last,
+        jk_tui::log_view::LogAction::ToggleHelp => RenderedAction::ToggleHelp,
+        jk_tui::log_view::LogAction::Refresh => RenderedAction::Refresh,
+        jk_tui::log_view::LogAction::Quit => RenderedAction::Quit,
+        _ => RenderedAction::ReturnToLog,
+    };
+
+    match view.apply(rendered_action) {
+        RenderedActionResult::Refresh => refresh_status(view, query, history, status_source),
+        RenderedActionResult::ReturnToLog => return AppTransition::PopView,
+        RenderedActionResult::Quit => return AppTransition::Quit,
         _ => {}
     }
 
@@ -390,40 +1782,24 @@ enum AppLoop {
 
 /// View transition requested after an action is applied.
 #[derive(Debug)]
-enum AppTransition {
+pub(crate) enum AppTransition {
     Continue,
-    OpenDiff(Box<DiffView>),
-    ReturnToLog,
+    Push(AppView),
+    PopView,
+    PushSelectedWorkspaceStatus,
+    PushSelectedWorkspaceLog,
+    PushSelectedWorkspaceDiff,
+    OpenViewOptions,
     Quit,
 }
 
-/// Reloads the current command without replacing the view on failure.
-fn refresh_log(app: &mut LogView, source: &JjLog) {
-    match source.load() {
-        Ok(snapshot) => app.refresh(snapshot),
-        Err(error) => app.show_error(error.to_string()),
-    }
-}
-
-/// Reloads the active diff without replacing the view on failure.
-fn refresh_diff(app: &mut DiffView, source: &JjDiff) {
-    let change_id = app.change_id().to_owned();
-    match source.load(&change_id) {
-        Ok(snapshot) => app.refresh(snapshot),
-        Err(error) => app.show_error(error.to_string()),
-    }
-}
-
-/// Switches the command context only after the replacement log loads.
-fn switch_log_command(app: &mut LogView, source: &mut JjLog, command: JjLogCommand) {
-    let next_source = source.clone().with_command(command);
-    match next_source.load() {
-        Ok(snapshot) => {
-            *source = next_source;
-            app.refresh(snapshot);
-        }
-        Err(error) => app.show_error(error.to_string()),
-    }
+fn open_template_selector(modes: &mut ModeStack, source: &JjLog) {
+    let options = source.template_options();
+    let selected = options
+        .iter()
+        .position(|template| template == source.template())
+        .unwrap_or(0);
+    modes.push(InputMode::LogTemplate { options, selected });
 }
 
 /// Restores terminal mode even when the event loop returns through an error.
@@ -432,5 +1808,1983 @@ struct TerminalRestore;
 impl Drop for TerminalRestore {
     fn drop(&mut self) {
         ratatui::restore();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use jk_tui::workspaces_view::WorkspaceViewRow;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+    use crate::test_support::*;
+
+    #[test]
+    fn view_stack_keeps_root_when_popped() {
+        let root = diff_app_view("aaa");
+        let mut stack = ViewStack::new(root.clone());
+
+        assert!(!stack.pop());
+        assert_eq!(stack.active(), &root);
+    }
+
+    #[test]
+    fn app_state_exposes_retained_command_history_for_tests() {
+        let mut history = CommandHistory::new(4);
+        let spec = jk_core::JjCommandSpec::render_read_only(["status"]);
+        history.start(jk_core::CommandRecordStart::from_spec(
+            &spec,
+            CommandSource::new(SourceView::Status, SourceAction::InitialLoad),
+        ));
+        let state = AppState::with_history(AppView::Log(LogView::default()), history);
+
+        assert_eq!(state.command_history().records().count(), 1);
+    }
+
+    #[test]
+    fn opening_command_history_from_log_pushes_snapshot_without_recording() {
+        let mut history = CommandHistory::new(4);
+        append_history_record(
+            &mut history,
+            jk_core::JjCommandSpec::render_read_only(["log"]),
+            SourceView::Log,
+            SourceAction::InitialLoad,
+        );
+        let mut state = AppState::with_history(AppView::Log(LogView::default()), history);
+
+        open_command_history(&mut state);
+
+        assert_eq!(state.views.len(), 2);
+        assert!(matches!(
+            state.views.active(),
+            AppView::CommandHistory { .. }
+        ));
+        assert_eq!(state.command_history().records().count(), 1);
+    }
+
+    #[test]
+    fn opening_command_history_from_workspaces_preserves_previous_view() {
+        let mut history = CommandHistory::new(4);
+        append_history_record(
+            &mut history,
+            jk_core::JjCommandSpec::render_read_only(["workspace", "list"]),
+            SourceView::Workspaces,
+            SourceAction::WorkspaceList,
+        );
+        let workspace_view = workspace_app_view();
+        let expected = workspace_view.clone();
+        let mut state = AppState::with_history(
+            AppView::Workspaces {
+                view: workspace_view,
+            },
+            history,
+        );
+
+        open_command_history(&mut state);
+
+        assert_eq!(state.views.len(), 2);
+        assert!(matches!(
+            state.views.active(),
+            AppView::CommandHistory { .. }
+        ));
+
+        handle_back(&mut state);
+
+        assert_eq!(
+            state.views.active(),
+            &AppView::Workspaces { view: expected }
+        );
+        assert_eq!(state.command_history().records().count(), 1);
+    }
+
+    #[test]
+    fn opening_command_history_again_refreshes_without_stacking() {
+        let mut history = CommandHistory::new(4);
+        append_history_record(
+            &mut history,
+            jk_core::JjCommandSpec::render_read_only(["log"]),
+            SourceView::Log,
+            SourceAction::InitialLoad,
+        );
+        let mut state = AppState::with_history(AppView::Log(LogView::default()), history);
+
+        open_command_history(&mut state);
+        open_command_history(&mut state);
+
+        assert_eq!(state.views.len(), 2);
+        assert!(matches!(
+            state.views.active(),
+            AppView::CommandHistory { .. }
+        ));
+        assert_eq!(state.command_history().records().count(), 1);
+    }
+
+    #[test]
+    fn refreshing_command_history_rebuilds_snapshot_without_recording() {
+        let mut history = CommandHistory::new(4);
+        append_history_record(
+            &mut history,
+            jk_core::JjCommandSpec::render_read_only(["log"]),
+            SourceView::Log,
+            SourceAction::InitialLoad,
+        );
+        let mut view = CommandHistoryView::new(CommandHistorySnapshot::new(Vec::new()));
+
+        let transition =
+            apply_command_history_action(&mut view, &history, jk_tui::log_view::LogAction::Refresh);
+
+        assert!(matches!(transition, AppTransition::Continue));
+        assert_eq!(
+            view.selected_row().map(|row| row.command.as_str()),
+            Some("jj log")
+        );
+        assert_eq!(history.records().count(), 1);
+    }
+
+    #[test]
+    fn unsupported_command_history_actions_do_not_pop_view() {
+        let history = CommandHistory::new(4);
+        let mut view = CommandHistoryView::new(CommandHistorySnapshot::new(Vec::new()));
+
+        let transition = apply_command_history_action(
+            &mut view,
+            &history,
+            jk_tui::log_view::LogAction::OpenDiff,
+        );
+
+        assert!(matches!(transition, AppTransition::Continue));
+    }
+
+    #[test]
+    fn command_history_enter_pushes_details_view() {
+        let mut history = CommandHistory::new(4);
+        append_history_record_with_operation_id(
+            &mut history,
+            jk_core::JjCommandSpec::render_read_only(["status"]),
+            SourceView::Log,
+            SourceAction::OpenStatus,
+            Some("op-status"),
+        );
+        let mut state = AppState::with_history(
+            AppView::CommandHistory {
+                view: CommandHistoryView::new(command_history_snapshot(&history)),
+            },
+            history,
+        );
+
+        push_selected_command_history_details(&mut state);
+
+        assert_eq!(state.views.len(), 2);
+        assert!(matches!(
+            state.views.active(),
+            AppView::CommandHistoryDetails { .. }
+        ));
+    }
+
+    #[test]
+    fn static_command_details_refresh_shows_local_status() {
+        let snapshot = jk_core::InspectionSnapshot::new("command 1", "Command: jj status\n")
+            .with_title("Command 1");
+        let mut view = RenderedView::new(snapshot);
+
+        let transition =
+            apply_static_rendered_action(&mut view, jk_tui::log_view::LogAction::Refresh);
+
+        assert!(matches!(transition, AppTransition::Continue));
+        let backend = TestBackend::new(92, 4);
+        let mut terminal = match Terminal::new(backend) {
+            Ok(terminal) => terminal,
+            Err(error) => match error {},
+        };
+        let draw_result = terminal.draw(|frame| view.render(frame));
+        assert!(draw_result.is_ok());
+        assert!(buffer_line(terminal.backend().buffer(), 3).contains("retained in memory"));
+    }
+
+    #[test]
+    fn view_options_are_ignored_from_command_history() {
+        let mut state = AppState::new(AppView::CommandHistory {
+            view: CommandHistoryView::new(CommandHistorySnapshot::new(Vec::new())),
+        });
+
+        open_view_options(&mut state);
+
+        assert_eq!(state.modes.active(), None);
+    }
+
+    #[test]
+    fn command_history_operation_with_id_opens_operation_show() {
+        let mut history = CommandHistory::new(4);
+        append_history_record_with_operation_id(
+            &mut history,
+            jk_core::JjCommandSpec::render_read_only(["describe", "-m", "message", "@"]),
+            SourceView::Log,
+            SourceAction::DescribeRevision,
+            Some("abc123op"),
+        );
+        let mut state = AppState::with_history(
+            AppView::CommandHistory {
+                view: CommandHistoryView::new(command_history_snapshot(&history)),
+            },
+            history,
+        );
+        let source = JjOperation::default();
+
+        open_command_history_operation_with_runner(
+            &mut state,
+            &source,
+            SequencedRunner::successes(vec![output(0, "operation details\n", "")]),
+        );
+
+        assert!(matches!(
+            state.views.active(),
+            AppView::OperationShow {
+                query: OperationQuery::Show { operation },
+                ..
+            } if operation == "abc123op"
+        ));
+        let newest = state.command_history().records().last().expect("record");
+        assert_eq!(newest.source.view, SourceView::CommandHistory);
+        assert_eq!(newest.source.action, SourceAction::OperationShow);
+        assert_eq!(newest.command.title, "jj op show abc123op");
+    }
+
+    #[test]
+    fn command_history_operation_without_id_opens_operation_log() {
+        let mut history = CommandHistory::new(4);
+        append_history_record(
+            &mut history,
+            jk_core::JjCommandSpec::render_read_only(["log"]),
+            SourceView::Log,
+            SourceAction::InitialLoad,
+        );
+        let mut state = AppState::with_history(
+            AppView::CommandHistory {
+                view: CommandHistoryView::new(command_history_snapshot(&history)),
+            },
+            history,
+        );
+        let source = JjOperation::default();
+
+        open_command_history_operation_with_runner(
+            &mut state,
+            &source,
+            SequencedRunner::successes(vec![output(
+                0,
+                "@ abc123def456 user@example.test now\n│  current operation\n",
+                "",
+            )]),
+        );
+
+        assert!(matches!(state.views.active(), AppView::OperationLog { .. }));
+        let newest = state.command_history().records().last().expect("record");
+        assert_eq!(newest.source.view, SourceView::CommandHistory);
+        assert_eq!(newest.source.action, SourceAction::OperationLog);
+        assert_eq!(newest.command.title, "jj op log");
+    }
+
+    #[test]
+    fn opening_workspaces_from_log_records_log_workspace_list() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        let source = JjWorkspaces::default();
+        let runner = SequencedRunner::successes(vec![
+            output(0, "dogfood\t/repo/dogfood\tabc123\tdef456\n", ""),
+            output(0, "/repo/dogfood\n", ""),
+        ]);
+
+        open_workspaces_with_runner(&mut state, &source, runner);
+
+        assert_eq!(state.views.len(), 2);
+        assert!(matches!(state.views.active(), AppView::Workspaces { .. }));
+        assert_eq!(state.command_history().records().count(), 2);
+
+        let records = state.command_history().records().collect::<Vec<_>>();
+        assert!(
+            records[0]
+                .command
+                .spec_preview
+                .starts_with("jj workspace list")
+        );
+        assert!(records[1].command.spec_preview.starts_with("jj root"));
+        assert!(
+            records
+                .iter()
+                .all(|record| record.source.view == SourceView::Log)
+        );
+        assert!(
+            records
+                .iter()
+                .all(|record| record.source.action == SourceAction::WorkspaceList)
+        );
+    }
+
+    #[test]
+    fn refreshing_workspaces_keeps_workspace_source_and_refresh_action() {
+        let mut state = AppState::new(AppView::Workspaces {
+            view: WorkspacesView::new(WorkspaceViewSnapshot::new(Vec::new())),
+        });
+        let source = JjWorkspaces::default();
+        let runner = SequencedRunner::successes(vec![
+            output(0, "dogfood\t/repo/dogfood\tabc123\tdef456\n", ""),
+            output(0, "/repo/dogfood\n", ""),
+        ]);
+
+        open_workspaces_with_runner(&mut state, &source, runner);
+
+        assert_eq!(state.views.len(), 1);
+        assert!(matches!(state.views.active(), AppView::Workspaces { .. }));
+        assert_eq!(state.command_history().records().count(), 2);
+
+        let records = state.command_history().records().collect::<Vec<_>>();
+        assert!(
+            records[0]
+                .command
+                .spec_preview
+                .starts_with("jj workspace list")
+        );
+        assert!(records[1].command.spec_preview.starts_with("jj root"));
+        assert!(
+            records
+                .iter()
+                .all(|record| record.source.view == SourceView::Workspaces)
+        );
+        assert!(
+            records
+                .iter()
+                .all(|record| record.source.action == SourceAction::Refresh)
+        );
+    }
+
+    #[test]
+    fn opening_status_from_log_records_log_open_status() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        let source = JjStatus::default();
+        let runner = SequencedRunner::successes(vec![output(0, "status output\n", "")]);
+
+        push_status_with_runner(&mut state, &source, runner);
+
+        assert_eq!(state.views.len(), 2);
+        assert!(matches!(state.views.active(), AppView::Status { .. }));
+        assert_eq!(state.command_history().records().count(), 1);
+
+        let record = state.command_history().records().next().expect("record");
+        assert_eq!(record.command.spec_preview, "jj status");
+        assert_eq!(record.source.view, SourceView::Log);
+        assert_eq!(record.source.action, SourceAction::OpenStatus);
+    }
+
+    #[test]
+    fn view_stack_returns_to_previous_log_state() {
+        let mut log = LogView::default();
+        log.show_error("preserved log state");
+        let previous_log = log.clone();
+        let mut stack = ViewStack::new(AppView::Log(log));
+
+        stack.push(diff_app_view("bbb"));
+
+        assert!(stack.pop());
+        assert_eq!(stack.active(), &AppView::Log(previous_log));
+    }
+
+    #[test]
+    fn loaded_evolog_pushes_from_log() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        let query = EvologQuery::from("aaa".to_owned());
+        let view = RenderedView::from_error("aaa", "jj evolog -r aaa", "fixture".to_owned());
+
+        push_evolog_view(&mut state, query.clone(), view.clone());
+
+        assert_eq!(state.views.len(), 2);
+        assert_eq!(state.views.active(), &AppView::Evolog { view, query });
+    }
+
+    #[test]
+    fn loaded_evolog_is_ignored_outside_log() {
+        let root = diff_app_view("aaa");
+        let mut state = AppState::new(root.clone());
+        let query = EvologQuery::from("aaa".to_owned());
+        let view = RenderedView::from_error("aaa", "jj evolog -r aaa", "fixture".to_owned());
+
+        push_evolog_view(&mut state, query, view);
+
+        assert_eq!(state.views.len(), 1);
+        assert_eq!(state.views.active(), &root);
+    }
+
+    #[test]
+    fn back_from_evolog_returns_to_preserved_log() {
+        let mut log = LogView::default();
+        log.show_error("preserved log state");
+        let expected_log = log.clone();
+        let mut state = AppState::new(AppView::Log(log));
+        let query = EvologQuery::from("aaa".to_owned());
+        let view = RenderedView::from_error("aaa", "jj evolog -r aaa", "fixture".to_owned());
+        push_evolog_view(&mut state, query, view);
+
+        handle_back(&mut state);
+
+        assert_eq!(state.views.active(), &AppView::Log(expected_log));
+    }
+
+    #[test]
+    fn loaded_workspace_pushes_view() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        let view = workspace_app_view();
+
+        push_workspace_view(&mut state, view.clone());
+
+        assert_eq!(state.views.len(), 2);
+        assert_eq!(state.views.active(), &AppView::Workspaces { view });
+    }
+
+    #[test]
+    fn w_on_active_workspace_list_does_not_stack_another_list() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        push_workspace_view(&mut state, workspace_app_view());
+        let expected_depth = state.views.len();
+
+        open_workspaces(
+            &mut state,
+            &JjWorkspaces::default().with_repository("/definitely/not-a-jj-repo"),
+        );
+
+        assert_eq!(state.views.len(), expected_depth);
+        assert!(matches!(state.views.active(), AppView::Workspaces { .. }));
+    }
+
+    #[test]
+    fn workspace_missing_root_status_shows_error_without_pushing() {
+        let mut state = AppState::new(AppView::Workspaces {
+            view: WorkspacesView::new(WorkspaceViewSnapshot::new(vec![WorkspaceViewRow::new(
+                "detached",
+                "(no root)",
+                true,
+            )])),
+        });
+        let source = JjWorkspaces::default();
+        let mut expected =
+            WorkspacesView::new(WorkspaceViewSnapshot::new(vec![WorkspaceViewRow::new(
+                "detached",
+                "(no root)",
+                true,
+            )]));
+        expected.show_error("workspace `detached` has no root");
+
+        push_selected_workspace_status(&mut state, &source);
+
+        assert_eq!(state.views.len(), 1);
+        assert_eq!(
+            state.views.active(),
+            &AppView::Workspaces { view: expected }
+        );
+    }
+
+    #[test]
+    fn workspace_missing_root_log_shows_error_without_pushing() {
+        let mut state = AppState::new(AppView::Workspaces {
+            view: WorkspacesView::new(WorkspaceViewSnapshot::new(vec![WorkspaceViewRow::new(
+                "detached",
+                "(no root)",
+                true,
+            )])),
+        });
+        let source = JjWorkspaces::default();
+        let mut expected =
+            WorkspacesView::new(WorkspaceViewSnapshot::new(vec![WorkspaceViewRow::new(
+                "detached",
+                "(no root)",
+                true,
+            )]));
+        expected.show_error("workspace `detached` has no root");
+
+        push_selected_workspace_log(&mut state, &source);
+
+        assert_eq!(state.views.len(), 1);
+        assert_eq!(
+            state.views.active(),
+            &AppView::Workspaces { view: expected }
+        );
+    }
+
+    #[test]
+    fn selected_workspace_log_pushes_rendered_log_view() {
+        let mut state = AppState::new(AppView::Workspaces {
+            view: workspace_app_view(),
+        });
+        let source = JjWorkspaces::default();
+        let runner =
+            SequencedRunner::successes(vec![output(0, "@  abc123 selected workspace\n", "")]);
+
+        push_selected_workspace_log_with_runner(&mut state, &source, runner);
+
+        let AppView::WorkspaceLog { query, .. } = state.views.active() else {
+            panic!("expected workspace log view");
+        };
+        assert_eq!(
+            query.workspace_root(),
+            std::path::Path::new("/repo/dogfood")
+        );
+        assert_eq!(state.command_history().records().count(), 1);
+        let record = state.command_history().records().next().expect("record");
+        assert_eq!(record.source.view, SourceView::Workspaces);
+        assert_eq!(record.source.action, SourceAction::WorkspaceLog);
+        assert_eq!(record.command.spec_preview, "jj log");
+        assert_eq!(record.command.title, "jj -R /repo/dogfood log");
+        assert_eq!(
+            record.context.repository.as_deref(),
+            Some(std::path::Path::new("/repo/dogfood"))
+        );
+    }
+
+    #[test]
+    fn workspace_missing_root_diff_shows_error_without_pushing() {
+        let mut state = AppState::new(AppView::Workspaces {
+            view: WorkspacesView::new(WorkspaceViewSnapshot::new(vec![WorkspaceViewRow::new(
+                "detached",
+                "(no root)",
+                true,
+            )])),
+        });
+        let source = JjWorkspaces::default();
+        let mut expected =
+            WorkspacesView::new(WorkspaceViewSnapshot::new(vec![WorkspaceViewRow::new(
+                "detached",
+                "(no root)",
+                true,
+            )]));
+        expected.show_error("workspace `detached` has no root");
+
+        push_selected_workspace_diff(&mut state, &source);
+
+        assert_eq!(state.views.len(), 1);
+        assert_eq!(
+            state.views.active(),
+            &AppView::Workspaces { view: expected }
+        );
+    }
+
+    #[test]
+    fn workspace_missing_root_update_stale_shows_error_without_pushing() {
+        let mut state = AppState::new(AppView::Workspaces {
+            view: WorkspacesView::new(WorkspaceViewSnapshot::new(vec![WorkspaceViewRow::new(
+                "detached",
+                "(no root)",
+                true,
+            )])),
+        });
+        let source = JjWorkspaces::default();
+        let mut expected =
+            WorkspacesView::new(WorkspaceViewSnapshot::new(vec![WorkspaceViewRow::new(
+                "detached",
+                "(no root)",
+                true,
+            )]));
+        expected.show_error("workspace `detached` has no root");
+
+        update_selected_workspace_stale(&mut state, &source);
+
+        assert_eq!(state.views.len(), 1);
+        assert_eq!(
+            state.views.active(),
+            &AppView::Workspaces { view: expected }
+        );
+    }
+
+    #[test]
+    fn workspace_update_stale_without_selection_keeps_list_visible() {
+        let mut state = AppState::new(AppView::Workspaces {
+            view: WorkspacesView::new(WorkspaceViewSnapshot::new(Vec::new())),
+        });
+        let source = JjWorkspaces::default();
+        let mut expected = WorkspacesView::new(WorkspaceViewSnapshot::new(Vec::new()));
+        expected.show_status("No workspace selected");
+
+        update_selected_workspace_stale(&mut state, &source);
+
+        assert_eq!(state.views.len(), 1);
+        assert_eq!(
+            state.views.active(),
+            &AppView::Workspaces { view: expected }
+        );
+    }
+
+    #[test]
+    fn back_from_workspace_status_returns_to_workspaces() {
+        let workspace_view = workspace_app_view();
+        let expected = workspace_view.clone();
+        let mut state = AppState::new(AppView::Workspaces {
+            view: workspace_view,
+        });
+        state.views.push(AppView::WorkspaceStatus {
+            view: RenderedView::from_error("/repo/dogfood", "jj status", "fixture".to_owned()),
+            query: WorkspaceInspectionQuery::new("/repo/dogfood"),
+        });
+
+        handle_back(&mut state);
+
+        assert_eq!(
+            state.views.active(),
+            &AppView::Workspaces { view: expected }
+        );
+    }
+
+    #[test]
+    fn active_binding_context_reports_workspaces() {
+        let state = AppState::new(AppView::Workspaces {
+            view: workspace_app_view(),
+        });
+
+        assert_eq!(active_binding_context(&state), BindingContext::Workspaces);
+    }
+
+    #[test]
+    fn mode_stack_closes_search_before_popping_view() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        state.views.push(diff_app_view("aaa"));
+        state.modes.push(InputMode::DiffSearch {
+            query: "alpha".to_owned(),
+        });
+
+        handle_back(&mut state);
+
+        assert_eq!(state.modes.active(), None);
+        assert!(matches!(state.views.active(), AppView::Diff { .. }));
+        assert_eq!(state.views.len(), 2);
+    }
+
+    #[test]
+    fn mode_stack_submit_search_restores_normal_mode() {
+        let mut state = AppState::new(diff_app_view("aaa"));
+        state.modes.push(InputMode::DiffSearch {
+            query: "alpha".to_owned(),
+        });
+        let mut expected = diff_view("aaa");
+        let _ = expected.apply(DiffAction::Search("alpha".to_owned()));
+
+        let mut source = JjLog::default();
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(state.modes.active(), None);
+        assert_eq!(
+            state.views.active(),
+            &AppView::Diff {
+                view: expected,
+                query: diff_query("aaa")
+            }
+        );
+    }
+
+    #[test]
+    fn command_discovery_opens_for_active_context() {
+        let mut state = AppState::new(diff_app_view("aaa"));
+
+        open_command_discovery(&mut state);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::CommandDiscovery {
+                context: BindingContext::Diff,
+                query: String::new(),
+                selected: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn command_discovery_filters_and_clamps_selection() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        state.modes.push(InputMode::CommandDiscovery {
+            context: BindingContext::Log,
+            query: "jj sho".to_owned(),
+            selected: 12,
+        });
+        let mut source = JjLog::default();
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::CommandDiscovery {
+                context: BindingContext::Log,
+                query: "jj show".to_owned(),
+                selected: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn command_discovery_navigation_wraps_between_edges() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        state.modes.push(InputMode::CommandDiscovery {
+            context: BindingContext::Log,
+            query: String::new(),
+            selected: 0,
+        });
+        let row_count = filtered_discovery_len(BindingContext::Log, "");
+
+        move_command_discovery_selection(&mut state, MenuDirection::Previous);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::CommandDiscovery {
+                context: BindingContext::Log,
+                query: String::new(),
+                selected: row_count - 1,
+            })
+        );
+
+        move_command_discovery_selection(&mut state, MenuDirection::Next);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::CommandDiscovery {
+                context: BindingContext::Log,
+                query: String::new(),
+                selected: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn command_discovery_enter_closes_without_executing() {
+        let mut state = AppState::new(diff_app_view("aaa"));
+        let expected_view = state.views.active().clone();
+        state.modes.push(InputMode::CommandDiscovery {
+            context: BindingContext::Diff,
+            query: "refresh".to_owned(),
+            selected: 0,
+        });
+        let mut source = JjLog::default();
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(state.modes.active(), None);
+        assert_eq!(state.views.active(), &expected_view);
+    }
+
+    #[test]
+    fn command_discovery_backspace_closes_when_query_empty() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        state.modes.push(InputMode::CommandDiscovery {
+            context: BindingContext::Log,
+            query: String::new(),
+            selected: 0,
+        });
+        let mut source = JjLog::default();
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(state.modes.active(), None);
+    }
+
+    #[test]
+    fn describe_message_opens_for_selected_revision() {
+        let mut state = AppState::new(log_app_view("abc123"));
+
+        open_describe_message(&mut state);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::DescribeMessage {
+                rev: "abc123".to_owned(),
+                message: "abc123 summary".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn describe_message_prefills_full_selected_description() {
+        let mut state = AppState::new(log_app_view_with_description(
+            "abc123",
+            "Current summary\n\nCurrent body",
+        ));
+
+        open_describe_message(&mut state);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::DescribeMessage {
+                rev: "abc123".to_owned(),
+                message: "Current summary\n\nCurrent body".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn describe_message_control_u_clears_prefilled_message() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        open_describe_message(&mut state);
+        let mut source = JjLog::default();
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::DescribeMessage {
+                rev: "abc123".to_owned(),
+                message: String::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn describe_message_enter_opens_command_preview() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        state.modes.push(InputMode::DescribeMessage {
+            rev: "abc123".to_owned(),
+            message: "New description".to_owned(),
+        });
+        let mut source = JjLog::default();
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        let Some(InputMode::CommandPreview { pending }) = state.modes.active() else {
+            panic!("expected command preview mode");
+        };
+        let preview = &pending.preview;
+        assert_eq!(pending.source_action, SourceAction::DescribeRevision);
+        assert_eq!(pending.source_key, "m");
+        assert_eq!(preview.spec.argv()[0].to_string_lossy(), "describe");
+        assert_eq!(
+            preview.command_line,
+            "jj --no-pager --color always describe -m 'New description' abc123"
+        );
+        assert_eq!(preview.safety, jk_core::SafetyClass::LocalRewrite);
+    }
+
+    #[test]
+    fn describe_message_enter_ignores_empty_message() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        state.modes.push(InputMode::DescribeMessage {
+            rev: "abc123".to_owned(),
+            message: "   ".to_owned(),
+        });
+        let mut source = JjLog::default();
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::DescribeMessage {
+                rev: "abc123".to_owned(),
+                message: "   ".to_owned(),
+            })
+        );
+        assert_eq!(state.command_history().records().count(), 0);
+    }
+
+    #[test]
+    fn abandon_preview_uses_selected_revision() {
+        let mut state = AppState::new(log_app_view("abc123"));
+
+        open_abandon_preview(&mut state, &JjAbandon::default());
+
+        let Some(InputMode::CommandPreview { pending }) = state.modes.active() else {
+            panic!("expected abandon command preview");
+        };
+        assert_eq!(pending.source_action, SourceAction::AbandonRevision);
+        assert_eq!(pending.source_key, "a");
+        assert_eq!(pending.failure_label, "jj abandon");
+        assert_eq!(
+            pending.preview.command_line,
+            "jj --no-pager --color always abandon abc123"
+        );
+        assert_eq!(
+            pending.preview.safety,
+            jk_core::SafetyClass::DestructiveLocal
+        );
+        assert_eq!(
+            pending.preview.warnings,
+            vec![jk_core::CommandPreviewWarning::DestructiveLocal]
+        );
+    }
+
+    #[test]
+    fn new_preview_uses_selected_revision_as_parent() {
+        let mut state = AppState::new(log_app_view("abc123"));
+
+        open_new_preview(&mut state, &JjNew::default());
+
+        let Some(InputMode::CommandPreview { pending }) = state.modes.active() else {
+            panic!("expected new command preview");
+        };
+        assert_eq!(pending.source_action, SourceAction::NewRevision);
+        assert_eq!(pending.source_key, "n");
+        assert_eq!(pending.failure_label, "jj new");
+        assert_eq!(
+            pending.preview.command_line,
+            "jj --no-pager --color always new abc123"
+        );
+        assert_eq!(pending.preview.safety, jk_core::SafetyClass::LocalRewrite);
+        assert_eq!(
+            pending.preview.warnings,
+            vec![jk_core::CommandPreviewWarning::LocalRewrite]
+        );
+    }
+
+    #[test]
+    fn new_preview_uses_ordered_marks_as_parents() {
+        let mut state = AppState::new(log_app_view_with_changes(["aaa", "bbb", "ccc"]));
+        let AppView::Log(log) = state.views.active_mut() else {
+            panic!("expected log");
+        };
+        let _ = log.apply(LogAction::ToggleMark);
+        let _ = log.apply(LogAction::Next);
+        let _ = log.apply(LogAction::Next);
+        let _ = log.apply(LogAction::ToggleMark);
+
+        open_new_preview(&mut state, &JjNew::default());
+
+        let Some(InputMode::CommandPreview { pending }) = state.modes.active() else {
+            panic!("expected new command preview");
+        };
+        assert_eq!(
+            pending.preview.command_line,
+            "jj --no-pager --color always new aaa ccc"
+        );
+    }
+
+    #[test]
+    fn edit_preview_uses_selected_revision() {
+        let mut state = AppState::new(log_app_view("abc123"));
+
+        open_edit_preview(&mut state, &JjEdit::default());
+
+        let Some(InputMode::CommandPreview { pending }) = state.modes.active() else {
+            panic!("expected edit command preview");
+        };
+        assert_eq!(pending.source_action, SourceAction::EditRevision);
+        assert_eq!(pending.source_key, "e");
+        assert_eq!(pending.failure_label, "jj edit");
+        assert_eq!(
+            pending.preview.command_line,
+            "jj --no-pager --color always edit abc123"
+        );
+        assert_eq!(pending.preview.safety, jk_core::SafetyClass::LocalRewrite);
+        assert_eq!(
+            pending.preview.warnings,
+            vec![jk_core::CommandPreviewWarning::LocalRewrite]
+        );
+    }
+
+    #[test]
+    fn confirming_describe_preview_records_mutation_before_refresh() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        let mut source = JjLog::default();
+        let preview = JjDescribe::default()
+            .spec_for(&DescribeQuery::new("abc123", "New description"))
+            .command_preview();
+        let runner = SequencedRunner::successes(vec![
+            output(0, "111111111111\n", ""),
+            output(0, "Working copy now at: abc123\n", ""),
+            output(0, "222222222222\n", ""),
+            output(0, "refreshed rendered log\n", ""),
+            output(0, "{}\n", ""),
+        ]);
+
+        confirm_command_preview_with_runner(
+            &mut state,
+            &mut source,
+            PendingCommandPreview::describe(preview),
+            runner,
+        );
+
+        let records = state.command_history().records().collect::<Vec<_>>();
+        assert_eq!(records.len(), 3);
+        assert_eq!(
+            records[0].command.spec_preview,
+            "jj describe -m 'New description' abc123"
+        );
+        assert_eq!(records[0].command.title, "jj describe abc123");
+        assert_eq!(records[0].source.view, SourceView::Log);
+        assert_eq!(records[0].source.action, SourceAction::DescribeRevision);
+        assert_eq!(records[0].source.key.as_deref(), Some("m"));
+        assert_eq!(records[0].safety, jk_core::SafetyClass::LocalRewrite);
+        assert_eq!(
+            records[0].execution_mode,
+            jk_core::ExecutionMode::ConfirmMutation
+        );
+        assert_eq!(records[0].operation_id.as_deref(), Some("222222222222"));
+        assert_eq!(records[0].refresh, jk_core::RefreshPlan::None);
+        assert_eq!(records[1].source.action, SourceAction::Refresh);
+        assert_eq!(records[2].source.action, SourceAction::Refresh);
+    }
+
+    #[test]
+    fn confirming_abandon_preview_records_destructive_mutation() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        let mut source = JjLog::default();
+        let preview = JjAbandon::default()
+            .spec_for(&AbandonQuery::new("abc123"))
+            .command_preview();
+        let runner = SequencedRunner::successes(vec![
+            output(0, "111111111111\n", ""),
+            output(0, "Abandoned 1 commits.\n", ""),
+            output(0, "222222222222\n", ""),
+            output(0, "refreshed rendered log\n", ""),
+            output(0, "{}\n", ""),
+        ]);
+
+        confirm_command_preview_with_runner(
+            &mut state,
+            &mut source,
+            PendingCommandPreview::abandon(preview),
+            runner,
+        );
+
+        let records = state.command_history().records().collect::<Vec<_>>();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].command.spec_preview, "jj abandon abc123");
+        assert_eq!(records[0].command.title, "jj abandon abc123");
+        assert_eq!(records[0].source.view, SourceView::Log);
+        assert_eq!(records[0].source.action, SourceAction::AbandonRevision);
+        assert_eq!(records[0].source.key.as_deref(), Some("a"));
+        assert_eq!(records[0].safety, jk_core::SafetyClass::DestructiveLocal);
+        assert_eq!(records[0].operation_id.as_deref(), Some("222222222222"));
+        assert_eq!(records[1].source.action, SourceAction::Refresh);
+        assert_eq!(records[2].source.action, SourceAction::Refresh);
+    }
+
+    #[test]
+    fn confirming_new_preview_records_local_rewrite_mutation() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        let mut source = JjLog::default();
+        let preview = JjNew::default()
+            .spec_for(&NewQuery::new(["abc123"]))
+            .command_preview();
+        let runner = SequencedRunner::successes(vec![
+            output(0, "111111111111\n", ""),
+            output(0, "Working copy now at: def456\n", ""),
+            output(0, "222222222222\n", ""),
+            output(0, "refreshed rendered log\n", ""),
+            output(0, "{}\n", ""),
+        ]);
+
+        confirm_command_preview_with_runner(
+            &mut state,
+            &mut source,
+            PendingCommandPreview::new_change(preview),
+            runner,
+        );
+
+        let records = state.command_history().records().collect::<Vec<_>>();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].command.spec_preview, "jj new abc123");
+        assert_eq!(records[0].command.title, "jj new abc123");
+        assert_eq!(records[0].source.view, SourceView::Log);
+        assert_eq!(records[0].source.action, SourceAction::NewRevision);
+        assert_eq!(records[0].source.key.as_deref(), Some("n"));
+        assert_eq!(records[0].safety, jk_core::SafetyClass::LocalRewrite);
+        assert_eq!(records[0].operation_id.as_deref(), Some("222222222222"));
+        assert_eq!(records[1].source.action, SourceAction::Refresh);
+        assert_eq!(records[2].source.action, SourceAction::Refresh);
+    }
+
+    #[test]
+    fn confirming_edit_preview_records_local_rewrite_mutation() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        let mut source = JjLog::default();
+        let preview = JjEdit::default()
+            .spec_for(&EditQuery::new("abc123"))
+            .command_preview();
+        let runner = SequencedRunner::successes(vec![
+            output(0, "111111111111\n", ""),
+            output(0, "Working copy now at: abc123\n", ""),
+            output(0, "222222222222\n", ""),
+            output(0, "refreshed rendered log\n", ""),
+            output(0, "{}\n", ""),
+        ]);
+
+        confirm_command_preview_with_runner(
+            &mut state,
+            &mut source,
+            PendingCommandPreview::edit(preview),
+            runner,
+        );
+
+        let records = state.command_history().records().collect::<Vec<_>>();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].command.spec_preview, "jj edit abc123");
+        assert_eq!(records[0].command.title, "jj edit abc123");
+        assert_eq!(records[0].source.view, SourceView::Log);
+        assert_eq!(records[0].source.action, SourceAction::EditRevision);
+        assert_eq!(records[0].source.key.as_deref(), Some("e"));
+        assert_eq!(records[0].safety, jk_core::SafetyClass::LocalRewrite);
+        assert_eq!(records[0].operation_id.as_deref(), Some("222222222222"));
+        assert_eq!(records[1].source.action, SourceAction::Refresh);
+        assert_eq!(records[2].source.action, SourceAction::Refresh);
+    }
+
+    #[test]
+    fn command_history_after_confirmed_mutation_opens_resulting_operation() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        let mut source = JjLog::default();
+        let preview = JjDescribe::default()
+            .spec_for(&DescribeQuery::new("abc123", "New description"))
+            .command_preview();
+        let runner = SequencedRunner::successes(vec![
+            output(0, "111111111111\n", ""),
+            output(0, "Working copy now at: abc123\n", ""),
+            output(0, "222222222222\n", ""),
+            output(0, "refreshed rendered log\n", ""),
+            output(0, "{}\n", ""),
+        ]);
+
+        confirm_command_preview_with_runner(
+            &mut state,
+            &mut source,
+            PendingCommandPreview::describe(preview),
+            runner,
+        );
+        open_command_history(&mut state);
+        open_command_history_operation_with_runner(
+            &mut state,
+            &JjOperation::default(),
+            SequencedRunner::successes(vec![output(0, "operation details\n", "")]),
+        );
+
+        assert!(matches!(
+            state.views.active(),
+            AppView::OperationShow {
+                query: OperationQuery::Show { operation },
+                ..
+            } if operation == "222222222222"
+        ));
+    }
+
+    #[test]
+    fn undo_preview_uses_recovery_command_spec() {
+        let mut state = AppState::new(log_app_view("abc123"));
+
+        open_recovery_preview(&mut state, &JjRecovery::default(), RecoveryCommand::Undo);
+
+        let Some(InputMode::CommandPreview { pending }) = state.modes.active() else {
+            panic!("expected undo command preview");
+        };
+        assert_eq!(pending.source_action, SourceAction::Undo);
+        assert_eq!(pending.source_key, "u");
+        assert_eq!(
+            pending.preview.command_line,
+            "jj --no-pager --color always undo"
+        );
+        assert_eq!(pending.preview.safety, jk_core::SafetyClass::LocalRewrite);
+    }
+
+    #[test]
+    fn redo_preview_uses_recovery_command_spec() {
+        let mut state = AppState::new(log_app_view("abc123"));
+
+        open_recovery_preview(&mut state, &JjRecovery::default(), RecoveryCommand::Redo);
+
+        let Some(InputMode::CommandPreview { pending }) = state.modes.active() else {
+            panic!("expected redo command preview");
+        };
+        assert_eq!(pending.source_action, SourceAction::Redo);
+        assert_eq!(pending.source_key, "U");
+        assert_eq!(
+            pending.preview.command_line,
+            "jj --no-pager --color always redo"
+        );
+    }
+
+    #[test]
+    fn command_mode_empty_enter_keeps_prompt_with_error() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        open_jj_command_mode(&mut state);
+
+        submit_jj_command_mode(&mut state, None);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::JjCommand {
+                input: String::new(),
+                error: Some("type a jj command after :".to_owned()),
+            })
+        );
+        assert_eq!(state.views.len(), 1);
+    }
+
+    #[test]
+    fn command_mode_runs_command_and_records_user_source() {
+        let mut state = AppState::new(log_app_view("abc123"));
+
+        run_jj_command_mode_with_runner(
+            &mut state,
+            Some(Path::new("/repo/dogfood")),
+            "status",
+            SequencedRunner::successes(vec![output(0, "clean\n", "")]),
+        )
+        .expect("command mode runs");
+
+        assert!(matches!(
+            state.views.active(),
+            AppView::CommandOutput { .. }
+        ));
+        let record = state.command_history().records().next().expect("record");
+        assert_eq!(
+            record.command.command_family,
+            jk_core::CommandFamily::UserJjCommand
+        );
+        assert_eq!(record.command.spec_preview, "jj status");
+        assert_eq!(
+            record.command.process_preview(),
+            "jj --no-pager --color always --repository /repo/dogfood status"
+        );
+        assert_eq!(
+            record.source.view,
+            SourceView::Other("command mode".to_owned())
+        );
+        assert_eq!(record.source.action, SourceAction::UserJjCommand);
+        assert_eq!(record.source.key.as_deref(), Some(":"));
+        assert_eq!(record.execution_mode, jk_core::ExecutionMode::CommandMode);
+    }
+
+    #[test]
+    fn command_output_edit_reopens_prompt_with_previous_input() {
+        let mut state = AppState::new(log_app_view("abc123"));
+
+        run_jj_command_mode_with_runner(
+            &mut state,
+            None,
+            "jj log -r @",
+            SequencedRunner::successes(vec![output(0, "rendered log\n", "")]),
+        )
+        .expect("command mode runs");
+        edit_command_output(&mut state);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::JjCommand {
+                input: "jj log -r @".to_owned(),
+                error: None,
+            })
+        );
+    }
+
+    #[test]
+    fn command_mode_accepts_optional_jj_prefix() {
+        let mut state = AppState::new(log_app_view("abc123"));
+
+        run_jj_command_mode_with_runner(
+            &mut state,
+            None,
+            "jj status",
+            SequencedRunner::successes(vec![output(0, "clean\n", "")]),
+        )
+        .expect("command mode runs");
+
+        let record = state.command_history().records().next().expect("record");
+        assert_eq!(record.command.spec_preview, "jj status");
+    }
+
+    #[test]
+    fn confirming_undo_preview_records_recovery_action_before_refresh() {
+        let mut state = AppState::new(log_app_view("abc123"));
+        let mut source = JjLog::default();
+        let preview = JjRecovery::default()
+            .spec_for(RecoveryCommand::Undo)
+            .command_preview();
+        let runner = SequencedRunner::successes(vec![
+            output(0, "111111111111\n", ""),
+            output(0, "undid\n", ""),
+            output(0, "222222222222\n", ""),
+            output(0, "refreshed rendered log\n", ""),
+            output(0, "{}\n", ""),
+        ]);
+
+        confirm_command_preview_with_runner(
+            &mut state,
+            &mut source,
+            PendingCommandPreview::undo(preview),
+            runner,
+        );
+
+        let records = state.command_history().records().collect::<Vec<_>>();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].command.spec_preview, "jj undo");
+        assert_eq!(records[0].source.action, SourceAction::Undo);
+        assert_eq!(records[0].source.key.as_deref(), Some("u"));
+        assert_eq!(records[0].operation_id.as_deref(), Some("222222222222"));
+        assert_eq!(records[1].source.action, SourceAction::Refresh);
+    }
+
+    #[test]
+    fn view_options_opens_for_active_context() {
+        let mut state = AppState::new(diff_app_view("aaa"));
+
+        open_view_options(&mut state);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::ViewOptions {
+                context: BindingContext::Diff,
+                selected: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn view_options_opens_on_active_diff_format() {
+        let mut state = AppState::new(AppView::Diff {
+            view: diff_view("aaa"),
+            query: DiffQuery::Revision {
+                rev: "aaa".to_owned(),
+                format: DiffFormat::Summary,
+            },
+        });
+
+        open_view_options(&mut state);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::ViewOptions {
+                context: BindingContext::Diff,
+                selected: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn view_options_navigation_wraps_between_edges() {
+        let mut state = AppState::new(diff_app_view("aaa"));
+        state.modes.push(InputMode::ViewOptions {
+            context: BindingContext::Diff,
+            selected: 0,
+        });
+
+        move_view_options_selection(&mut state, MenuDirection::Previous);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::ViewOptions {
+                context: BindingContext::Diff,
+                selected: view_option_rows(BindingContext::Diff).len() - 1,
+            })
+        );
+
+        move_view_options_selection(&mut state, MenuDirection::Next);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::ViewOptions {
+                context: BindingContext::Diff,
+                selected: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn diff_file_list_opens_with_current_file_selected() {
+        let mut view = real_diff_view("aaa");
+        view.select_file_index(1);
+        let mut state = AppState::new(AppView::Diff {
+            view,
+            query: diff_query("aaa"),
+        });
+
+        open_diff_file_list(&mut state);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::DiffFileList { selected: 1 })
+        );
+    }
+
+    #[test]
+    fn diff_file_list_navigation_wraps_between_edges() {
+        let mut state = AppState::new(AppView::Diff {
+            view: real_diff_view("aaa"),
+            query: diff_query("aaa"),
+        });
+        state.modes.push(InputMode::DiffFileList { selected: 0 });
+
+        move_diff_file_list_selection(&mut state, MenuDirection::Previous);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::DiffFileList { selected: 1 })
+        );
+
+        move_diff_file_list_selection(&mut state, MenuDirection::Next);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::DiffFileList { selected: 0 })
+        );
+    }
+
+    #[test]
+    fn diff_file_list_enter_jumps_to_selected_file() {
+        let mut state = AppState::new(AppView::Diff {
+            view: real_diff_view("aaa"),
+            query: diff_query("aaa"),
+        });
+        state.modes.push(InputMode::DiffFileList { selected: 0 });
+        let mut source = JjLog::default();
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+        );
+        assert_eq!(result, InputModeResult::Handled);
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(state.modes.active(), None);
+        let AppView::Diff { view, .. } = state.views.active() else {
+            panic!("expected diff view");
+        };
+        assert_eq!(view.selected_file_index(), Some(1));
+    }
+
+    #[test]
+    fn diff_file_list_lines_mark_selected_path() {
+        let view = real_diff_view("aaa");
+
+        assert_eq!(
+            diff_file_list_lines(&view, 1),
+            vec![
+                "   1/2 src/a.rs",
+                ">  2/2 src/b.rs",
+                "",
+                "j/k or arrows move   enter jump   esc close",
+            ]
+        );
+    }
+
+    #[test]
+    fn view_options_enter_opens_log_template_selector() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        state.modes.push(InputMode::ViewOptions {
+            context: BindingContext::Log,
+            selected: 0,
+        });
+        let mut source = JjLog::default().with_template(LogTemplateSelection::Detailed);
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        let options = source.template_options();
+        let selected = options
+            .iter()
+            .position(|template| template == source.template())
+            .unwrap_or_default();
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::LogTemplate { options, selected })
+        );
+    }
+
+    #[test]
+    fn template_selection_navigation_wraps_between_edges() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        let options = JjLog::default().template_options();
+        state.modes.push(InputMode::LogTemplate {
+            options: options.clone(),
+            selected: 0,
+        });
+
+        move_template_selection(&mut state, MenuDirection::Previous);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::LogTemplate {
+                options: options.clone(),
+                selected: options.len() - 1,
+            })
+        );
+
+        move_template_selection(&mut state, MenuDirection::Next);
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::LogTemplate {
+                options,
+                selected: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn view_options_placeholder_enter_closes_inspection_overlay() {
+        let snapshot =
+            jk_core::InspectionSnapshot::new("show", "rendered show\n").with_title("jj show aaa");
+        let mut state = AppState::new(AppView::Show {
+            view: RenderedView::new(snapshot),
+            query: ShowQuery::new(vec!["aaa".to_owned()]),
+        });
+        state.modes.push(InputMode::ViewOptions {
+            context: BindingContext::Inspection,
+            selected: 0,
+        });
+        let mut source = JjLog::default();
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(state.modes.active(), None);
+    }
+
+    #[test]
+    fn diff_view_options_apply_selected_format() {
+        let mut state = AppState::new(diff_app_view("aaa"));
+
+        apply_diff_format_option_with_runner(
+            &mut state,
+            &JjDiff::default(),
+            DiffFormat::Summary,
+            SequencedRunner::successes(vec![
+                output(0, "M src/a.rs\n", ""),
+                output(0, "src/a.rs | 1 +\n", ""),
+            ]),
+        );
+
+        assert!(matches!(
+            state.views.active(),
+            AppView::Diff {
+                query: DiffQuery::Revision { rev, format },
+                ..
+            } if rev == "aaa" && *format == DiffFormat::Summary
+        ));
+        let newest = state.command_history().records().last().expect("record");
+        assert_eq!(newest.command.title, "jj diff -r aaa --stat");
+        assert_eq!(newest.source.view, SourceView::Diff);
+        assert_eq!(newest.source.action, SourceAction::Refresh);
+    }
+
+    #[test]
+    fn view_options_close_without_changing_source() {
+        let mut state = AppState::new(AppView::Log(LogView::default()));
+        state.modes.push(InputMode::ViewOptions {
+            context: BindingContext::Log,
+            selected: 0,
+        });
+        let mut source = JjLog::default().with_template(LogTemplateSelection::Compact);
+        let expected = source.template().clone();
+
+        let result = handle_input_mode(
+            &mut state,
+            &mut source,
+            &JjDiff::default(),
+            &JjDescribe::default(),
+            None,
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+        );
+
+        assert_eq!(result, InputModeResult::Handled);
+        assert_eq!(state.modes.active(), None);
+        assert_eq!(source.template(), &expected);
+    }
+
+    #[test]
+    fn view_options_lines_show_template_or_placeholder() {
+        assert_eq!(
+            view_options_lines(
+                BindingContext::Log,
+                0,
+                &LogTemplateSelection::CompactFullDescription,
+                None,
+            ),
+            vec![
+                "> Template           full description",
+                "",
+                "j/k or arrows move   enter open   esc close",
+            ]
+        );
+        assert_eq!(
+            view_options_lines(
+                BindingContext::Diff,
+                2,
+                &LogTemplateSelection::Configured,
+                Some(DiffFormat::Stat),
+            ),
+            vec![
+                "    patch         ",
+                "    summary       ",
+                "> * stat          ",
+                "    types         ",
+                "    name only     ",
+                "    git           ",
+                "    color words   ",
+                "",
+                "j/k or arrows move   enter apply   esc close",
+            ]
+        );
+    }
+
+    #[test]
+    fn template_selection_failure_preserves_previous_log_and_source() {
+        let previous_log = LogView::default();
+        let mut state = AppState::new(AppView::Log(previous_log.clone()));
+        let source = JjLog::default().with_template(LogTemplateSelection::Detailed);
+        let expected_template = source.template().clone();
+
+        show_log_template_load_error(&mut state, "template reload failed".to_owned());
+
+        let mut expected_log = previous_log;
+        expected_log.show_error("template reload failed");
+        assert_eq!(source.template(), &expected_template);
+        assert_eq!(state.views.active(), &AppView::Log(expected_log));
+    }
+
+    #[test]
+    fn mark_action_pages_diff_view() {
+        let query = diff_query("aaa");
+        let source = JjDiff::default();
+        let mut mark_view = diff_view("aaa");
+        let mut page_view = diff_view("aaa");
+        let mut mark_history = CommandHistory::default();
+        let mut page_history = CommandHistory::default();
+
+        let mark_transition = apply_diff_action(
+            &mut mark_view,
+            &query,
+            &mut mark_history,
+            &source,
+            LogAction::ToggleMark,
+        );
+        let page_transition = apply_diff_action(
+            &mut page_view,
+            &query,
+            &mut page_history,
+            &source,
+            LogAction::PageNext,
+        );
+
+        assert!(matches!(mark_transition, AppTransition::Continue));
+        assert!(matches!(page_transition, AppTransition::Continue));
+        assert_eq!(mark_view, page_view);
+    }
+
+    #[test]
+    fn mark_action_pages_inspection_views() {
+        let show_query = ShowQuery::from("aaa".to_owned());
+        let show_source = JjShow::default();
+        let mut mark_show = RenderedView::from_error("aaa", "jj show aaa", "fixture".to_owned());
+        let mut page_show = mark_show.clone();
+        let mut mark_history = CommandHistory::default();
+        let mut page_history = CommandHistory::default();
+
+        let mark_transition = apply_show_action(
+            &mut mark_show,
+            &show_query,
+            &mut mark_history,
+            &show_source,
+            LogAction::ToggleMark,
+        );
+        let page_transition = apply_show_action(
+            &mut page_show,
+            &show_query,
+            &mut page_history,
+            &show_source,
+            LogAction::PageNext,
+        );
+
+        assert!(matches!(mark_transition, AppTransition::Continue));
+        assert!(matches!(page_transition, AppTransition::Continue));
+        assert_eq!(mark_show, page_show);
+
+        let evolog_query = EvologQuery::from("aaa".to_owned());
+        let evolog_source = JjEvolog::default();
+        let mut mark_evolog =
+            RenderedView::from_error("aaa", "jj evolog -r aaa", "fixture".to_owned());
+        let mut page_evolog = mark_evolog.clone();
+        let mut mark_history = CommandHistory::default();
+        let mut page_history = CommandHistory::default();
+
+        let mark_transition = apply_evolog_action(
+            &mut mark_evolog,
+            &evolog_query,
+            &mut mark_history,
+            &evolog_source,
+            LogAction::ToggleMark,
+        );
+        let page_transition = apply_evolog_action(
+            &mut page_evolog,
+            &evolog_query,
+            &mut page_history,
+            &evolog_source,
+            LogAction::PageNext,
+        );
+
+        assert!(matches!(mark_transition, AppTransition::Continue));
+        assert!(matches!(page_transition, AppTransition::Continue));
+        assert_eq!(mark_evolog, page_evolog);
+
+        let status_query = StatusQuery::default();
+        let status_source = JjStatus::default();
+        let mut mark_status = RenderedView::from_error("status", "jj status", "fixture".to_owned());
+        let mut page_status = mark_status.clone();
+        let mut mark_history = CommandHistory::default();
+        let mut page_history = CommandHistory::default();
+
+        let mark_transition = apply_status_action(
+            &mut mark_status,
+            &status_query,
+            &mut mark_history,
+            &status_source,
+            LogAction::ToggleMark,
+        );
+        let page_transition = apply_status_action(
+            &mut page_status,
+            &status_query,
+            &mut page_history,
+            &status_source,
+            LogAction::PageNext,
+        );
+
+        assert!(matches!(mark_transition, AppTransition::Continue));
+        assert!(matches!(page_transition, AppTransition::Continue));
+        assert_eq!(mark_status, page_status);
+    }
+
+    #[test]
+    fn diff_args_default_to_revision_at() {
+        let args = Args::try_parse_from(["jk", "diff"]).expect("valid diff args");
+        let Some(Command::Diff(diff_args)) = args.command else {
+            panic!("expected diff command");
+        };
+
+        assert_eq!(
+            diff_args.query(),
+            DiffQuery::Revision {
+                rev: "@".to_owned(),
+                format: DiffFormat::Patch,
+            }
+        );
+    }
+
+    #[test]
+    fn evolog_is_not_a_root_cli_command() {
+        assert!(Args::try_parse_from(["jk", "evolog", "-r", "abc123"]).is_err());
+    }
+
+    #[test]
+    fn workspaces_is_a_root_cli_command() {
+        let args = Args::try_parse_from(["jk", "workspaces"]).expect("valid workspaces command");
+
+        assert!(matches!(args.command, Some(Command::Workspaces)));
+    }
+
+    #[test]
+    fn log_args_preserve_startup_template() {
+        let args =
+            Args::try_parse_from(["jk", "log", "-T", "description"]).expect("valid log args");
+        let Some(Command::Log(log_args)) = args.command else {
+            panic!("expected log command");
+        };
+
+        assert_eq!(log_args.template, Some("description".to_owned()));
+    }
+
+    #[test]
+    fn diff_args_keep_positional_revision_as_sugar() {
+        let args =
+            Args::try_parse_from(["jk", "diff", "abc123", "--stat"]).expect("valid diff args");
+        let Some(Command::Diff(diff_args)) = args.command else {
+            panic!("expected diff command");
+        };
+
+        assert_eq!(
+            diff_args.query(),
+            DiffQuery::Revision {
+                rev: "abc123".to_owned(),
+                format: DiffFormat::Stat,
+            }
+        );
+    }
+
+    #[test]
+    fn diff_args_resolve_explicit_revision_query() {
+        let args = Args::try_parse_from(["jk", "diff", "-r", "abc123"]).expect("valid diff args");
+        let Some(Command::Diff(diff_args)) = args.command else {
+            panic!("expected diff command");
+        };
+
+        assert_eq!(
+            diff_args.query(),
+            DiffQuery::Revision {
+                rev: "abc123".to_owned(),
+                format: DiffFormat::Patch,
+            }
+        );
+    }
+
+    #[test]
+    fn diff_args_resolve_supported_format_flags() {
+        for (flag, format) in [
+            ("--summary", DiffFormat::Summary),
+            ("--types", DiffFormat::Types),
+            ("--name-only", DiffFormat::NameOnly),
+            ("--git", DiffFormat::Git),
+            ("--color-words", DiffFormat::ColorWords),
+        ] {
+            let args = Args::try_parse_from(["jk", "diff", "-r", "abc123", flag])
+                .expect("valid diff args");
+            let Some(Command::Diff(diff_args)) = args.command else {
+                panic!("expected diff command");
+            };
+
+            assert_eq!(
+                diff_args.query(),
+                DiffQuery::Revision {
+                    rev: "abc123".to_owned(),
+                    format,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn diff_args_reject_multiple_format_flags() {
+        assert!(Args::try_parse_from(["jk", "diff", "--stat", "--summary"]).is_err());
+    }
+
+    #[test]
+    fn diff_args_resolve_from_to_query() {
+        let args = Args::try_parse_from(["jk", "diff", "--from", "main", "--to", "@"])
+            .expect("valid diff args");
+        let Some(Command::Diff(diff_args)) = args.command else {
+            panic!("expected diff command");
+        };
+
+        assert_eq!(
+            diff_args.query(),
+            DiffQuery::FromTo {
+                from: "main".to_owned(),
+                to: "@".to_owned(),
+                format: DiffFormat::Patch,
+            }
+        );
+    }
+
+    #[test]
+    fn diff_args_reject_mixed_revision_and_from_to() {
+        assert!(
+            Args::try_parse_from(["jk", "diff", "-r", "@", "--from", "main", "--to", "@"]).is_err()
+        );
+    }
+
+    #[test]
+    fn diff_args_require_from_and_to_together() {
+        assert!(Args::try_parse_from(["jk", "diff", "--from", "main"]).is_err());
+        assert!(Args::try_parse_from(["jk", "diff", "--to", "@"]).is_err());
+    }
+
+    #[test]
+    fn status_args_default_to_repository_status() {
+        let args = Args::try_parse_from(["jk", "status"]).expect("valid status args");
+        let Some(Command::Status(status_args)) = args.command else {
+            panic!("expected status command");
+        };
+
+        assert_eq!(status_args.query(), StatusQuery::default());
+    }
+
+    #[test]
+    fn status_args_preserve_filesets() {
+        let args =
+            Args::try_parse_from(["jk", "status", "crates/jk", "docs"]).expect("valid status args");
+        let Some(Command::Status(status_args)) = args.command else {
+            panic!("expected status command");
+        };
+
+        assert_eq!(
+            status_args.query(),
+            StatusQuery::new(vec!["crates/jk".to_owned(), "docs".to_owned()])
+        );
+    }
+
+    #[test]
+    fn workspace_source_defaults_to_cwd_discovery() {
+        let args = Args::try_parse_from(["jk"]).expect("valid args");
+        let source = args.workspaces_source();
+        let spec = source.list_spec();
+
+        assert_eq!(spec.repository(), None);
     }
 }

--- a/crates/jk/src/menus.rs
+++ b/crates/jk/src/menus.rs
@@ -1,0 +1,216 @@
+use jk_cli::{DiffFormat, LogTemplateSelection};
+use jk_tui::command_discovery::{BindingContext, filtered_discovery_len};
+use jk_tui::diff_view::DiffView;
+
+#[derive(Clone, Copy)]
+pub enum MenuDirection {
+    Previous,
+    Next,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ViewOptionRow {
+    LogTemplate,
+    DiffFormat(DiffFormat),
+    Placeholder,
+}
+
+const DIFF_VIEW_OPTION_ROWS: &[ViewOptionRow] = &[
+    ViewOptionRow::DiffFormat(DiffFormat::Patch),
+    ViewOptionRow::DiffFormat(DiffFormat::Summary),
+    ViewOptionRow::DiffFormat(DiffFormat::Stat),
+    ViewOptionRow::DiffFormat(DiffFormat::Types),
+    ViewOptionRow::DiffFormat(DiffFormat::NameOnly),
+    ViewOptionRow::DiffFormat(DiffFormat::Git),
+    ViewOptionRow::DiffFormat(DiffFormat::ColorWords),
+];
+
+pub fn wrapped_selection(selected: usize, row_count: usize, direction: MenuDirection) -> usize {
+    if row_count == 0 {
+        return 0;
+    }
+
+    let selected = selected.min(row_count - 1);
+    match direction {
+        MenuDirection::Previous => selected.checked_sub(1).unwrap_or(row_count - 1),
+        MenuDirection::Next => (selected + 1) % row_count,
+    }
+}
+
+pub fn clamp_command_discovery_selection(
+    context: BindingContext,
+    query: &str,
+    selected: &mut usize,
+) {
+    let row_count = filtered_discovery_len(context, query);
+    if row_count == 0 {
+        *selected = 0;
+    } else {
+        *selected = (*selected).min(row_count - 1);
+    }
+}
+
+pub const fn view_option_rows(context: BindingContext) -> &'static [ViewOptionRow] {
+    match context {
+        BindingContext::Log => &[ViewOptionRow::LogTemplate],
+        BindingContext::Diff => DIFF_VIEW_OPTION_ROWS,
+        BindingContext::Inspection
+        | BindingContext::Workspaces
+        | BindingContext::CommandHistory
+        | BindingContext::OperationLog => &[ViewOptionRow::Placeholder],
+    }
+}
+
+pub fn view_options_lines(
+    context: BindingContext,
+    selected: usize,
+    template: &LogTemplateSelection,
+    active_diff_format: Option<DiffFormat>,
+) -> Vec<String> {
+    match context {
+        BindingContext::Log => {
+            let marker = if selected == 0 { ">" } else { " " };
+            vec![
+                format!("{marker} {:<18} {}", "Template", template.label()),
+                String::new(),
+                "j/k or arrows move   enter open   esc close".to_owned(),
+            ]
+        }
+        BindingContext::Diff => {
+            let active = active_diff_format.unwrap_or(DiffFormat::Patch);
+            let mut lines = DIFF_VIEW_OPTION_ROWS
+                .iter()
+                .enumerate()
+                .map(|(index, row)| {
+                    let marker = if index == selected { ">" } else { " " };
+                    let ViewOptionRow::DiffFormat(format) = row else {
+                        unreachable!("diff view rows are all formats");
+                    };
+                    let active_marker = if *format == active { "*" } else { " " };
+                    format!("{marker} {active_marker} {:<14}", format.label())
+                })
+                .collect::<Vec<_>>();
+            lines.push(String::new());
+            lines.push("j/k or arrows move   enter apply   esc close".to_owned());
+            lines
+        }
+        BindingContext::Inspection => vec![
+            "No view options in this slice.".to_owned(),
+            String::new(),
+            "esc close".to_owned(),
+        ],
+        BindingContext::Workspaces => vec![
+            "No workspace view options in this slice.".to_owned(),
+            String::new(),
+            "esc close".to_owned(),
+        ],
+        BindingContext::CommandHistory => vec![
+            "No command history options in this slice.".to_owned(),
+            String::new(),
+            "esc close".to_owned(),
+        ],
+        BindingContext::OperationLog => vec![
+            "No operation log options in this slice.".to_owned(),
+            String::new(),
+            "esc close".to_owned(),
+        ],
+    }
+}
+
+pub fn diff_file_list_lines(view: &DiffView, selected: usize) -> Vec<String> {
+    let paths = view.file_paths();
+    if paths.is_empty() {
+        return vec![
+            "No files in this diff.".to_owned(),
+            String::new(),
+            "esc close".to_owned(),
+        ];
+    }
+
+    paths
+        .iter()
+        .enumerate()
+        .map(|(index, path)| {
+            let marker = if index == selected { ">" } else { " " };
+            format!("{marker} {:>2}/{} {path}", index + 1, paths.len())
+        })
+        .chain(std::iter::once(String::new()))
+        .chain(std::iter::once(
+            "j/k or arrows move   enter jump   esc close".to_owned(),
+        ))
+        .collect()
+}
+
+pub fn template_selector_lines(options: &[LogTemplateSelection], selected: usize) -> Vec<String> {
+    options
+        .iter()
+        .enumerate()
+        .map(|(index, template)| {
+            let marker = if index == selected { ">" } else { " " };
+            let name = template.template_name().unwrap_or("jj configured template");
+            format!("{marker} {:<18} {name}", template.label())
+        })
+        .chain(std::iter::once(String::new()))
+        .chain(std::iter::once(
+            "j/k or arrows move   enter apply   esc cancel".to_owned(),
+        ))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrapped_selection_wraps_and_clamps() {
+        assert_eq!(wrapped_selection(0, 3, MenuDirection::Previous), 2);
+        assert_eq!(wrapped_selection(2, 3, MenuDirection::Next), 0);
+        assert_eq!(wrapped_selection(99, 3, MenuDirection::Previous), 1);
+        assert_eq!(wrapped_selection(99, 3, MenuDirection::Next), 0);
+        assert_eq!(wrapped_selection(4, 0, MenuDirection::Next), 0);
+    }
+
+    #[test]
+    fn view_options_lines_show_template_or_placeholder() {
+        assert_eq!(
+            view_options_lines(BindingContext::Log, 0, &LogTemplateSelection::Oneline, None),
+            vec![
+                "> Template           oneline".to_owned(),
+                String::new(),
+                "j/k or arrows move   enter open   esc close".to_owned(),
+            ]
+        );
+        assert_eq!(
+            view_options_lines(
+                BindingContext::Inspection,
+                0,
+                &LogTemplateSelection::Configured,
+                None
+            ),
+            vec![
+                "No view options in this slice.".to_owned(),
+                String::new(),
+                "esc close".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn template_selector_lines_show_template_names() {
+        assert_eq!(
+            template_selector_lines(
+                &[
+                    LogTemplateSelection::Configured,
+                    LogTemplateSelection::Compact,
+                ],
+                1
+            ),
+            vec![
+                "  configured         jj configured template".to_owned(),
+                "> compact            builtin_log_compact".to_owned(),
+                String::new(),
+                "j/k or arrows move   enter apply   esc cancel".to_owned(),
+            ]
+        );
+    }
+}

--- a/crates/jk/src/mutation_preview.rs
+++ b/crates/jk/src/mutation_preview.rs
@@ -1,0 +1,166 @@
+use jk_core::{CommandPreview, SourceAction};
+use jk_tui::log_view::LogView;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingCommandPreview {
+    pub(crate) preview: CommandPreview,
+    pub(crate) source_action: SourceAction,
+    pub(crate) source_key: &'static str,
+    pub(crate) failure_label: &'static str,
+    pub(crate) copy_status: Option<String>,
+}
+
+impl PendingCommandPreview {
+    pub(crate) const fn describe(preview: CommandPreview) -> Self {
+        Self {
+            preview,
+            source_action: SourceAction::DescribeRevision,
+            source_key: "m",
+            failure_label: "jj describe",
+            copy_status: None,
+        }
+    }
+
+    pub(crate) const fn abandon(preview: CommandPreview) -> Self {
+        Self {
+            preview,
+            source_action: SourceAction::AbandonRevision,
+            source_key: "a",
+            failure_label: "jj abandon",
+            copy_status: None,
+        }
+    }
+
+    pub(crate) const fn new_change(preview: CommandPreview) -> Self {
+        Self {
+            preview,
+            source_action: SourceAction::NewRevision,
+            source_key: "n",
+            failure_label: "jj new",
+            copy_status: None,
+        }
+    }
+
+    pub(crate) const fn edit(preview: CommandPreview) -> Self {
+        Self {
+            preview,
+            source_action: SourceAction::EditRevision,
+            source_key: "e",
+            failure_label: "jj edit",
+            copy_status: None,
+        }
+    }
+
+    pub(crate) const fn undo(preview: CommandPreview) -> Self {
+        Self {
+            preview,
+            source_action: SourceAction::Undo,
+            source_key: "u",
+            failure_label: "jj undo",
+            copy_status: None,
+        }
+    }
+
+    pub(crate) const fn redo(preview: CommandPreview) -> Self {
+        Self {
+            preview,
+            source_action: SourceAction::Redo,
+            source_key: "U",
+            failure_label: "jj redo",
+            copy_status: None,
+        }
+    }
+}
+
+pub fn selected_new_parents(log: &LogView) -> Vec<String> {
+    if log.has_marks() {
+        return log.marked_change_ids().to_vec();
+    }
+
+    log.selected_change_id()
+        .map(ToOwned::to_owned)
+        .into_iter()
+        .collect()
+}
+
+pub fn describe_message_lines(rev: &str, message: &str) -> Vec<String> {
+    vec![
+        format!("Revision: {rev}"),
+        format!("Message: {message}"),
+        String::new(),
+        "type message   enter preview   Ctrl-u clear   backspace edit   esc cancel".to_owned(),
+    ]
+}
+
+pub fn command_failure_message(command: &str, stderr: &[u8], stdout: &[u8]) -> String {
+    let stderr = String::from_utf8_lossy(stderr).trim().to_owned();
+    if !stderr.is_empty() {
+        return format!("{command} failed: {stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(stdout).trim().to_owned();
+    if !stdout.is_empty() {
+        return format!("{command} failed: {stdout}");
+    }
+
+    format!("{command} failed")
+}
+
+#[cfg(test)]
+mod tests {
+    use jk_core::JjCommandSpec;
+
+    use super::*;
+
+    fn preview() -> CommandPreview {
+        JjCommandSpec::render_read_only(["status"]).command_preview()
+    }
+
+    #[test]
+    fn pending_preview_metadata_matches_source_actions() {
+        let describe = PendingCommandPreview::describe(preview());
+        assert_eq!(describe.source_action, SourceAction::DescribeRevision);
+        assert_eq!(describe.source_key, "m");
+        assert_eq!(describe.failure_label, "jj describe");
+
+        let abandon = PendingCommandPreview::abandon(preview());
+        assert_eq!(abandon.source_action, SourceAction::AbandonRevision);
+        assert_eq!(abandon.source_key, "a");
+        assert_eq!(abandon.failure_label, "jj abandon");
+
+        let redo = PendingCommandPreview::redo(preview());
+        assert_eq!(redo.source_action, SourceAction::Redo);
+        assert_eq!(redo.source_key, "U");
+        assert_eq!(redo.failure_label, "jj redo");
+    }
+
+    #[test]
+    fn describe_prompt_lines_include_revision_message_and_controls() {
+        assert_eq!(
+            describe_message_lines("abc123", "current message"),
+            vec![
+                "Revision: abc123".to_owned(),
+                "Message: current message".to_owned(),
+                String::new(),
+                "type message   enter preview   Ctrl-u clear   backspace edit   esc cancel"
+                    .to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn failure_message_prefers_stderr_then_stdout() {
+        assert_eq!(
+            command_failure_message("jj abandon", b"bad rev\n", b"ignored\n"),
+            "jj abandon failed: bad rev"
+        );
+        assert_eq!(
+            command_failure_message("jj new", b"", b"stdout failure\n"),
+            "jj new failed: stdout failure"
+        );
+        assert_eq!(
+            command_failure_message("jj edit", b"", b""),
+            "jj edit failed"
+        );
+    }
+}

--- a/crates/jk/src/mutations.rs
+++ b/crates/jk/src/mutations.rs
@@ -1,0 +1,91 @@
+use jk_cli::{
+    JjCommandRunner, JjLog, JjRecovery, RecordingJjCommandRunner, RecoveryCommand,
+    SystemJjCommandRunner,
+};
+use jk_core::{CommandSource, SourceAction, SourceView};
+
+use crate::mutation_preview::{PendingCommandPreview, command_failure_message};
+use crate::state::{AppState, AppView, InputMode};
+
+pub const POST_MUTATION_RECOVERY_STATUS: &str = "u undo  U redo  o operation  C history";
+
+pub fn confirm_command_preview(
+    state: &mut AppState,
+    source: &mut JjLog,
+    pending: PendingCommandPreview,
+) {
+    confirm_command_preview_with_runner(state, source, pending, SystemJjCommandRunner);
+}
+
+pub fn confirm_command_preview_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    source: &mut JjLog,
+    pending: PendingCommandPreview,
+    runner: R,
+) {
+    let command_source = CommandSource::new(SourceView::Log, pending.source_action.clone())
+        .with_key(pending.source_key);
+    let mut runner = RecordingJjCommandRunner::new(runner, &mut state.history, command_source);
+    let result = runner.run_confirmed_mutation(&pending.preview.spec);
+    let runner = runner.into_inner();
+    match result {
+        Ok(output) if output.status.success() => {
+            refresh_after_mutation_with_runner(state, source, runner)
+        }
+        Ok(output) => {
+            let message =
+                command_failure_message(pending.failure_label, &output.stderr, &output.stdout);
+            show_log_error(state, message);
+        }
+        Err(error) => {
+            show_log_error(
+                state,
+                format!("failed to run {}: {error}", pending.failure_label),
+            );
+        }
+    }
+}
+
+pub fn open_recovery_preview(
+    state: &mut AppState,
+    recovery_source: &JjRecovery,
+    command: RecoveryCommand,
+) {
+    if !matches!(state.views.active(), AppView::Log(_)) {
+        return;
+    }
+
+    let preview = recovery_source.spec_for(command).command_preview();
+    let pending = match command {
+        RecoveryCommand::Undo => PendingCommandPreview::undo(preview),
+        RecoveryCommand::Redo => PendingCommandPreview::redo(preview),
+    };
+    state.modes.push(InputMode::CommandPreview { pending });
+}
+
+fn refresh_after_mutation_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    source: &mut JjLog,
+    runner: R,
+) {
+    let AppView::Log(log) = state.views.active_mut() else {
+        return;
+    };
+
+    let refreshed = crate::refresh::refresh_log_with_runner(
+        log,
+        &mut state.history,
+        source,
+        CommandSource::new(SourceView::Log, SourceAction::Refresh),
+        runner,
+    );
+    if refreshed {
+        log.show_status(POST_MUTATION_RECOVERY_STATUS);
+    }
+}
+
+fn show_log_error(state: &mut AppState, message: String) {
+    if let AppView::Log(log) = state.views.active_mut() {
+        log.show_error(message);
+    }
+}

--- a/crates/jk/src/operation_log.rs
+++ b/crates/jk/src/operation_log.rs
@@ -1,0 +1,108 @@
+use jk_tui::operation_log_view::{OperationLogRow, OperationLogSnapshot};
+
+pub fn operation_log_snapshot(title: &str, rendered: &str) -> OperationLogSnapshot {
+    let rows = operation_log_rows(rendered);
+    OperationLogSnapshot::new(rows).with_title(title)
+}
+
+fn operation_log_rows(rendered: &str) -> Vec<OperationLogRow> {
+    let mut rows = Vec::new();
+    for line in rendered.lines().map(strip_ansi) {
+        if let Some(row) = parse_operation_row(&line) {
+            rows.push(row);
+        } else if let Some(title) = parse_operation_title_line(&line)
+            && let Some(row) = rows.last_mut()
+            && row.title.trim().is_empty()
+        {
+            row.title = title.to_owned();
+        }
+    }
+    rows
+}
+
+fn parse_operation_row(line: &str) -> Option<OperationLogRow> {
+    let mut fields = line.split_whitespace();
+    let marker = fields.next()?;
+    let operation_id = fields.next()?;
+    if !is_operation_marker(marker) || !looks_like_operation_id(operation_id) {
+        return None;
+    }
+    Some(OperationLogRow::new(
+        operation_id,
+        operation_id.chars().take(12).collect::<String>(),
+        String::new(),
+        marker == "@",
+    ))
+}
+
+fn parse_operation_title_line(line: &str) -> Option<&str> {
+    line.strip_prefix("│  ")
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+}
+
+fn is_operation_marker(marker: &str) -> bool {
+    matches!(marker, "@" | "○" | "◆" | "×" | "◉")
+}
+
+fn looks_like_operation_id(value: &str) -> bool {
+    value.len() >= 8 && value.chars().all(|character| character.is_ascii_hexdigit())
+}
+
+fn strip_ansi(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(character) = chars.next() {
+        if character == '\u{1b}' && chars.peek() == Some(&'[') {
+            let _ = chars.next();
+            for code in chars.by_ref() {
+                if code.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            output.push(character);
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_extracts_operation_rows_and_titles() {
+        let rendered = "\
+@ abcdef1234567890 user@example.test now
+│  latest operation
+○ 0123456789abcdef user@example.test earlier
+│  previous operation
+";
+
+        let snapshot = operation_log_snapshot("jj op log", rendered);
+
+        assert_eq!(snapshot.title(), "jj op log");
+        assert_eq!(snapshot.rows().len(), 2);
+        assert_eq!(snapshot.rows()[0].operation_id, "abcdef1234567890");
+        assert_eq!(snapshot.rows()[0].display_id, "abcdef123456");
+        assert_eq!(snapshot.rows()[0].title, "latest operation");
+        assert!(snapshot.rows()[0].current);
+        assert_eq!(snapshot.rows()[1].operation_id, "0123456789abcdef");
+        assert_eq!(snapshot.rows()[1].title, "previous operation");
+        assert!(!snapshot.rows()[1].current);
+    }
+
+    #[test]
+    fn snapshot_ignores_ansi_sequences_before_parsing() {
+        let rendered = "\u{1b}[32m@ abcdef1234567890 user@example.test now\u{1b}[0m\n\
+│  colored current operation\n";
+
+        let snapshot = operation_log_snapshot("jj op log", rendered);
+
+        assert_eq!(snapshot.rows().len(), 1);
+        assert_eq!(snapshot.rows()[0].operation_id, "abcdef1234567890");
+        assert_eq!(snapshot.rows()[0].title, "colored current operation");
+        assert!(snapshot.rows()[0].current);
+    }
+}

--- a/crates/jk/src/refresh.rs
+++ b/crates/jk/src/refresh.rs
@@ -1,0 +1,312 @@
+use jk_cli::{
+    DiffQuery, EvologQuery, JjCommandRunner, JjDiff, JjEvolog, JjLog, JjLogCommand, JjOperation,
+    JjShow, JjStatus, JjWorkspaces, LogTemplateSelection, OperationQuery, RecordingJjCommandRunner,
+    ShowQuery, StatusQuery, SystemJjCommandRunner, WorkspaceInspectionQuery,
+};
+use jk_core::{CommandHistory, CommandSource, SourceAction, SourceView};
+use jk_tui::diff_view::DiffView;
+use jk_tui::log_view::LogView;
+use jk_tui::operation_log_view::OperationLogView;
+use jk_tui::rendered_view::RenderedView;
+use jk_tui::workspaces_view::WorkspacesView;
+
+use crate::operation_log::operation_log_snapshot;
+use crate::state::{AppState, AppView};
+use crate::workspaces::workspace_view_snapshot;
+use crate::{AppTransition, WorkspaceInspectionKind};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OperationRenderedKind {
+    Show,
+    Diff,
+}
+
+/// Reloads the current command without replacing the view on failure.
+pub fn refresh_log(
+    app: &mut LogView,
+    history: &mut CommandHistory,
+    source: &JjLog,
+    command_source: CommandSource,
+) -> bool {
+    refresh_log_with_runner(app, history, source, command_source, SystemJjCommandRunner)
+}
+
+pub fn refresh_log_with_runner<R: JjCommandRunner>(
+    app: &mut LogView,
+    history: &mut CommandHistory,
+    source: &JjLog,
+    command_source: CommandSource,
+    runner: R,
+) -> bool {
+    let mut runner = RecordingJjCommandRunner::new(runner, history, command_source);
+    match source.load_with_runner(&mut runner) {
+        Ok(snapshot) => {
+            app.refresh(snapshot);
+            true
+        }
+        Err(error) => {
+            app.show_error(error.to_string());
+            false
+        }
+    }
+}
+
+/// Reloads the active diff without replacing the view on failure.
+pub fn refresh_diff(
+    app: &mut DiffView,
+    query: &DiffQuery,
+    history: &mut CommandHistory,
+    source: &JjDiff,
+) {
+    let mut runner = crate::recording_runner(
+        history,
+        CommandSource::new(SourceView::Diff, SourceAction::Refresh),
+    );
+    match source.load_query_with_runner(query, &mut runner) {
+        Ok(snapshot) => app.refresh(snapshot),
+        Err(error) => app.show_error(error.to_string()),
+    }
+}
+
+/// Reloads the active show/details view without replacing it on failure.
+pub fn refresh_show(
+    app: &mut RenderedView,
+    query: &ShowQuery,
+    history: &mut CommandHistory,
+    source: &JjShow,
+) {
+    let mut runner = crate::recording_runner(
+        history,
+        CommandSource::new(SourceView::Show, SourceAction::Refresh),
+    );
+    match source.load_query_with_runner(query, &mut runner) {
+        Ok(snapshot) => app.refresh(snapshot),
+        Err(error) => app.show_error(error.to_string()),
+    }
+}
+
+/// Reloads the active evolog view without replacing it on failure.
+pub fn refresh_evolog(
+    app: &mut RenderedView,
+    query: &EvologQuery,
+    history: &mut CommandHistory,
+    source: &JjEvolog,
+) {
+    let mut runner = crate::recording_runner(
+        history,
+        CommandSource::new(SourceView::Evolog, SourceAction::Refresh),
+    );
+    match source.load_query_with_runner(query, &mut runner) {
+        Ok(snapshot) => app.refresh(snapshot),
+        Err(error) => app.show_error(error.to_string()),
+    }
+}
+
+/// Reloads the active status view without replacing it on failure.
+pub fn refresh_status(
+    app: &mut RenderedView,
+    query: &StatusQuery,
+    history: &mut CommandHistory,
+    source: &JjStatus,
+) {
+    let mut runner = crate::recording_runner(
+        history,
+        CommandSource::new(SourceView::Status, SourceAction::Refresh),
+    );
+    match source.load_query_with_runner(query, &mut runner) {
+        Ok(snapshot) => app.refresh(snapshot),
+        Err(error) => app.show_error(error.to_string()),
+    }
+}
+
+/// Reloads the workspace list without replacing the view on failure.
+pub fn refresh_workspaces(
+    app: &mut WorkspacesView,
+    history: &mut CommandHistory,
+    source: &JjWorkspaces,
+) {
+    refresh_workspaces_with_runner(app, history, source, SystemJjCommandRunner);
+}
+
+pub fn refresh_workspaces_with_runner<R: JjCommandRunner>(
+    app: &mut WorkspacesView,
+    history: &mut CommandHistory,
+    source: &JjWorkspaces,
+    runner: R,
+) {
+    let mut runner = RecordingJjCommandRunner::new(
+        runner,
+        history,
+        CommandSource::new(SourceView::Workspaces, SourceAction::Refresh),
+    );
+    match source.load_list_with_runner(&mut runner) {
+        Ok(snapshot) => app.refresh(workspace_view_snapshot(snapshot)),
+        Err(error) => app.show_error(error.to_string()),
+    }
+}
+
+pub fn refresh_operation_log(
+    app: &mut OperationLogView,
+    history: &mut CommandHistory,
+    source: &JjOperation,
+) {
+    let mut runner = crate::recording_runner(
+        history,
+        CommandSource::new(SourceView::OperationLog, SourceAction::Refresh),
+    );
+    match source.load_query_with_runner(&OperationQuery::log(), &mut runner) {
+        Ok(snapshot) => app.refresh(operation_log_snapshot(
+            snapshot.title(),
+            snapshot.rendered(),
+        )),
+        Err(_error) => {}
+    }
+}
+
+pub fn operation_rendered_transition(
+    history: &mut CommandHistory,
+    source: &JjOperation,
+    query: OperationQuery,
+    source_view: SourceView,
+    action: SourceAction,
+    kind: OperationRenderedKind,
+) -> AppTransition {
+    operation_rendered_transition_with_runner(
+        history,
+        source,
+        query,
+        source_view,
+        action,
+        kind,
+        SystemJjCommandRunner,
+    )
+}
+
+pub fn operation_rendered_transition_with_runner<R: JjCommandRunner>(
+    history: &mut CommandHistory,
+    source: &JjOperation,
+    query: OperationQuery,
+    source_view: SourceView,
+    action: SourceAction,
+    kind: OperationRenderedKind,
+    runner: R,
+) -> AppTransition {
+    let mut runner =
+        RecordingJjCommandRunner::new(runner, history, CommandSource::new(source_view, action));
+    match source.load_query_with_runner(&query, &mut runner) {
+        Ok(snapshot) => {
+            let view = RenderedView::new(snapshot);
+            let app_view = match kind {
+                OperationRenderedKind::Show => AppView::OperationShow { view, query },
+                OperationRenderedKind::Diff => AppView::OperationDiff { view, query },
+            };
+            AppTransition::Push(app_view)
+        }
+        Err(_error) => AppTransition::Continue,
+    }
+}
+
+pub fn refresh_operation_rendered(
+    app: &mut RenderedView,
+    query: &OperationQuery,
+    history: &mut CommandHistory,
+    source: &JjOperation,
+    view: SourceView,
+) {
+    let mut runner =
+        crate::recording_runner(history, CommandSource::new(view, SourceAction::Refresh));
+    match source.load_query_with_runner(query, &mut runner) {
+        Ok(snapshot) => app.refresh(snapshot),
+        Err(error) => app.show_error(error.to_string()),
+    }
+}
+
+/// Reloads a selected-workspace inspection view without changing its workspace root.
+pub fn refresh_workspace_inspection(
+    app: &mut RenderedView,
+    query: &WorkspaceInspectionQuery,
+    history: &mut CommandHistory,
+    source: &JjWorkspaces,
+    kind: WorkspaceInspectionKind,
+) {
+    let command_source = match kind {
+        WorkspaceInspectionKind::Log => {
+            CommandSource::new(SourceView::WorkspaceLog, SourceAction::Refresh)
+        }
+        WorkspaceInspectionKind::Status => {
+            CommandSource::new(SourceView::WorkspaceStatus, SourceAction::Refresh)
+        }
+        WorkspaceInspectionKind::Diff => {
+            CommandSource::new(SourceView::WorkspaceDiff, SourceAction::Refresh)
+        }
+    };
+    let mut runner = crate::recording_runner(history, command_source);
+    let snapshot = match kind {
+        WorkspaceInspectionKind::Log => source.load_log_with_runner(query, &mut runner),
+        WorkspaceInspectionKind::Status => source.load_status_with_runner(query, &mut runner),
+        WorkspaceInspectionKind::Diff => source.load_diff_with_runner(query, &mut runner),
+    };
+    match snapshot {
+        Ok(snapshot) => app.refresh(snapshot),
+        Err(error) => app.show_error(error.to_string()),
+    }
+}
+
+/// Switches the command context only after the replacement log loads.
+pub fn switch_log_command(
+    app: &mut LogView,
+    history: &mut CommandHistory,
+    source: &mut JjLog,
+    command: JjLogCommand,
+) {
+    let mut next_source = source.clone().with_command(command);
+    if command == JjLogCommand::ConfiguredDefault {
+        next_source = next_source.with_configured_template();
+    }
+    let mut runner = crate::recording_runner(
+        history,
+        CommandSource::new(SourceView::Log, SourceAction::Refresh),
+    );
+    match next_source.load_with_runner(&mut runner) {
+        Ok(snapshot) => {
+            *source = next_source;
+            app.refresh(snapshot);
+        }
+        Err(error) => app.show_error(error.to_string()),
+    }
+}
+
+/// Switches the rendered log template only after the replacement log loads.
+pub fn apply_log_template_selection(
+    state: &mut AppState,
+    source: &mut JjLog,
+    template: LogTemplateSelection,
+) {
+    if !matches!(state.views.active(), AppView::Log(_)) {
+        return;
+    }
+
+    let next_source = source
+        .clone()
+        .with_command(JjLogCommand::Log)
+        .with_template(template);
+    let mut runner = crate::recording_runner(
+        &mut state.history,
+        CommandSource::new(SourceView::Log, SourceAction::Refresh),
+    );
+    match next_source.load_with_runner(&mut runner) {
+        Ok(snapshot) => {
+            *source = next_source;
+            if let AppView::Log(log) = state.views.active_mut() {
+                log.refresh(snapshot);
+            }
+        }
+        Err(error) => show_log_template_load_error(state, error.to_string()),
+    }
+}
+
+pub fn show_log_template_load_error(state: &mut AppState, error: String) {
+    if let AppView::Log(log) = state.views.active_mut() {
+        log.show_error(error);
+    }
+}

--- a/crates/jk/src/rendering.rs
+++ b/crates/jk/src/rendering.rs
@@ -1,0 +1,226 @@
+use jk_cli::LogTemplateSelection;
+use jk_tui::command_discovery::discovery_lines;
+use jk_tui::command_preview_view::CommandPreviewView;
+
+use crate::command_mode::jj_command_lines;
+use crate::menus::{diff_file_list_lines, template_selector_lines, view_options_lines};
+use crate::mutation_preview::describe_message_lines;
+use crate::state::{AppState, AppView, InputMode};
+
+pub fn render_app(
+    frame: &mut ratatui::Frame<'_>,
+    state: &mut AppState,
+    template: &LogTemplateSelection,
+) {
+    let mode = state.modes.active().cloned();
+    match state.views.active_mut() {
+        AppView::Log(log) => match &mode {
+            Some(InputMode::ViewOptions { context, selected }) => {
+                let lines = view_options_lines(*context, *selected, template, None);
+                log.render_with_selector(frame, "View Options", &lines);
+            }
+            Some(InputMode::LogTemplate { options, selected }) => {
+                let lines = template_selector_lines(options, *selected);
+                log.render_with_selector(frame, "Log template", &lines);
+            }
+            Some(InputMode::CommandDiscovery {
+                context,
+                query,
+                selected,
+            }) => {
+                let lines = discovery_lines(*context, query, *selected);
+                log.render_with_selector(frame, "Command discovery", &lines);
+            }
+            Some(InputMode::JjCommand { input, error }) => {
+                log.render(frame);
+                let lines = jj_command_lines(input, error.as_deref());
+                render_mode_overlay(frame, "jj command", &lines);
+            }
+            Some(InputMode::DescribeMessage { rev, message }) => {
+                log.render(frame);
+                let lines = describe_message_lines(rev, message);
+                render_mode_overlay(frame, "Describe revision", &lines);
+            }
+            Some(InputMode::CommandPreview { pending }) => {
+                log.render(frame);
+                CommandPreviewView::new(pending.preview.clone())
+                    .with_status(pending.copy_status.clone())
+                    .render(frame);
+            }
+            _ => log.render(frame),
+        },
+        AppView::Diff { view, query } => match &mode {
+            Some(InputMode::ViewOptions { context, selected }) => {
+                let lines = view_options_lines(*context, *selected, template, Some(query.format()));
+                view.render_with_overlay(frame, "View Options", &lines);
+            }
+            Some(InputMode::DiffFileList { selected }) => {
+                let lines = diff_file_list_lines(view, *selected);
+                view.render_with_overlay(frame, "Diff files", &lines);
+            }
+            Some(InputMode::DiffSearch { query }) => {
+                let status = format!("/{query}");
+                view.render_with_status(frame, &status);
+            }
+            Some(InputMode::CommandDiscovery {
+                context,
+                query,
+                selected,
+            }) => {
+                let lines = discovery_lines(*context, query, *selected);
+                view.render_with_overlay(frame, "Command discovery", &lines);
+            }
+            Some(InputMode::JjCommand { input, error }) => {
+                let lines = jj_command_lines(input, error.as_deref());
+                view.render_with_overlay(frame, "jj command", &lines);
+            }
+            _ => view.render(frame),
+        },
+        AppView::Show { view, .. } => render_inspection(frame, view, &mode, template),
+        AppView::Evolog { view, .. } => render_inspection(frame, view, &mode, template),
+        AppView::Status { view, .. } => render_inspection(frame, view, &mode, template),
+        AppView::Workspaces { view } => match &mode {
+            Some(InputMode::ViewOptions { context, selected }) => {
+                let lines = view_options_lines(*context, *selected, template, None);
+                view.render(frame);
+                render_mode_overlay(frame, "View Options", &lines);
+            }
+            Some(InputMode::CommandDiscovery {
+                context,
+                query,
+                selected,
+            }) => {
+                let lines = discovery_lines(*context, query, *selected);
+                view.render(frame);
+                render_mode_overlay(frame, "Command discovery", &lines);
+            }
+            Some(InputMode::JjCommand { input, error }) => {
+                view.render(frame);
+                let lines = jj_command_lines(input, error.as_deref());
+                render_mode_overlay(frame, "jj command", &lines);
+            }
+            _ => view.render(frame),
+        },
+        AppView::CommandHistory { view } => match &mode {
+            Some(InputMode::CommandDiscovery {
+                context,
+                query,
+                selected,
+            }) => {
+                let lines = discovery_lines(*context, query, *selected);
+                view.render(frame);
+                render_mode_overlay(frame, "Command discovery", &lines);
+            }
+            Some(InputMode::JjCommand { input, error }) => {
+                view.render(frame);
+                let lines = jj_command_lines(input, error.as_deref());
+                render_mode_overlay(frame, "jj command", &lines);
+            }
+            _ => view.render(frame),
+        },
+        AppView::OperationLog { view } => match &mode {
+            Some(InputMode::ViewOptions { context, selected }) => {
+                let lines = view_options_lines(*context, *selected, template, None);
+                view.render(frame);
+                render_mode_overlay(frame, "View Options", &lines);
+            }
+            Some(InputMode::CommandDiscovery {
+                context,
+                query,
+                selected,
+            }) => {
+                let lines = discovery_lines(*context, query, *selected);
+                view.render(frame);
+                render_mode_overlay(frame, "Command discovery", &lines);
+            }
+            Some(InputMode::JjCommand { input, error }) => {
+                view.render(frame);
+                let lines = jj_command_lines(input, error.as_deref());
+                render_mode_overlay(frame, "jj command", &lines);
+            }
+            _ => view.render(frame),
+        },
+        AppView::CommandHistoryDetails { view }
+        | AppView::CommandOutput { view, .. }
+        | AppView::WorkspaceLog { view, .. }
+        | AppView::WorkspaceStatus { view, .. }
+        | AppView::WorkspaceDiff { view, .. }
+        | AppView::OperationShow { view, .. }
+        | AppView::OperationDiff { view, .. } => render_inspection(frame, view, &mode, template),
+    }
+}
+
+fn render_inspection(
+    frame: &mut ratatui::Frame<'_>,
+    view: &mut jk_tui::rendered_view::RenderedView,
+    mode: &Option<InputMode>,
+    template: &LogTemplateSelection,
+) {
+    match mode {
+        Some(InputMode::ViewOptions { context, selected }) => {
+            let lines = view_options_lines(*context, *selected, template, None);
+            view.render_with_overlay(frame, "View Options", &lines);
+        }
+        Some(InputMode::InspectionSearch { query }) => {
+            let status = format!("/{query}");
+            view.render_with_status(frame, &status);
+        }
+        Some(InputMode::CommandDiscovery {
+            context,
+            query,
+            selected,
+        }) => {
+            let lines = discovery_lines(*context, query, *selected);
+            view.render_with_overlay(frame, "Command discovery", &lines);
+        }
+        Some(InputMode::JjCommand { input, error }) => {
+            let lines = jj_command_lines(input, error.as_deref());
+            view.render_with_overlay(frame, "jj command", &lines);
+        }
+        _ => view.render(frame),
+    }
+}
+
+fn render_mode_overlay(frame: &mut ratatui::Frame<'_>, title: &str, lines: &[String]) {
+    use ratatui::layout::Rect;
+    use ratatui::prelude::{Color, Line, Modifier, Span, Style, Text};
+    use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
+
+    let area = frame.area();
+    if area.is_empty() {
+        return;
+    }
+
+    let content = Rect {
+        x: area.x,
+        y: area.y.saturating_add(1),
+        width: area.width,
+        height: area.height.saturating_sub(2),
+    };
+    let width = 72_u16.min(content.width);
+    let height = u16::try_from(lines.len().saturating_add(4))
+        .unwrap_or(u16::MAX)
+        .min(content.height);
+    let overlay = Rect {
+        x: content.x + content.width.saturating_sub(width) / 2,
+        y: content.y + content.height.saturating_sub(height) / 2,
+        width,
+        height,
+    };
+    frame.render_widget(Clear, overlay);
+
+    let text = Text::from(
+        std::iter::once(Line::from(Span::styled(
+            title,
+            Style::new().add_modifier(Modifier::BOLD),
+        )))
+        .chain(std::iter::once(Line::from("")))
+        .chain(lines.iter().map(|line| Line::from(line.as_str())))
+        .collect::<Vec<_>>(),
+    );
+    let paragraph = Paragraph::new(text)
+        .block(Block::bordered())
+        .style(Style::new().fg(Color::White).bg(Color::Black))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, overlay);
+}

--- a/crates/jk/src/root_views.rs
+++ b/crates/jk/src/root_views.rs
@@ -1,0 +1,104 @@
+use jk_cli::{DiffQuery, JjDiff, JjLog, JjShow, JjStatus, JjWorkspaces, ShowQuery, StatusQuery};
+use jk_core::{CommandHistory, CommandSource, SourceAction, SourceView};
+use jk_tui::diff_view::DiffView;
+use jk_tui::log_view::LogView;
+use jk_tui::rendered_view::RenderedView;
+use jk_tui::workspaces_view::{WorkspaceViewSnapshot, WorkspacesView};
+
+use crate::runner::recording_runner;
+use crate::state::AppView;
+use crate::workspaces::workspace_view_snapshot;
+
+pub fn root_log_view(source: &JjLog, history: &mut CommandHistory) -> color_eyre::Result<AppView> {
+    let mut runner = recording_runner(
+        history,
+        CommandSource::new(SourceView::Log, SourceAction::InitialLoad),
+    );
+    let entries = source.load_with_runner(&mut runner)?;
+    Ok(AppView::Log(LogView::new(entries)))
+}
+
+pub fn root_diff_view(
+    diff_source: &JjDiff,
+    query: DiffQuery,
+    history: &mut CommandHistory,
+) -> AppView {
+    let mut runner = recording_runner(
+        history,
+        CommandSource::new(SourceView::Diff, SourceAction::InitialLoad),
+    );
+    let snapshot = diff_source.load_query_with_runner(&query, &mut runner);
+    let diff = match snapshot {
+        Ok(snapshot) => DiffView::new(snapshot),
+        Err(error) => DiffView::from_error(
+            query.target_label(),
+            diff_source.spec_for(&query).title().to_owned(),
+            error.to_string(),
+        ),
+    };
+    AppView::Diff { view: diff, query }
+}
+
+pub fn root_show_view(
+    show_source: &JjShow,
+    query: ShowQuery,
+    history: &mut CommandHistory,
+) -> AppView {
+    let mut runner = recording_runner(
+        history,
+        CommandSource::new(SourceView::Show, SourceAction::InitialLoad),
+    );
+    let snapshot = show_source.load_query_with_runner(&query, &mut runner);
+    let show = match snapshot {
+        Ok(snapshot) => RenderedView::new(snapshot),
+        Err(error) => RenderedView::from_error(
+            query.target_label(),
+            show_source.spec_for(&query).title().to_owned(),
+            error.to_string(),
+        ),
+    };
+    AppView::Show { view: show, query }
+}
+
+pub fn root_status_view(
+    status_source: &JjStatus,
+    query: StatusQuery,
+    history: &mut CommandHistory,
+) -> AppView {
+    let mut runner = recording_runner(
+        history,
+        CommandSource::new(SourceView::Status, SourceAction::InitialLoad),
+    );
+    let snapshot = status_source.load_query_with_runner(&query, &mut runner);
+    let status = match snapshot {
+        Ok(snapshot) => RenderedView::new(snapshot),
+        Err(error) => RenderedView::from_error(
+            query.target_label(),
+            status_source.spec_for(&query).title().to_owned(),
+            error.to_string(),
+        ),
+    };
+    AppView::Status {
+        view: status,
+        query,
+    }
+}
+
+pub fn root_workspaces_view(
+    workspaces_source: &JjWorkspaces,
+    history: &mut CommandHistory,
+) -> AppView {
+    let mut runner = recording_runner(
+        history,
+        CommandSource::new(SourceView::Workspaces, SourceAction::InitialLoad),
+    );
+    let view = match workspaces_source.load_list_with_runner(&mut runner) {
+        Ok(snapshot) => WorkspacesView::new(workspace_view_snapshot(snapshot)),
+        Err(error) => {
+            let mut view = WorkspacesView::new(WorkspaceViewSnapshot::new(Vec::new()));
+            view.show_error(error.to_string());
+            view
+        }
+    };
+    AppView::Workspaces { view }
+}

--- a/crates/jk/src/runner.rs
+++ b/crates/jk/src/runner.rs
@@ -1,0 +1,9 @@
+use jk_cli::{RecordingJjCommandRunner, SystemJjCommandRunner};
+use jk_core::{CommandHistory, CommandSource};
+
+pub const fn recording_runner(
+    history: &mut CommandHistory,
+    source: CommandSource,
+) -> RecordingJjCommandRunner<'_, SystemJjCommandRunner> {
+    RecordingJjCommandRunner::new(SystemJjCommandRunner, history, source)
+}

--- a/crates/jk/src/state.rs
+++ b/crates/jk/src/state.rs
@@ -1,0 +1,213 @@
+use jk_cli::{
+    DiffQuery, EvologQuery, LogTemplateSelection, OperationQuery, ShowQuery, StatusQuery,
+    WorkspaceInspectionQuery,
+};
+use jk_core::CommandHistory;
+use jk_tui::command_discovery::BindingContext;
+use jk_tui::command_history_view::CommandHistoryView;
+use jk_tui::diff_view::DiffView;
+use jk_tui::log_view::LogView;
+use jk_tui::operation_log_view::OperationLogView;
+use jk_tui::rendered_view::RenderedView;
+use jk_tui::workspaces_view::WorkspacesView;
+
+use crate::mutation_preview::PendingCommandPreview;
+
+/// Active top-level application view.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AppView {
+    Log(LogView),
+    Diff {
+        view: DiffView,
+        query: DiffQuery,
+    },
+    Show {
+        view: RenderedView,
+        query: ShowQuery,
+    },
+    Evolog {
+        view: RenderedView,
+        query: EvologQuery,
+    },
+    Status {
+        view: RenderedView,
+        query: StatusQuery,
+    },
+    Workspaces {
+        view: WorkspacesView,
+    },
+    CommandHistory {
+        view: CommandHistoryView,
+    },
+    CommandHistoryDetails {
+        view: RenderedView,
+    },
+    CommandOutput {
+        view: RenderedView,
+        input: String,
+    },
+    OperationLog {
+        view: OperationLogView,
+    },
+    OperationShow {
+        view: RenderedView,
+        query: OperationQuery,
+    },
+    OperationDiff {
+        view: RenderedView,
+        query: OperationQuery,
+    },
+    WorkspaceStatus {
+        view: RenderedView,
+        query: WorkspaceInspectionQuery,
+    },
+    WorkspaceLog {
+        view: RenderedView,
+        query: WorkspaceInspectionQuery,
+    },
+    WorkspaceDiff {
+        view: RenderedView,
+        query: WorkspaceInspectionQuery,
+    },
+}
+
+/// Application state owned by the terminal loop.
+#[derive(Debug)]
+pub struct AppState {
+    pub(crate) views: ViewStack,
+    pub(crate) modes: ModeStack,
+    pub(crate) history: CommandHistory,
+}
+
+impl AppState {
+    #[cfg(test)]
+    pub(crate) fn new(root: AppView) -> Self {
+        Self::with_history(root, CommandHistory::default())
+    }
+
+    pub(crate) fn with_history(root: AppView, history: CommandHistory) -> Self {
+        Self {
+            views: ViewStack::new(root),
+            modes: ModeStack::default(),
+            history,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn command_history(&self) -> &CommandHistory {
+        &self.history
+    }
+}
+
+/// Non-empty stack of top-level views.
+#[derive(Debug)]
+pub struct ViewStack {
+    views: Vec<AppView>,
+}
+
+impl ViewStack {
+    pub(crate) fn new(root: AppView) -> Self {
+        Self { views: vec![root] }
+    }
+
+    pub(crate) fn active(&self) -> &AppView {
+        match self.views.last() {
+            Some(view) => view,
+            None => panic!("view stack always keeps one root view"),
+        }
+    }
+
+    pub(crate) fn active_mut(&mut self) -> &mut AppView {
+        match self.views.last_mut() {
+            Some(view) => view,
+            None => panic!("view stack always keeps one root view"),
+        }
+    }
+
+    pub(crate) fn push(&mut self, view: AppView) {
+        self.views.push(view);
+    }
+
+    pub(crate) fn pop(&mut self) -> bool {
+        if self.views.len() == 1 {
+            return false;
+        }
+
+        self.views.pop();
+        true
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn len(&self) -> usize {
+        self.views.len()
+    }
+}
+
+/// Stack of transient prompt-like modes.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ModeStack {
+    modes: Vec<InputMode>,
+}
+
+impl ModeStack {
+    pub(crate) fn active(&self) -> Option<&InputMode> {
+        self.modes.last()
+    }
+
+    pub(crate) fn active_mut(&mut self) -> Option<&mut InputMode> {
+        self.modes.last_mut()
+    }
+
+    pub(crate) fn push(&mut self, mode: InputMode) {
+        self.modes.push(mode);
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<InputMode> {
+        self.modes.pop()
+    }
+}
+
+/// Transient input modes owned by the terminal loop.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InputMode {
+    ViewOptions {
+        context: BindingContext,
+        selected: usize,
+    },
+    DiffFileList {
+        selected: usize,
+    },
+    DiffSearch {
+        query: String,
+    },
+    InspectionSearch {
+        query: String,
+    },
+    CommandDiscovery {
+        context: BindingContext,
+        query: String,
+        selected: usize,
+    },
+    DescribeMessage {
+        rev: String,
+        message: String,
+    },
+    CommandPreview {
+        pending: PendingCommandPreview,
+    },
+    JjCommand {
+        input: String,
+        error: Option<String>,
+    },
+    LogTemplate {
+        options: Vec<LogTemplateSelection>,
+        selected: usize,
+    },
+}
+
+/// Whether an input-mode handler consumed a key event.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InputModeResult {
+    Handled,
+    Unhandled,
+}

--- a/crates/jk/src/test_support.rs
+++ b/crates/jk/src/test_support.rs
@@ -1,0 +1,167 @@
+use std::collections::VecDeque;
+use std::io;
+use std::process::Output;
+
+use jk_cli::{DiffFormat, DiffQuery, JjCommandRunner};
+use jk_core::{CommandHistory, CommandSource, SourceAction, SourceView};
+use jk_tui::diff_view::DiffView;
+use jk_tui::log_view::LogView;
+use jk_tui::workspaces_view::{WorkspaceViewRow, WorkspaceViewSnapshot, WorkspacesView};
+
+use crate::state::AppView;
+
+pub fn diff_app_view(change_id: &str) -> AppView {
+    AppView::Diff {
+        view: diff_view(change_id),
+        query: diff_query(change_id),
+    }
+}
+
+pub fn diff_query(change_id: &str) -> DiffQuery {
+    DiffQuery::Revision {
+        rev: change_id.to_owned(),
+        format: DiffFormat::Patch,
+    }
+}
+
+pub fn diff_view(change_id: &str) -> DiffView {
+    DiffView::from_error(
+        change_id,
+        format!("jj diff -r {change_id}"),
+        "synthetic diff fixture".to_owned(),
+    )
+}
+
+pub fn real_diff_view(change_id: &str) -> DiffView {
+    DiffView::new(
+        jk_core::DiffSnapshot::new(
+            change_id,
+            "Modified regular file src/a.rs:\n a\nModified regular file src/b.rs:\n b\n",
+        )
+        .with_title(format!("jj diff -r {change_id}")),
+    )
+}
+
+pub fn log_app_view(change_id: &str) -> AppView {
+    log_app_view_with_changes([change_id])
+}
+
+pub fn log_app_view_with_description(change_id: &str, description: &str) -> AppView {
+    AppView::Log(LogView::new(
+        jk_core::LogSnapshot::new(
+            format!("@  {change_id} {description}\n"),
+            vec![jk_core::LogEntry::new(change_id, "commit", description).with_rendered_line(0)],
+        )
+        .with_title("jj log"),
+    ))
+}
+
+pub fn log_app_view_with_changes<const N: usize>(change_ids: [&str; N]) -> AppView {
+    let rendered = change_ids
+        .iter()
+        .enumerate()
+        .map(|(index, change_id)| {
+            let marker = if index == 0 { "@" } else { "○" };
+            format!("{marker}  {change_id} {change_id} summary\n")
+        })
+        .collect::<String>();
+    let entries = change_ids
+        .iter()
+        .enumerate()
+        .map(|(index, change_id)| {
+            jk_core::LogEntry::new(*change_id, "commit", format!("{change_id} summary"))
+                .with_rendered_line(index)
+        })
+        .collect();
+    AppView::Log(LogView::new(
+        jk_core::LogSnapshot::new(rendered, entries).with_title("jj log"),
+    ))
+}
+
+pub fn buffer_line(buffer: &ratatui::buffer::Buffer, y: u16) -> String {
+    (0..buffer.area.width)
+        .map(|x| buffer[(x, y)].symbol())
+        .collect::<String>()
+}
+
+pub fn workspace_app_view() -> WorkspacesView {
+    WorkspacesView::new(WorkspaceViewSnapshot::new(vec![
+        WorkspaceViewRow::new("default", "/repo/default", false).with_root("/repo/default"),
+        WorkspaceViewRow::new("dogfood", "/repo/dogfood", true).with_root("/repo/dogfood"),
+    ]))
+}
+
+pub fn append_history_record(
+    history: &mut CommandHistory,
+    spec: jk_core::JjCommandSpec,
+    view: SourceView,
+    action: SourceAction,
+) {
+    append_history_record_with_operation_id(history, spec, view, action, None);
+}
+
+pub fn append_history_record_with_operation_id(
+    history: &mut CommandHistory,
+    spec: jk_core::JjCommandSpec,
+    view: SourceView,
+    action: SourceAction,
+    operation_id: Option<&str>,
+) {
+    let start = jk_core::CommandRecordStart::from_spec(&spec, CommandSource::new(view, action))
+        .with_started_at(std::time::SystemTime::UNIX_EPOCH);
+    let mut finish = jk_core::CommandRecordFinish::from_exit_code(
+        0,
+        "",
+        "",
+        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(1),
+    );
+    finish.operation_id = operation_id.map(str::to_owned);
+    history.append(start, finish);
+}
+
+pub fn output(code: i32, stdout: &str, stderr: &str) -> Output {
+    Output {
+        status: exit_status(code),
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: stderr.as_bytes().to_vec(),
+    }
+}
+
+pub struct SequencedRunner {
+    outputs: VecDeque<io::Result<Output>>,
+}
+
+impl SequencedRunner {
+    pub(crate) fn successes(outputs: Vec<Output>) -> Self {
+        Self {
+            outputs: outputs.into_iter().map(Ok).collect(),
+        }
+    }
+}
+
+impl JjCommandRunner for SequencedRunner {
+    fn run(&mut self, _spec: &jk_core::JjCommandSpec) -> io::Result<Output> {
+        self.outputs
+            .pop_front()
+            .expect("runner called too many times")
+    }
+}
+
+#[cfg(unix)]
+fn exit_status(code: i32) -> std::process::ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+
+    std::process::ExitStatus::from_raw(code << 8)
+}
+
+#[cfg(not(unix))]
+fn exit_status(code: i32) -> std::process::ExitStatus {
+    std::process::Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+        .args(if cfg!(windows) {
+            vec!["/C".into(), format!("exit {code}").into()]
+        } else {
+            vec!["-c".into(), format!("exit {code}").into()]
+        })
+        .status()
+        .unwrap()
+}

--- a/crates/jk/src/workspace_routes.rs
+++ b/crates/jk/src/workspace_routes.rs
@@ -1,0 +1,255 @@
+use jk_cli::{
+    JjCommandRunner, JjStatus, JjWorkspaces, RecordingJjCommandRunner, StatusQuery,
+    SystemJjCommandRunner, WorkspaceInspectionQuery,
+};
+use jk_core::{CommandSource, SourceAction, SourceView};
+use jk_tui::rendered_view::RenderedView;
+use jk_tui::workspaces_view::{WorkspaceViewSnapshot, WorkspacesView};
+
+use crate::refresh::refresh_workspaces_with_runner;
+use crate::state::{AppState, AppView};
+use crate::workspaces::{update_stale_success_message, workspace_view_snapshot};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceInspectionKind {
+    Log,
+    Status,
+    Diff,
+}
+
+pub fn push_status(state: &mut AppState, status_source: &JjStatus) {
+    push_status_with_runner(state, status_source, SystemJjCommandRunner);
+}
+
+pub fn push_status_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    status_source: &JjStatus,
+    runner: R,
+) {
+    if !matches!(state.views.active(), AppView::Log(_)) {
+        return;
+    }
+
+    let query = StatusQuery::default();
+    let mut runner = RecordingJjCommandRunner::new(
+        runner,
+        &mut state.history,
+        CommandSource::new(SourceView::Log, SourceAction::OpenStatus),
+    );
+    match status_source.load_query_with_runner(&query, &mut runner) {
+        Ok(snapshot) => {
+            state.views.push(AppView::Status {
+                view: RenderedView::new(snapshot),
+                query,
+            });
+        }
+        Err(error) => {
+            if let AppView::Log(log) = state.views.active_mut() {
+                log.show_error(error.to_string());
+            }
+        }
+    }
+}
+
+pub fn open_workspaces(state: &mut AppState, workspaces_source: &JjWorkspaces) {
+    open_workspaces_with_runner(state, workspaces_source, SystemJjCommandRunner);
+}
+
+pub fn open_workspaces_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    workspaces_source: &JjWorkspaces,
+    runner: R,
+) {
+    if matches!(state.views.active(), AppView::Workspaces { .. }) {
+        let AppState { views, history, .. } = state;
+        if let AppView::Workspaces { view } = views.active_mut() {
+            refresh_workspaces_with_runner(view, history, workspaces_source, runner);
+        }
+        return;
+    }
+
+    push_workspaces_with_runner(
+        state,
+        workspaces_source,
+        CommandSource::new(SourceView::Log, SourceAction::WorkspaceList),
+        runner,
+    );
+}
+
+fn push_workspaces_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    workspaces_source: &JjWorkspaces,
+    source: CommandSource,
+    runner: R,
+) {
+    let mut runner = RecordingJjCommandRunner::new(runner, &mut state.history, source);
+    let view = match workspaces_source.load_list_with_runner(&mut runner) {
+        Ok(snapshot) => WorkspacesView::new(workspace_view_snapshot(snapshot)),
+        Err(error) => {
+            let mut view = WorkspacesView::new(WorkspaceViewSnapshot::new(Vec::new()));
+            view.show_error(error.to_string());
+            view
+        }
+    };
+    push_workspace_view(state, view);
+}
+
+pub fn push_workspace_view(state: &mut AppState, view: WorkspacesView) {
+    state.views.push(AppView::Workspaces { view });
+}
+
+pub fn push_selected_workspace_status(state: &mut AppState, workspaces_source: &JjWorkspaces) {
+    push_selected_workspace_inspection_with_runner(
+        state,
+        workspaces_source,
+        WorkspaceInspectionKind::Status,
+        SystemJjCommandRunner,
+    );
+}
+
+pub fn push_selected_workspace_log(state: &mut AppState, workspaces_source: &JjWorkspaces) {
+    push_selected_workspace_inspection_with_runner(
+        state,
+        workspaces_source,
+        WorkspaceInspectionKind::Log,
+        SystemJjCommandRunner,
+    );
+}
+
+#[cfg(test)]
+pub fn push_selected_workspace_log_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    workspaces_source: &JjWorkspaces,
+    runner: R,
+) {
+    push_selected_workspace_inspection_with_runner(
+        state,
+        workspaces_source,
+        WorkspaceInspectionKind::Log,
+        runner,
+    );
+}
+
+pub fn push_selected_workspace_diff(state: &mut AppState, workspaces_source: &JjWorkspaces) {
+    push_selected_workspace_inspection_with_runner(
+        state,
+        workspaces_source,
+        WorkspaceInspectionKind::Diff,
+        SystemJjCommandRunner,
+    );
+}
+
+fn push_selected_workspace_inspection_with_runner<R: JjCommandRunner>(
+    state: &mut AppState,
+    workspaces_source: &JjWorkspaces,
+    kind: WorkspaceInspectionKind,
+    runner: R,
+) {
+    let query = {
+        let AppView::Workspaces { view } = state.views.active_mut() else {
+            return;
+        };
+        let Some(row) = view.selected_row() else {
+            return;
+        };
+        let Some(root) = row.root().map(ToOwned::to_owned) else {
+            view.show_error(format!("workspace `{}` has no root", row.name));
+            return;
+        };
+        WorkspaceInspectionQuery::new(root)
+    };
+
+    let command_source = match kind {
+        WorkspaceInspectionKind::Log => {
+            CommandSource::new(SourceView::Workspaces, SourceAction::WorkspaceLog)
+        }
+        WorkspaceInspectionKind::Status => {
+            CommandSource::new(SourceView::Workspaces, SourceAction::WorkspaceStatus)
+        }
+        WorkspaceInspectionKind::Diff => {
+            CommandSource::new(SourceView::Workspaces, SourceAction::WorkspaceDiff)
+        }
+    };
+    let mut runner = RecordingJjCommandRunner::new(runner, &mut state.history, command_source);
+    let snapshot = match kind {
+        WorkspaceInspectionKind::Log => workspaces_source.load_log_with_runner(&query, &mut runner),
+        WorkspaceInspectionKind::Status => {
+            workspaces_source.load_status_with_runner(&query, &mut runner)
+        }
+        WorkspaceInspectionKind::Diff => {
+            workspaces_source.load_diff_with_runner(&query, &mut runner)
+        }
+    };
+    match snapshot {
+        Ok(snapshot) => {
+            let view = RenderedView::new(snapshot);
+            let app_view = match kind {
+                WorkspaceInspectionKind::Log => AppView::WorkspaceLog { view, query },
+                WorkspaceInspectionKind::Status => AppView::WorkspaceStatus { view, query },
+                WorkspaceInspectionKind::Diff => AppView::WorkspaceDiff { view, query },
+            };
+            state.views.push(app_view);
+        }
+        Err(error) => {
+            if let AppView::Workspaces { view } = state.views.active_mut() {
+                view.show_error(error.to_string());
+            }
+        }
+    }
+}
+
+pub fn update_selected_workspace_stale(state: &mut AppState, workspaces_source: &JjWorkspaces) {
+    let (workspace_name, query) = {
+        let AppView::Workspaces { view } = state.views.active_mut() else {
+            return;
+        };
+        let Some(row) = view.selected_row() else {
+            view.show_status("No workspace selected");
+            return;
+        };
+        let workspace_name = row.name.clone();
+        let Some(root) = row.root().map(ToOwned::to_owned) else {
+            view.show_error(format!("workspace `{}` has no root", row.name));
+            return;
+        };
+        (workspace_name, WorkspaceInspectionQuery::new(root))
+    };
+
+    let mut update_runner = crate::recording_runner(
+        &mut state.history,
+        CommandSource::new(SourceView::Workspaces, SourceAction::WorkspaceUpdateStale),
+    );
+    match workspaces_source.update_stale_with_runner(&query, &mut update_runner) {
+        Ok(outcome) => {
+            let success = update_stale_success_message(
+                &workspace_name,
+                &outcome.title,
+                &outcome.stderr,
+                &outcome.stdout,
+            );
+            let refresh_result = {
+                let mut refresh_runner = crate::recording_runner(
+                    &mut state.history,
+                    CommandSource::new(SourceView::Workspaces, SourceAction::Refresh),
+                );
+                workspaces_source.load_list_with_runner(&mut refresh_runner)
+            };
+            if let AppView::Workspaces { view } = state.views.active_mut() {
+                match refresh_result {
+                    Ok(snapshot) => {
+                        view.refresh(workspace_view_snapshot(snapshot));
+                        view.show_status(success);
+                    }
+                    Err(error) => {
+                        view.show_status(format!("{success}; refresh failed: {error}"));
+                    }
+                }
+            }
+        }
+        Err(error) => {
+            if let AppView::Workspaces { view } = state.views.active_mut() {
+                view.show_error(error.to_string());
+            }
+        }
+    }
+}

--- a/crates/jk/src/workspaces.rs
+++ b/crates/jk/src/workspaces.rs
@@ -1,0 +1,216 @@
+use jk_cli::{WorkspaceListSnapshot, WorkspaceSummary};
+use jk_tui::log_view::LogAction;
+use jk_tui::rendered_view::RenderedAction;
+use jk_tui::workspaces_view::{WorkspaceViewRow, WorkspaceViewSnapshot, WorkspacesAction};
+
+pub fn workspace_view_snapshot(snapshot: WorkspaceListSnapshot) -> WorkspaceViewSnapshot {
+    let rows = snapshot
+        .workspaces
+        .into_iter()
+        .map(workspace_view_row)
+        .collect();
+    WorkspaceViewSnapshot::new(rows).with_title(snapshot.title)
+}
+
+fn workspace_view_row(workspace: WorkspaceSummary) -> WorkspaceViewRow {
+    let root_display = workspace
+        .root
+        .as_ref()
+        .map_or_else(|| "(no root)".to_owned(), |root| root.display().to_string());
+    let mut row = WorkspaceViewRow::new(workspace.name, root_display, workspace.current);
+    if let Some(root) = workspace.root {
+        row = row.with_root(root);
+    }
+    if let Some(change_id) = workspace.change_id {
+        row = row.with_change_id(change_id);
+    }
+    if let Some(commit_id) = workspace.commit_id {
+        row = row.with_commit_id(commit_id);
+    }
+    row
+}
+
+pub fn update_stale_success_message(
+    workspace_name: &str,
+    command: &str,
+    stderr: &str,
+    stdout: &str,
+) -> String {
+    let command = compact_update_stale_command(command);
+    let output = compact_command_output(stderr).or_else(|| compact_command_output(stdout));
+    match output {
+        Some(output) => format!("updated {workspace_name} via {command}: {output}"),
+        None => format!("updated {workspace_name} via {command}"),
+    }
+}
+
+pub const fn workspace_action_for_log_action(action: LogAction) -> WorkspacesAction {
+    match action {
+        LogAction::Previous => WorkspacesAction::Previous,
+        LogAction::Next => WorkspacesAction::Next,
+        LogAction::ScrollPreviousLine => WorkspacesAction::ScrollPreviousLine,
+        LogAction::ScrollNextLine => WorkspacesAction::ScrollNextLine,
+        LogAction::PagePrevious => WorkspacesAction::Previous,
+        LogAction::PageNext => WorkspacesAction::Next,
+        LogAction::First => WorkspacesAction::First,
+        LogAction::Last => WorkspacesAction::Last,
+        LogAction::Refresh => WorkspacesAction::Refresh,
+        LogAction::OpenDiff => WorkspacesAction::OpenDiff,
+        LogAction::ToggleExpanded => WorkspacesAction::OpenLog,
+        LogAction::ToggleHelp => WorkspacesAction::ToggleHelp,
+        LogAction::Quit => WorkspacesAction::Quit,
+        LogAction::Home | LogAction::Log | LogAction::CollapseExpanded => {
+            WorkspacesAction::ReturnBack
+        }
+        _ => WorkspacesAction::ReturnBack,
+    }
+}
+
+pub const fn workspace_inspection_action_for_log_action(action: LogAction) -> RenderedAction {
+    match action {
+        LogAction::Previous => RenderedAction::ScrollPrevious,
+        LogAction::Next => RenderedAction::ScrollNext,
+        LogAction::ScrollPreviousLine => RenderedAction::ScrollPrevious,
+        LogAction::ScrollNextLine => RenderedAction::ScrollNext,
+        LogAction::PagePrevious => RenderedAction::PagePrevious,
+        LogAction::PageNext => RenderedAction::PageNext,
+        LogAction::ToggleMark => RenderedAction::PageNext,
+        LogAction::ClearMarks => RenderedAction::Ignore,
+        LogAction::First => RenderedAction::First,
+        LogAction::Last => RenderedAction::Last,
+        LogAction::ToggleHelp => RenderedAction::ToggleHelp,
+        LogAction::Refresh => RenderedAction::Refresh,
+        LogAction::Quit => RenderedAction::Quit,
+        _ => RenderedAction::ReturnToLog,
+    }
+}
+
+fn compact_update_stale_command(command: &str) -> &str {
+    command
+        .strip_prefix("jj -R ")
+        .and_then(|command| command.split_once(" workspace update-stale"))
+        .map_or(command, |_| "workspace update-stale")
+}
+
+fn compact_command_output(output: &str) -> Option<String> {
+    let first_line = output.lines().find(|line| !line.trim().is_empty())?.trim();
+    const MAX_STATUS_CHARS: usize = 120;
+    if first_line.chars().count() <= MAX_STATUS_CHARS {
+        Some(first_line.to_owned())
+    } else {
+        let mut summary = first_line
+            .chars()
+            .take(MAX_STATUS_CHARS.saturating_sub(3))
+            .collect::<String>();
+        summary.push_str("...");
+        Some(summary)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn snapshot_mapping_preserves_row_fields() {
+        let snapshot = WorkspaceListSnapshot {
+            title: "jj workspace list".to_owned(),
+            workspaces: vec![WorkspaceSummary {
+                name: "dogfood".to_owned(),
+                root: Some(PathBuf::from("/repo/dogfood")),
+                current: true,
+                change_id: Some("abc123".to_owned()),
+                commit_id: Some("def456".to_owned()),
+            }],
+        };
+
+        let snapshot = workspace_view_snapshot(snapshot);
+
+        assert_eq!(snapshot.title(), "jj workspace list");
+        assert_eq!(
+            snapshot.rows(),
+            &[WorkspaceViewRow::new("dogfood", "/repo/dogfood", true)
+                .with_root("/repo/dogfood")
+                .with_change_id("abc123")
+                .with_commit_id("def456")]
+        );
+    }
+
+    #[test]
+    fn update_stale_success_message_prefers_stderr_then_stdout() {
+        assert_eq!(
+            update_stale_success_message(
+                "dogfood",
+                "jj -R /repo/dogfood workspace update-stale",
+                "warning line",
+                "stdout line",
+            ),
+            "updated dogfood via workspace update-stale: warning line"
+        );
+
+        assert_eq!(
+            update_stale_success_message(
+                "dogfood",
+                "jj -R /repo/dogfood workspace update-stale",
+                "",
+                "stdout line",
+            ),
+            "updated dogfood via workspace update-stale: stdout line"
+        );
+
+        assert_eq!(
+            update_stale_success_message("dogfood", "jj workspace update-stale", "", ""),
+            "updated dogfood via jj workspace update-stale"
+        );
+    }
+
+    #[test]
+    fn workspace_action_mapping_preserves_workspace_policy() {
+        assert_eq!(
+            workspace_action_for_log_action(LogAction::Next),
+            WorkspacesAction::Next
+        );
+        assert_eq!(
+            workspace_action_for_log_action(LogAction::PageNext),
+            WorkspacesAction::Next
+        );
+        assert_eq!(
+            workspace_action_for_log_action(LogAction::OpenDiff),
+            WorkspacesAction::OpenDiff
+        );
+        assert_eq!(
+            workspace_action_for_log_action(LogAction::ToggleExpanded),
+            WorkspacesAction::OpenLog
+        );
+        assert_eq!(
+            workspace_action_for_log_action(LogAction::Home),
+            WorkspacesAction::ReturnBack
+        );
+    }
+
+    #[test]
+    fn workspace_inspection_action_mapping_preserves_rendered_policy() {
+        assert_eq!(
+            workspace_inspection_action_for_log_action(LogAction::Next),
+            RenderedAction::ScrollNext
+        );
+        assert_eq!(
+            workspace_inspection_action_for_log_action(LogAction::ToggleMark),
+            RenderedAction::PageNext
+        );
+        assert_eq!(
+            workspace_inspection_action_for_log_action(LogAction::ClearMarks),
+            RenderedAction::Ignore
+        );
+        assert_eq!(
+            workspace_inspection_action_for_log_action(LogAction::Refresh),
+            RenderedAction::Refresh
+        );
+        assert_eq!(
+            workspace_inspection_action_for_log_action(LogAction::OpenDiff),
+            RenderedAction::ReturnToLog
+        );
+    }
+}

--- a/docs/plans/0001-command-spec.md
+++ b/docs/plans/0001-command-spec.md
@@ -1,7 +1,7 @@
 # Command Spec Foundation
 
 Status: draft  
-Owner: implementation spike  
+Owner: current dogfood workspace pass  
 Scope: first foundation implementation chunk
 
 ## Problem

--- a/docs/plans/0002-keymap-help-data.md
+++ b/docs/plans/0002-keymap-help-data.md
@@ -1,7 +1,7 @@
 # Keymap Help Data Foundation
 
 Status: draft  
-Owner: implementation spike  
+Owner: current dogfood workspace pass  
 Scope: first keymap/help implementation chunk
 
 ## Problem

--- a/docs/plans/0003-view-stack-foundation.md
+++ b/docs/plans/0003-view-stack-foundation.md
@@ -1,7 +1,7 @@
 # View Stack Foundation
 
 Status: draft  
-Owner: implementation spike  
+Owner: `dogfood-view-stack` workspace pass  
 Scope: first view-stack/mode-stack implementation chunk
 
 ## Problem

--- a/docs/plans/0004-inspection-foundation.md
+++ b/docs/plans/0004-inspection-foundation.md
@@ -2,7 +2,7 @@
 
 Status: draft
 
-Owner: implementation spike
+Owner: `dogfood-inspection-spec` workspace pass
 
 Scope: first `jj`-shaped inspection roadmap bucket after foundation
 

--- a/docs/plans/0005-log-template-selection.md
+++ b/docs/plans/0005-log-template-selection.md
@@ -2,14 +2,14 @@
 
 Status: draft
 
-Owner: implementation spike
+Owner: `dogfood-log-template-selection` workspace pass
 
 Scope: first log template chooser and startup-template implementation chunk
 
 Planning update: the [CLI surface addendum](cli-surface-addendum.md) keeps this startup-template
 work, but changes the long-term in-app key shape. `T` is reserved for the tags screen, standalone
 `v` is reserved for `evolog`, and template switching should become a log-specific branch of the
-reusable `V` View Options overlay. The current implementation has a temporary standalone `T`
+reusable `V` View Options overlay. The current dogfood implementation has a temporary standalone `T`
 popup because View Options did not exist yet; migrate that popup under `V` before turning the slice
 into review-ready product work.
 
@@ -139,8 +139,8 @@ Collision notes:
 - lowercase `v` is reserved for standalone `jj evolog`;
 - keep templates under `V` so log templates, graph/list flags, and diff display flags share one
   View Options model.
-- the current `T` popup is acceptable only as a temporary precursor to `V` while this remains a
-  local spike.
+- the current dogfood `T` popup is acceptable only as a temporary precursor to `V` while this
+  remains local dogfood work.
 
 Visible help/hotbar:
 

--- a/docs/plans/0006-searchable-command-discovery.md
+++ b/docs/plans/0006-searchable-command-discovery.md
@@ -2,7 +2,7 @@
 
 Status: draft
 
-Owner: implementation spike
+Owner: `dogfood-searchable-command-discovery` workspace pass
 
 Scope: first searchable help and command-discovery implementation chunk
 
@@ -46,7 +46,7 @@ not replace the future `:` command mode.
 
 ## Current Dependencies
 
-This plan assumes the current spike state rather than only the earlier written plans:
+This plan assumes the current dogfood state state rather than only the earlier written plans:
 
 1. `0001-command-spec.md`: `JjCommandSpec` exists for read-only `jj` command metadata.
 1. `0002-keymap-help-data.md`: `crates/jk-tui/src/keymap.rs` owns generated help and hotbar
@@ -54,7 +54,7 @@ This plan assumes the current spike state rather than only the earlier written p
 1. `0003-view-stack-foundation.md`: `crates/jk/src/main.rs` owns `ViewStack`, `ModeStack`, and
    transient input modes.
 1. `0004-inspection-foundation.md`: diff/show/status query sources and pushed inspection views
-   exist in the current spike.
+   exist in the current dogfood state.
 1. `0005-log-template-selection.md`: the log template popup selector provides a nearby overlay and
    selection precedent.
 

--- a/docs/plans/0007-ordered-revision-marks.md
+++ b/docs/plans/0007-ordered-revision-marks.md
@@ -2,7 +2,7 @@
 
 Status: draft
 
-Owner: implementation spike
+Owner: `dogfood-ordered-revision-marks` workspace pass
 
 Scope: first ordered revision mark implementation chunk
 

--- a/docs/plans/0008-view-options-overlay.md
+++ b/docs/plans/0008-view-options-overlay.md
@@ -1,8 +1,8 @@
 # View Options Overlay
 
-Status: implemented in the current implementation spike
+Status: implemented in the current dogfood work
 
-Owner: implementation spike
+Owner: `dogfood-view-options-overlay` workspace pass
 
 Scope: first reusable View Options overlay chunk, centered on moving log template selection under
 `V`
@@ -53,7 +53,7 @@ existing log-template selector from a `Template` row inside that overlay.
 
 ## Pre-Slice State
 
-This plan was written from the pre-slice implementation workspace state:
+This plan was written from the pre-slice current dogfood workspace state:
 
 1. `crates/jk-cli/src/log.rs` already owns `LogTemplateSelection`, built-in template aliases,
    startup custom templates, and `JjLog::template_options`.

--- a/docs/plans/0009-global-run-options-foundation.md
+++ b/docs/plans/0009-global-run-options-foundation.md
@@ -1,8 +1,8 @@
 # Global Run Options Foundation
 
-Status: first foundation chunk implemented in the current implementation spike
+Status: first foundation chunk implemented in the current dogfood work
 
-Owner: implementation spike
+Owner: `dogfood-global-run-options` workspace pass
 
 Scope: smallest foundation slice after `0008-view-options-overlay.md`
 

--- a/docs/plans/0010-selected-change-evolog.md
+++ b/docs/plans/0010-selected-change-evolog.md
@@ -2,7 +2,7 @@
 
 Status: draft
 
-Owner: implementation spike
+Owner: current dogfood workspace pass
 
 Scope: first selected-change evolution-log implementation slice
 
@@ -54,7 +54,7 @@ jj evolog -r abc123
 
 ## Context
 
-This slice follows the foundations already present in the implementation workspace:
+This slice follows the foundations already present in the current dogfood workspace:
 
 1. `JjCommandSpec` and `GlobalOptions` are implemented in `jk-core`.
 1. `JjShow` and `JjStatus` prove the `InspectionSnapshot` source pattern.

--- a/docs/plans/0011-adaptive-hotbar.md
+++ b/docs/plans/0011-adaptive-hotbar.md
@@ -1,8 +1,8 @@
 # Adaptive Hotbar Slice
 
-Status: implemented in the current implementation spike
+Status: implemented in the current dogfood work
 
-Owner: implementation spike
+Owner: current dogfood workspace pass
 
 Scope: first width-aware hotbar/status implementation chunk
 
@@ -45,7 +45,7 @@ letting Ratatui clip a long string.
 
 ## Context
 
-This plan assumes the current implementation workspace state:
+This plan assumes the current dogfood workspace state:
 
 1. `crates/jk-tui/src/keymap.rs` owns `BindingContext`, hotbar labels, `hotbar_rank`, generated
    help rows, and searchable discovery rows.

--- a/docs/plans/0012-workspace-scope.md
+++ b/docs/plans/0012-workspace-scope.md
@@ -2,7 +2,7 @@
 
 Status: draft/spec
 
-Owner: implementation spike
+Owner: current dogfood workspace pass
 
 Scope: first early workspace implementation slice
 
@@ -56,7 +56,7 @@ The CLI surface addendum assigns scoped workspace keys:
 - `o`: operation log;
 - `V`: view/sparse options.
 
-This slice assumes the current implementation foundation:
+This slice assumes the current dogfood foundation:
 
 1. `JjCommandSpec` and `GlobalOptions` exist in `jk-core`.
 1. Read-only inspection providers exist for status, diff, show, and evolog.
@@ -103,7 +103,7 @@ The implementation order should be:
 - Open selected-workspace status and diff as ordinary rendered inspection child views.
 - Preserve workspace selection across refreshes when the selected workspace still exists.
 - Provide generated help, searchable discovery, and an adaptive hotbar for workspace actions.
-- Add tests and Betamax evidence under `target/jk-artifacts`.
+- Add tests and Betamax evidence under `target/dogfood-artifacts`.
 
 ## Non-Goals
 
@@ -406,8 +406,8 @@ facts scannable:
 Use concise markers and avoid dense prose in row text. A possible row shape:
 
 ```text
-> * feature    current   /path/to/repo/feature
-    default    stale     /path/to/repo/default
+> * dogfood       current   /Users/joshka/local/jk/dogfood
+    default   stale     /Users/joshka/local/jk/default
 ```
 
 The title should make the command source clear:
@@ -546,17 +546,17 @@ the fixture.
 
 ## Betamax Evidence Plan
 
-Store first-slice evidence under `target/jk-artifacts/` so the spike has durable local proof
+Store first-slice evidence under `target/dogfood-artifacts/` so the pass has durable local proof
 without committing generated media to the repo.
 
 Suggested artifacts:
 
 ```text
-target/jk-artifacts/workspaces-list.txt
-target/jk-artifacts/workspaces-status.txt
-target/jk-artifacts/workspaces-diff.txt
-target/jk-artifacts/workspaces-help.txt
-target/jk-artifacts/workspaces-empty-or-error.txt
+target/dogfood-artifacts/workspaces-list.txt
+target/dogfood-artifacts/workspaces-status.txt
+target/dogfood-artifacts/workspaces-diff.txt
+target/dogfood-artifacts/workspaces-help.txt
+target/dogfood-artifacts/workspaces-empty-or-error.txt
 ```
 
 Suggested tapes:

--- a/docs/plans/0013-workspace-update-stale.md
+++ b/docs/plans/0013-workspace-update-stale.md
@@ -2,7 +2,7 @@
 
 Status: draft/spec
 
-Owner: implementation spike
+Owner: current dogfood workspace pass
 
 Scope: second workspace implementation slice
 
@@ -218,7 +218,7 @@ If the update-stale command succeeds but list refresh fails:
 Example:
 
 ```text
-updated workspace; refresh failed: jj workspace list failed: ...
+updated dogfood; refresh failed: jj workspace list failed: ...
 ```
 
 If stale-state display is available by implementation time, the refreshed row should no longer show
@@ -247,7 +247,7 @@ a one-line summary. A future command-output/history screen can expose the full c
 
 ## Betamax Evidence
 
-Add Betamax evidence under `target/jk-artifacts` for the full Workspaces stale-update journey.
+Add Betamax evidence under `target/dogfood-artifacts` for the full Workspaces stale-update journey.
 The evidence should prove the user-visible behavior, not just unit-level command construction.
 
 Suggested tape:
@@ -377,7 +377,7 @@ This plan is ready for implementation when the next slice can be described as:
 - `s` and `d` continue to inspect the selected workspace after the update.
 - generated help, hotbar, and searchable discovery include the `u` action.
 - tests cover command shape, view state, app wiring, and stale-workspace fixture behavior.
-- Betamax artifacts prove the stale update journey under `target/jk-artifacts`.
+- Betamax artifacts prove the stale update journey under `target/dogfood-artifacts`.
 
 ## Deferred Follow-Up
 

--- a/docs/plans/0014-command-history-foundation.md
+++ b/docs/plans/0014-command-history-foundation.md
@@ -2,7 +2,7 @@
 
 Status: draft/spec
 
-Owner: implementation spike
+Owner: current dogfood workspace pass
 
 Scope: first command-history implementation slice after Workspaces
 
@@ -332,7 +332,7 @@ Persist by default:
 
 - recent command records in process memory;
 - bounded stdout/stderr snippets in process memory;
-- Betamax/test artifacts under `target/jk-artifacts` when validation asks for them.
+- Betamax/test artifacts under `target/dogfood-artifacts` when validation asks for them.
 
 Do not persist by default:
 
@@ -350,7 +350,7 @@ Future cross-session history can use the product-plan location:
 $XDG_STATE_HOME/jk/command-log
 ```
 
-That is deliberately out of scope here. This spike should make the in-memory model and UI stable
+That is deliberately out of scope here. This pass should make the in-memory model and UI stable
 before choosing file format, migration, retention limits, or user config keys.
 
 ### Redaction
@@ -401,7 +401,7 @@ First-slice app runs should use `SummaryOnly`. Betamax and explicit debug paths 
 under:
 
 ```text
-target/jk-artifacts/command-history/
+target/dogfood-artifacts/command-history/
 ```
 
 Artifact paths must stay local, ignored, and reproducible. Do not add committed media or committed
@@ -603,7 +603,7 @@ mutation history. Keep fixture setup isolated from the developer's real checkout
 
 ## Betamax Evidence
 
-Add Betamax evidence under `target/jk-artifacts`. The goal is to prove visible behavior and local
+Add Betamax evidence under `target/dogfood-artifacts`. The goal is to prove visible behavior and local
 artifact boundaries, not to commit generated output.
 
 Suggested tape:
@@ -626,10 +626,10 @@ Suggested journey:
 Suggested local artifacts:
 
 ```text
-target/jk-artifacts/command-history/history-screen.txt
-target/jk-artifacts/command-history/history-details.txt
-target/jk-artifacts/command-history/records.json
-target/jk-artifacts/command-history/redaction.txt
+target/dogfood-artifacts/command-history/history-screen.txt
+target/dogfood-artifacts/command-history/history-details.txt
+target/dogfood-artifacts/command-history/records.json
+target/dogfood-artifacts/command-history/redaction.txt
 ```
 
 The `records.json` artifact should contain redacted records only. If full output artifacts are
@@ -652,7 +652,7 @@ This plan is ready for implementation when the next slice can be described as:
 - Existing command behavior stays materially unchanged.
 - Tests cover the model, runner recording, UI entry point, redaction, retention, and workspace
   update-stale behavior.
-- Betamax artifacts under `target/jk-artifacts` prove the user-visible journey.
+- Betamax artifacts under `target/dogfood-artifacts` prove the user-visible journey.
 
 ## Follow-Up Slices
 

--- a/docs/plans/0015-safe-mutation-preview-foundation.md
+++ b/docs/plans/0015-safe-mutation-preview-foundation.md
@@ -2,7 +2,7 @@
 
 Status: draft/spec
 
-Owner: implementation spike
+Owner: current dogfood workspace pass
 
 Scope: first mutation-preview implementation slice after Command History
 
@@ -197,10 +197,10 @@ Add Betamax evidence under local artifacts, not committed generated media:
 
 ```text
 tapes/validation/safe-mutation-preview-foundation.tape
-target/jk-artifacts/safe-mutation-preview/preview-cancel.txt
-target/jk-artifacts/safe-mutation-preview/preview-confirm.txt
-target/jk-artifacts/safe-mutation-preview/history-after-confirm.txt
-target/jk-artifacts/safe-mutation-preview/failure-output.txt
+target/dogfood-artifacts/safe-mutation-preview/preview-cancel.txt
+target/dogfood-artifacts/safe-mutation-preview/preview-confirm.txt
+target/dogfood-artifacts/safe-mutation-preview/history-after-confirm.txt
+target/dogfood-artifacts/safe-mutation-preview/failure-output.txt
 ```
 
 The tape should use an isolated fixture repository and prove this journey:
@@ -251,7 +251,7 @@ This implementation slice is ready when:
 - advanced unsafe options are absent unless already present in the typed spec from a future source;
 - tests cover preview state, cancellation, confirmation, runner recording, refresh behavior,
   global-option ordering, and failure output;
-- Betamax artifacts under `target/jk-artifacts` prove the cancel, confirm, refresh, and history
+- Betamax artifacts under `target/dogfood-artifacts` prove the cancel, confirm, refresh, and history
   journey.
 
 ## Dependency Order

--- a/docs/plans/0016-operation-recovery-foundation.md
+++ b/docs/plans/0016-operation-recovery-foundation.md
@@ -2,7 +2,7 @@
 
 Status: draft/spec
 
-Owner: implementation spike
+Owner: current dogfood workspace pass
 
 Scope: bounded operation-recovery foundation after the first safe mutation flow
 
@@ -343,7 +343,7 @@ Betamax evidence should live under local ignored artifacts:
 
 ```text
 tapes/validation/operation-recovery-foundation.tape
-target/jk-artifacts/operation-recovery/
+target/dogfood-artifacts/operation-recovery/
 ```
 
 - Open operation log: `op-log.txt` proves `o` opens a focused Operation Log screen from a fixture.
@@ -404,7 +404,7 @@ This slice is ready when:
 - generated help and hotbar text include only actions that are actually enabled;
 - tests cover command-spec ordering, safety classification, selector routing, disabled recovery
   keys, command-history operation routing, and operation time-travel labels;
-- Betamax artifacts under `target/jk-artifacts/operation-recovery/` prove the read-only op-log
+- Betamax artifacts under `target/dogfood-artifacts/operation-recovery/` prove the read-only op-log
   journey and any enabled confirmation journey.
 
 ## Dependency Order

--- a/docs/plans/0017-dogfood-backlog-order.md
+++ b/docs/plans/0017-dogfood-backlog-order.md
@@ -1,6 +1,6 @@
 # Dogfood Backlog Order
 
-This note records the current implementation spike ordering for dogfoodable progress. It is intentionally
+This note records the current dogfood work ordering for dogfoodable progress. It is intentionally
 more execution-oriented than the product plan: finish the tight recovery and command surfaces first,
 then broaden into mutation flows, selectors, run options, and generated help.
 
@@ -35,6 +35,11 @@ then broaden into mutation flows, selectors, run options, and generated help.
    in multi-file diffs.
 1. Done: add diff file list overlay. Pressing `f` from a diff shows files in the current diff,
    preserves the active file as the selected row, and jumps to the chosen file on Enter.
+1. Done: polish selector menus and help ordering. View menus now wrap at the edges, View Options
+   opens on the active diff format, and generated help reads in task-first order instead of raw
+   registry order.
+1. Stabilize the current dogfood surface for release. Audit stack descriptions, code shape, docs,
+   README/crate README, Betamax media, and website handoff before starting rebase-specific work.
 
 ## First Useful Mutation Sprint
 
@@ -45,10 +50,14 @@ then broaden into mutation flows, selectors, run options, and generated help.
    for `jj new`; ordered marks become parents when present, otherwise the selected revision is the
    parent. Enter runs it, refreshes the log, records history with the resulting operation id, and
    exposes recovery actions.
-1. Add `jj edit` preview flow: move working copy to selected change, with warning when the action
-   may surprise.
-1. Add inline describe polish: multiline/editor describe, better prompt editing, and clearer
-   before/after description display.
+1. Done: add `jj edit` preview flow. Pressing `e` on the selected log revision opens a
+   local-rewrite command preview for `jj edit REV`; Enter runs it, refreshes the log, records
+   history with the resulting operation id, and exposes recovery actions.
+1. Done: add inline describe prompt prefill and clear. Pressing `m` opens the prompt with the
+   selected revision's current full description, and `Ctrl-u` clears the prompt before preview.
+1. Add remaining describe polish: multiline/editor describe and clearer before/after description
+   display.
+1. Release the stabilized dogfood milestone before starting rebase-specific behavior.
 1. Add minimal rebase preview: resolve source/destination from marks plus cursor and show exact
    `jj rebase` command before running.
 1. Add rebase destination search: search/filter the log while choosing a destination.
@@ -105,7 +114,7 @@ then broaden into mutation flows, selectors, run options, and generated help.
 - Treat items 13-22 as the first useful mutation sprint.
 - Treat items 23-30 as the point where roadmap foundation needs to catch up before broadening
   further.
-- For the near-term implementation spike, favor direct implementation in the orchestration thread
-  for small app wiring, crash fixes, and live `cargo run` feedback.
+- For the near-term dogfood work, favor direct implementation in the orchestration thread for small
+  app wiring, crash fixes, and live `cargo run` feedback.
 - Use subagents only for independent, file-scoped chunks large enough to amortize context setup.
 - Reserve Betamax GIF work for milestone user-visible flows rather than every incremental patch.

--- a/docs/plans/0018-command-mode-mvp.md
+++ b/docs/plans/0018-command-mode-mvp.md
@@ -24,7 +24,7 @@ typed jj command, capture output, record history, and keep failures inspectable.
 - Do not add persistent command history.
 - Do not add retry/edit/rerun from the output view yet.
 - Do not add a Run Options drawer or advanced safety policy for arbitrary typed commands yet.
-- Do not update the website or public docs during the local current implementation spike.
+- Do not update the website or public docs during the local dogfood work.
 
 ## Interaction
 
@@ -107,9 +107,9 @@ Unit coverage:
 
 Betamax coverage:
 
-- `target/jk-artifacts/command-mode.tape`;
-- `target/jk-artifacts/command-mode.gif`;
-- prompt, success, and failure screenshots under `target/jk-artifacts/`.
+- `target/dogfood-artifacts/command-mode.tape`;
+- `target/dogfood-artifacts/command-mode.gif`;
+- prompt, success, and failure screenshots under `target/dogfood-artifacts/`.
 
 ## Follow-Ups
 

--- a/docs/plans/0019-release-stabilization.md
+++ b/docs/plans/0019-release-stabilization.md
@@ -1,0 +1,545 @@
+# Release Stabilization Pass
+
+Status: planned release-readiness pass after the dogfood milestone
+
+Scope: turn the current local implementation stack into an intentional, documented, releasable
+milestone before starting rebase-specific workflows.
+
+## Why This Exists
+
+The local implementation has crossed from early exploration into release-candidate territory. It
+now contains enough user-facing behavior that the next best work is not another feature slice. The
+next best work is to make the existing behavior read, test, document, and demo like a product
+milestone.
+
+Rebase should wait until this work is complete. Rebase needs selector and role-resolver clarity, and
+adding it before stabilization would make the release harder to review and explain.
+
+## Release Cutoff
+
+Release the current dogfoodable jk TUI shape before rebase:
+
+- jj-rendered log and diff views;
+- show, status, evolog, workspaces, operation log, and command history;
+- command mode for direct `jj` commands;
+- safe command previews for describe, abandon, new, edit, undo, and redo;
+- operation-id capture, command history links, copy affordances, and recovery footer;
+- diff navigation, file list, folding, search, current-file status, and diff View Options;
+- generated help, searchable command discovery, adaptive hotbar, ordered marks, and menu polish.
+
+Do not include rebase in this release candidate unless it becomes necessary to repair an existing
+workflow. Rebase belongs in the next feature milestone after selector and role behavior are clearer.
+
+## Naming And Public Framing
+
+Do not describe the release by its implementation process in public artifacts.
+
+Acceptable framing:
+
+- "dogfood milestone";
+- "release stabilization pass";
+- "jj-native TUI";
+- "safe mutation preview loop";
+- "operation recovery and command history";
+- "Betamax-backed terminal evidence".
+
+Local planning files may still mention dogfood context when they are explicitly about local
+execution history. Public-facing docs, release notes, README copy, website copy, screenshots, GIF
+captions, and commit descriptions should describe product behavior rather than the way it was built.
+
+## Current Audit
+
+Current stack evidence from the local release workspace:
+
+- More than 40 changes sit on top of `main` after the product-plan merge.
+- `crates/jk/src/main.rs` started this work over 6,000 lines and owned many unrelated app-loop
+  concepts; first extractions have moved stable support concepts into focused modules, but the app
+  loop still needs more release-readiness review.
+- The repository README and crate README still describe the older inspection-loop surface.
+- Product-plan and roadmap docs needed a first pass from local dogfood wording toward
+  implementation-status wording.
+- Local Betamax evidence exists under `target/dogfood-artifacts`, but public media has not been
+  regenerated for the broader jk surface.
+- Website copy has been updated locally for the release snapshot. Screenshot publication is staged
+  for the owning media repository, but final public media should wait for the Betamax layout update
+  if release assets should include captions plus on-screen keys.
+
+This does not mean the work is unreleasable. It means the release pass needs to make the artifact
+set honest and reviewable before publication.
+
+## Pass 1: Stack And History Audit
+
+Review the jj stack from `main` to the release candidate.
+
+Goals:
+
+- every change has a product-shaped description with a useful 72-column body;
+- descriptions explain behavior and user value, not implementation trivia;
+- no public-facing description depends on private chat context;
+- duplicated or obsolete spec-only changes are squashed or clearly kept as durable decisions;
+- local-dogfood wording is removed from changes that should become public review history;
+- stack order still builds and validates at practical cut points.
+- commit messages are durable implementation records, but release notes are not generated from
+  commit messages.
+
+Suggested grouping for eventual review:
+
+1. foundation: command specs, view stack, help/hotbar, command metadata;
+1. inspection: show, status, diff query formats, evolog, View Options;
+1. workspaces: providers, models, list screen, stale update;
+1. command history and command mode;
+1. operation recovery and recovery previews;
+1. safe mutation previews for describe, abandon, new, and edit;
+1. diff navigation and file-list polish;
+1. release docs, README, media, and website update.
+
+History scrub checklist:
+
+- remove local-workspace, model, or "dogfood implementation" framing from changes that should
+  become public;
+- make each description explain the user-visible behavior, safety policy, or durable decision;
+- keep spec/planning changes only when they remain useful review context;
+- squash follow-up fixes into the owning behavior change when the parent would be misleading
+  without them;
+- leave separate changes when they document a durable product or architecture decision.
+
+## Pass 2: Code Shape Audit
+
+Focus review on real ownership boundaries, not line count alone.
+
+Known pressure points:
+
+- `crates/jk/src/main.rs` owns terminal lifecycle, CLI args, app state, mode stack, command previews,
+  command mode, mutation orchestration, workspace routing, and test fixtures.
+- `crates/jk-tui/src/keymap.rs` is now a rich registry for help, discovery, and hotbar metadata.
+- command history and mutation recording cross `jk`, `jk-cli`, and `jk-core`.
+
+Potential extraction targets:
+
+- startup CLI parsing, query conversion, and `jj` source construction;
+- operation-log snapshot parsing;
+- command mode parsing, command spec construction, and command output rendering;
+- workspace snapshot mapping, stale-update status formatting, and workspace action mapping;
+- popup/menu view models, wrapping policy, and selector lines;
+- mutation preview metadata, prompt text, selected-parent policy, and failure text;
+- refresh/load helpers across log, diff, rendered inspections, operation views, and workspaces;
+- stateful workspace routing for list, selected status/diff, and update-stale flows;
+- app mode handlers and overlay rendering;
+- test fixtures and fake command runners.
+
+Do not extract merely because a file is long. Extract when the new owner names a stable concept,
+reduces the context a reviewer must hold, and keeps side effects easier to audit.
+
+Code-shape review criteria:
+
+- reader locality: a maintainer can understand a flow without reconstructing unrelated modes;
+- concept coherence: each module owns one recognizable idea rather than a helper bucket;
+- explicit effects: command execution, mutation confirmation, refresh, operation capture, and
+  terminal side effects are named at call sites;
+- reversible structure: extraction happens after the behavior boundary is known, not as speculative
+  architecture;
+- test locality: fixtures and fake runners live where they prove the behavior without hiding the
+  boundary under test.
+
+Initial module-size pressure is evidence, not a rule. `main.rs` needs attention because it mixes
+many responsibilities, not because it crosses a numeric threshold. Prefer extracting command mode,
+preview/mutation orchestration, workspace routing, and app-mode handlers only when those moves make
+the current release easier to review and maintain.
+
+Mechanical split plan:
+
+1. Keep `state.rs` as the private app-state owner: `AppView`, `AppState`, `ViewStack`, `ModeStack`,
+   `InputMode`, and `InputModeResult`.
+1. Keep pure view-model modules separate from side effects: `menus.rs`, `operation_log.rs`,
+   `mutation_preview.rs`, `workspaces.rs`, and `command_mode.rs` own formatting, parsing, selector
+   policy, and command previews.
+1. Extract rendering next only if it can own the `AppView` + `InputMode` draw matrix without taking
+   command execution, refresh, or input dispatch with it.
+1. Keep confirmed mutation execution separate from preview metadata: `mutations.rs` owns command
+   confirmation, recovery preview entry, post-mutation log refresh, and the recovery footer.
+1. Extract action dispatch only after rendering is separate enough that handlers can be grouped by
+   user intent: open/push actions, rendered-view actions, workspace actions, and operation actions.
+1. Keep reload mechanics separate from input dispatch: `refresh.rs` owns command-runner history
+   recording, error fallback, and reload transitions across log, diff, rendered inspections,
+   operation views, and workspaces.
+1. Keep workspace routing separate from pure workspace view models: `workspace_routes.rs` owns the
+   stateful list, selected status/diff, repository status, and update-stale flows while
+   `workspaces.rs` keeps snapshot mapping and pure action policy.
+1. Keep shared binary test fixtures in `test_support.rs` so behavior tests can read as assertions
+   about product flows rather than fixture construction.
+
+Stop conditions for each extraction:
+
+- no behavior change is intended;
+- `cargo fmt --check`, focused tests where available, `cargo test -p jk`, and `cargo check` pass;
+- the new module has a single recognizable owner and is not a helper bucket;
+- `main.rs` loses live context rather than gaining indirection through generic wrappers.
+
+First extraction status:
+
+- `crates/jk/src/cli.rs` now owns startup argument parsing, root-command query conversion, and
+  repository-aware construction of `jj` sources.
+- `crates/jk/src/operation_log.rs` now owns conversion from rendered `jj op log` text into
+  operation-log snapshot rows, with local parser tests for row titles and ANSI stripping.
+- `crates/jk/src/command_mode.rs` now owns command-mode argument parsing, command spec
+  construction, prompt lines, and command-output rendering, with local parser and output tests.
+- `crates/jk/src/workspaces.rs` now owns workspace-list snapshot mapping, stale-update status
+  formatting, and pure key-action mapping for workspace list and workspace inspection views.
+- `crates/jk/src/mutation_preview.rs` now owns safe mutation preview metadata, describe prompt
+  text, selected-parent policy for `jj new`, and confirmed-command failure messages.
+- `crates/jk/src/menus.rs` now owns popup/menu selector policy, view-option row models,
+  diff-file-list rows, and template selector lines.
+- `crates/jk/src/state.rs` now owns the app view enum, view stack, mode stack, and transient input
+  mode model.
+- `crates/jk/src/rendering.rs` now owns the `AppView` + `InputMode` draw matrix and shared overlay
+  rendering without taking command execution, refresh, or input dispatch with it.
+- `crates/jk/src/actions.rs` now owns normal-mode key dispatch and search-mode selection while
+  leaving command execution, refresh, and mutation helpers in their current owners.
+- `crates/jk/src/mutations.rs` now owns confirmed command execution, recovery preview entry,
+  post-mutation log refresh, and recovery-footer status text.
+- `crates/jk/src/refresh.rs` now owns command-runner history recording, error fallback, and reload
+  transitions across log, diff, rendered inspections, operation views, and workspaces.
+- `crates/jk/src/workspace_routes.rs` now owns stateful workspace list, selected status/diff,
+  repository status, and update-stale flows while `workspaces.rs` keeps pure view mapping and
+  action policy.
+- `crates/jk/src/test_support.rs` now owns shared binary test fixtures: synthetic log/diff/workspace
+  views, command-history appenders, process-output builders, buffer helpers, and the sequenced fake
+  `jj` runner.
+- `crates/jk/src/root_views.rs` now owns initial root view construction for `jk`, `jk log`,
+  `jk diff`, `jk show`, and `jk status`, including error fallback for initial rendered views.
+- `crates/jk/src/runner.rs` now owns the small system-runner recording adapter used by loaders.
+- `crates/jk/src/clipboard.rs` now owns OSC52 command-copy support and its encoding tests.
+- `crates/jk/src/command_history.rs` now owns command-history list/details routing,
+  command-history operation links, operation-log opening, and command-history action translation.
+- `main.rs` is smaller and more reviewable, but still owns app-loop behavior and many behavior
+  tests. Further extraction should be driven by a user-visible change or a clearer owner, not by
+  line count alone.
+
+Second extraction status:
+
+- Started from a mechanical module map instead of opportunistic helper moves.
+- Kept the second pass behavior-preserving: no key bindings, command construction, mutation policy,
+  or rendered output semantics intentionally changed.
+- Reduced `main.rs` to 3,693 lines while keeping app startup, terminal lifecycle, input-mode
+  handling, active-view action application, and the existing broad behavior tests in one place.
+- Left the next likely extraction as input-mode handling only if it can be split by coherent mode
+  ownership rather than by line count.
+
+## Pass 3: User Documentation, Changelog, And Release Notes
+
+Update user-facing docs to match the release candidate.
+
+Required surfaces:
+
+- repository `README.md`;
+- `crates/jk/README.md`;
+- release notes / changelog entry;
+- local docs for command mode, safe mutation previews, command history, operation recovery,
+  workspaces, View Options, and diff navigation;
+- keymap/help documentation if the generated help surface becomes a documented contract.
+
+Release notes and changelog policy:
+
+- write release notes from a user-facing feature audit, not from commit messages or an automated
+  commit summary;
+- keep `CHANGELOG.md` useful for readers who want to know what changed, why it matters, what safety
+  rules changed, and which limitations remain;
+- group entries by workflow or user outcome, such as inspection, command history, recovery,
+  workspaces, mutation previews, diff navigation, docs/media, and compatibility;
+- include keymap changes and safety changes explicitly;
+- include known limitations and deferred rebase work without making them sound like bugs;
+- use the jj history as evidence, not as the structure of the release note.
+
+The docs should be direct about limitations:
+
+- rebase is intentionally deferred;
+- command previews are the supported mutation shape;
+- direct `a`, `n`, and `e` bindings are dogfood shortcuts until the action menu exists;
+- command history is currently in-memory unless later persistence lands;
+- generated media comes from Betamax and public assets live outside this source repository.
+
+Documentation review criteria:
+
+- README and crate README are entry points, not exhaustive manuals;
+- user docs state current behavior, not aspiration;
+- detailed workflows live in local docs or website pages where the reader can choose depth;
+- Markdown stays lintable, wrapped, and readable in source form;
+- examples and command lists are verified against the current binary before release.
+
+Pass 3 status:
+
+- `README.md` and `crates/jk/README.md` describe the current dogfoodable jk TUI surface at entry
+  point depth.
+- `CHANGELOG.md` has a curated `Unreleased` entry grouped by user workflow rather than commit
+  order.
+- `docs/usage.md` now documents current command surface, log inspection, diff review, safe
+  command previews, command mode, command history, operation recovery, workspaces, generated help,
+  and known limitations.
+- A progressive-disclosure pass keeps README files at entry-point depth, moves task flows into
+  `docs/usage.md`, and leaves exhaustive key reference to in-app generated help.
+- The documented root command list has been checked against `cargo run -p jk -- --help` and the
+  `log`, `diff`, `show`, and `status` subcommand help output.
+- Public README, crates.io, and website media still need the separate media/release handoff before
+  publication.
+
+## Pass 4: Betamax Evidence And Public Media
+
+Keep two artifact classes separate:
+
+- validation tapes prove behavior and should be suitable for CI or release smoke;
+- media tapes produce polished GIFs/screenshots for README, crates.io, website, and release notes.
+
+Candidate public media set:
+
+1. jk usage overview: log to show/diff/status and back;
+1. command history and operation recovery after a confirmed mutation;
+1. command mode success and failure output;
+1. workspace list to workspace status/diff;
+1. diff navigation with file list, folding, search, and View Options;
+1. safe mutation preview cancel/copy/confirm.
+
+Media requirements:
+
+- use Betamax keyboard overlays where they clarify the action being demonstrated;
+- use captions only when Betamax can place them outside the terminal content or otherwise avoid
+  covering the TUI hotbar, footer, prompts, and status text;
+- keep captions and keyboard overlays in separate visual space so they do not compete for the
+  viewer's attention or obscure each other;
+- dwell long enough for humans to read each state;
+- avoid private local paths, user email, or unrelated repository noise;
+- generate into the owning media repository, not the main `jk` source tree;
+- verify published URLs return real media bytes, not Git LFS pointer files.
+
+Public media may be prepared in the website or screenshot repositories, but it must not advertise
+unreleased behavior as already available. The website is allowed to lag a release. It should not
+lead one.
+
+Media ownership rule:
+
+- keep generated screenshots, GIFs, and videos out of the main `jk` source repository so jj does
+  not have to carry Git LFS-heavy media churn;
+- use `jk-screenshots` for README, crates.io, release-note, and other reusable public assets;
+- use `jk-website` for site-specific assets when the website is the only consumer;
+- keep local dogfood validation artifacts under `target/dogfood-artifacts/` until a release
+  handoff intentionally publishes them.
+
+Local tape status:
+
+- `just betamax` runs the existing log and diff visual smoke tapes with the installed `betamax`
+  binary by default.
+- `just betamax-release-smoke` runs the broader dogfood fixture tape for root status, workspaces,
+  command mode, mutation preview, command history, and operation-detail routing.
+- The tapes write local artifacts under `target/dogfood-artifacts/betamax/`, including
+  `jk-log.gif`, `jk-diff.gif`, screenshots, and terminal state JSON.
+- `just readme-media` is local-only during this work and writes to
+  `target/dogfood-artifacts/readme-media/`; publishing to the screenshots repository is a later
+  release handoff.
+- The README log hero tape intentionally keeps overlays off so the first product image reads as
+  the application, not a tutorial.
+- The deeper README diff tape and documentary dogfood tapes use short captions with
+  `Set KeyboardOverlay Input` where typed intent is part of the release narrative.
+- The installed Betamax build supports semantic waits, screenshots, state JSON, GIF/video output,
+  readable dwell, captions, and keyboard overlays with the caption and key chips outside the
+  terminal canvas.
+- `release-smoke.gif` is validation evidence, not final public media. It intentionally keeps enough
+  setup context to prove the disposable-repository fixture, while public website/release-note clips
+  should start on the TUI surface after setup has completed.
+
+Installed Betamax overlay behavior:
+
+- The local installed Betamax build includes the presentation-overlay fix from
+  `joshka/betamax#94`.
+- Betamax reserves a bottom presentation row before deriving the terminal grid whenever `Caption`
+  or `KeyboardOverlay` is active. Captions sit below the terminal frame on the left, keyboard chips
+  sit below the frame on the right, and long captions truncate instead of wrapping into the key
+  chips.
+- Render `jk` release tapes with `/Users/joshka/.cargo/bin/betamax` or by setting
+  `BETAMAX=/Users/joshka/.cargo/bin/betamax` for `just` recipes.
+- Because the reserved row changes the derived terminal grid, captioned/keyed public media should
+  avoid oversized margin or internal padding. The current release tapes use `Set Padding 0` and
+  `Set Margin 20` so the terminal remains prominent while the presentation row stays outside the
+  TUI canvas.
+
+Release-media overlay plan:
+
+- Keep the first README/crates.io hero GIF clean: no caption and no keyboard overlay. It should
+  show `jk` as the product without documentary chrome competing with the TUI.
+- Keep compact README final-frame screenshots clean unless the screenshot is explicitly teaching a
+  key-driven state. Static entry-point images should prioritize terminal legibility.
+- Use captions plus `Set KeyboardOverlay Keys` for documentary website and release-note clips that
+  teach key-driven navigation, such as log to show/status/evolog, diff file and hunk navigation,
+  View Options, operation log, and Command History routing.
+- Use captions plus `Set KeyboardOverlay Input` only when typed input is part of the story, such as
+  command mode success/failure or describe-message editing. Avoid `Input` for the first product
+  GIF because typed command chips can make the demo feel like a tutorial rather than the product.
+- Avoid `Set KeyboardOverlay All` for public `jk` media. Long setup commands should stay hidden,
+  and public overlays should show user intent rather than implementation setup.
+- Place `Caption` commands before the semantic action they explain, then use `Wait+Screen` or
+  `State` for the behavior proof. Add `Sleep` after a caption-only transition only when the
+  animation needs readable dwell without terminal changes.
+- Keep captions short enough to share the row with key chips. Prefer action-oriented captions such
+  as "Open the selected diff", "Preview before mutating", and "Follow the recorded operation".
+- Clear captions with `Caption ""` before cleanup, shell exit, or any frame that should return to a
+  pure terminal presentation.
+
+Planned public media set after Betamax release:
+
+1. `jk-log-v3.gif`: README/crates.io hero, clean log-to-diff overview, no captions or key overlay.
+1. `jk-diff-v3.gif`: README diff review with captions and input overlay only for guided search and
+   folding moments where typed intent improves the reader's understanding.
+1. Website jk usage overview: captioned, key-driven navigation from log to show/diff/status and
+   back.
+1. Website command preview/recovery: captioned, `KeyboardOverlay Input` for the describe prompt,
+   confirmation, Command History, and operation show route.
+1. Website command mode: captioned, `KeyboardOverlay Input` for `:status` and one failing command
+   so stderr capture is visible.
+1. Website workspaces: captioned, `KeyboardOverlay Keys` for workspace list, selected status, and
+   selected diff.
+1. Release-note stills: checkpoint PNGs from the same documentary tapes, with captions only where
+   the frame needs context outside the terminal text.
+
+## Pass 5: Website Update
+
+The active release goal includes the website. Website copy should track the release snapshot before
+publication. Final media can use the installed Betamax presentation-overlay behavior, but website
+media should still be published only when the source release candidate is stable enough to demo.
+
+Website pass happens in `/Users/joshka/local/jk-website` after the source release candidate is
+stable enough to demo.
+
+Update:
+
+- homepage story from inspection helper to jj-native TUI;
+- hero/demo media;
+- feature sections for command previews, recovery, command history, workspaces, View Options, and
+  diff navigation;
+- install and release notes links if release assets or Homebrew behavior changed.
+
+Website release policy:
+
+- the website should track released behavior, even if it lags by a release;
+- do not pre-publish demos or claims for unreleased behavior;
+- media may be pushed to the website or screenshot repositories as part of the release handoff when
+  the page that references it is gated to released behavior;
+- website copy should link to the release notes and should not force users to infer feature status
+  from commit history.
+
+Run the website's normal build and Betamax media generation from that repository.
+
+Pass 5 status:
+
+- `/Users/joshka/local/jk-website` now describes the current release snapshot rather than the
+  earlier log/diff-only milestone.
+- The homepage includes sections for inspection, diff review, command previews, command mode,
+  command history, operation recovery, workspaces, View Options, release boundaries, and docs.
+- `pnpm build` passes.
+- Playwright visual QA against `http://127.0.0.1:4322/jk` showed no horizontal overflow on desktop
+  or mobile, and header/footer navigation uses the release labels.
+- Final homepage/README media publication is pending the Betamax caption/key-overlay layout update.
+
+## Pass 6: Release Validation
+
+Minimum source validation:
+
+```sh
+cargo test -p jk-core
+cargo test -p jk-cli
+cargo test -p jk
+cargo test -p jk-tui
+cargo fmt --check
+cargo check
+markdownlint-cli2 --config ~/.markdownlint-cli2.yaml README.md crates/jk/README.md docs/**/*.md
+```
+
+Minimum dogfood validation:
+
+- `cargo run -- log`;
+- `cargo run -- diff`;
+- `cargo run -- status`;
+- `cargo run -- workspaces`;
+- command mode success and failure;
+- one confirmed mutation in a disposable fixture, followed by command history and operation view;
+- `cargo install --path crates/jk` for local dogfooding.
+
+Minimum media validation:
+
+- validation Betamax tapes pass for changed workflows;
+- selected media tapes regenerate;
+- published media URLs are checked after deploy.
+
+Minimum release-channel validation:
+
+- `just release-check` if available and still current;
+- release-plz dry-run or release PR readback;
+- cargo-binstall install smoke after release assets exist;
+- Homebrew tap smoke after the release artifact path is updated.
+
+Pass 6 source-validation status:
+
+- `just fmt-check` initially found Rust comment wrapping drift; `just fmt` corrected it and the
+  follow-up formatting check passed.
+- `just check` passed after the app-support extraction.
+- `just test` passed across the workspace after the clippy and documentation cleanup.
+- `just clippy` passed after fixing release-readiness warnings in the command model, command
+  history, TUI views, and app support modules.
+- `just doc` passed cleanly after fixing the command-runner intra-doc link.
+- `just package`, `just install-smoke`, and `just udeps` passed.
+- CLI help smoke checks passed for `jk --help`, `jk log --help`, `jk diff --help`,
+  `jk show --help`, `jk status --help`, and `jk --version`.
+- `betamax validate 'tapes/*.tape'` passed for the five repository tapes before the final
+  captioned media pass.
+- `just betamax` passed for the current log and diff visual smoke tapes and wrote artifacts under
+  `target/dogfood-artifacts/betamax/`.
+- `just readme-media` passed locally before the final captioned media pass and wrote artifacts
+  under `target/dogfood-artifacts/readme-media/`.
+- `tapes/release-smoke.tape` passed with a disposable jj repository, covering root status,
+  workspaces, command-mode success/failure, confirmed describe mutation, Command History, and the
+  captured operation route.
+- An early captioned README diff preview rendered with `/Users/joshka/.cargo/bin/betamax`; visual
+  inspection confirmed the `jk` hotbar stayed inside the terminal while the caption and Enter chip
+  shared the reserved presentation row below it.
+- `BETAMAX=/Users/joshka/.cargo/bin/betamax just readme-media` passed after switching the README
+  log hero to a clean overlay-free frame and the README diff media to captioned input-overlay
+  guidance with `Set Padding 0` and `Set Margin 20`.
+- `BETAMAX=/Users/joshka/.cargo/bin/betamax just betamax` passed for the captioned log and diff
+  smoke tapes using the same frame settings.
+- `JK_SOURCE_REPO=/path/to/jk BETAMAX=/Users/joshka/.cargo/bin/betamax just
+  betamax-release-smoke` passed for the disposable-repository release smoke tape using the same
+  frame settings.
+- Visual inspection of `target/dogfood-artifacts/readme-media/jk-log-v3.png`,
+  `target/dogfood-artifacts/readme-media/jk-diff-search-v3.png`, and
+  `target/dogfood-artifacts/betamax/jk-log-expanded.png` confirmed the clean hero, captioned
+  search frame, and captioned key-driven frame keep the `jk` hotbar visible while captions and key
+  chips stay outside the terminal canvas.
+- Versioned README/crates.io media was copied into `/Users/joshka/local/jk-screenshots/assets/`
+  for publication under `https://www.joshka.net/jk-screenshots/assets/`. The screenshot repository
+  has Git LFS attributes for PNG and GIF assets.
+- Website media was copied into `/Users/joshka/local/jk-website/public/assets/` under the
+  unversioned filenames used by the project page.
+- The website homepage tape was updated for the current jk behavior where `Enter` opens
+  `jk jj show`, then regenerated with
+  `JK_SOURCE_REPO=/path/to/jk JK_WEBSITE_REPO=/Users/joshka/local/jk-website
+  /Users/joshka/.cargo/bin/betamax run tapes/homepage.tape`.
+- `pnpm build` passed in `/Users/joshka/local/jk-website`.
+- Browser validation of the local website preview passed for the desktop hero, media grid, image
+  asset loading, and a 390 px mobile viewport with no horizontal overflow.
+- A tracked-text scrub removed local workspace naming from README, docs, release planning,
+  Betamax tapes, and source fixtures; local media now writes under `target/dogfood-artifacts/`.
+- `just release-check` passed on the current release-candidate workspace after the history and
+  public-wording scrub. This re-ran formatting, check, tests, clippy, udeps, docs, package,
+  install-smoke, and Markdown lint.
+- Broader dogfood fixture runs, final public-media publication, and post-published install-channel
+  checks remain open release work.
+
+## Done Criteria
+
+This pass is complete when:
+
+- the release candidate has no public "dogfood implementation" framing;
+- the stack descriptions and docs explain shipped behavior and limitations;
+- README, crate README, LLM-authored release notes, changelog, website, and media agree about the
+  feature surface;
+- public media has been regenerated and published through the owning repos;
+- source, dogfood, media, and release-channel validation have passed or have explicit documented
+  exceptions;
+- rebase work has a clean next-slice entry point after this release.

--- a/docs/plans/cli-surface-addendum.md
+++ b/docs/plans/cli-surface-addendum.md
@@ -27,7 +27,7 @@ as a separate button with a separate form. The CLI is organized around **reusabl
 - config/template languages: revsets, filesets, templates, string patterns, conditional config,
   template aliases, revset aliases.
 
-Therefore, the project plan should treat `jk` as a **flag-family workbench**, not a command-by-command
+Therefore, the project plan should treat `jk` as a **flag-family TUI**, not a command-by-command
 TUI. The UI should expose common flag families as reusable overlays and role pickers, and every
 workflow should still be able to fall back to `:` command mode.
 
@@ -1417,7 +1417,7 @@ Important config implication:
 Priorities:
 
 - **P0**: must be part of the obvious daily driver.
-- **P1**: important for a serious jj terminal workbench.
+- **P1**: important for a serious jj terminal UI.
 - **P2**: useful but specialized or advanced.
 - **P3**: command-mode only unless usage demands a focused UI.
 
@@ -1684,7 +1684,7 @@ These should be resolved by implementation experiments:
 
 The complete jj CLI surface does not invalidate the golden plan. It sharpens it.
 
-`jk` should become a jj-native workbench by building reusable UI primitives for jj's reusable flag
+`jk` should become a jj-native TUI by building reusable UI primitives for jj's reusable flag
 families:
 
 ```text

--- a/docs/product-plan.md
+++ b/docs/product-plan.md
@@ -36,13 +36,13 @@ Useful source links for `jj` compatibility and ecosystem context:
 
 ## 0. Executive thesis
 
-`jk` should become the terminal workbench that feels like the interactive form of `jj` itself.
+`jk` should become the terminal UI that feels like the interactive form of `jj` itself.
 
 The product should not be positioned as "a lazygit for jj" and should not be constrained by the
 narrow first-screen framing. The default screen can remain the revision graph because that is where
 many jj workflows begin, but the durable positioning is broader:
 
-> `jk` is a jj-native terminal workbench. It follows Jujutsu's command model and configuration, then
+> `jk` is a jj-native terminal UI. It follows Jujutsu's command model and configuration, then
 > adds fast navigation, selection, previews, safe mutations, operation recovery, command history,
 > and command mode.
 
@@ -184,7 +184,7 @@ Change for `jk`:
 
 Language / stack: Tauri + Svelte/TypeScript UI, Rust backend and CLI.
 
-GitButler's TUI is especially useful as a terminal-workbench reference. It has a full workspace TUI,
+GitButler's TUI is especially useful as a terminal-TUI reference. It has a full workspace TUI,
 focused diff TUI, stage/hunk picker, command mode, generated help, hotbar, marked commits,
 inline/editor rewording, external commands, undo/redo, and operation recovery.
 
@@ -397,6 +397,10 @@ movement uses `[ ]` and `{ }`.
 `?` opens generated contextual help. The help content and hotbar are generated from the active
 keymap and view state. If a keybinding changes, help changes automatically.
 
+Help rows should be ordered for the reader: primary view actions first, then mutation, recovery, and
+command actions, then view/refresh controls, navigation, and close/help commands. The order should
+not merely mirror implementation or dispatch registration order.
+
 Help should also become searchable. The help surface and command palette are related but distinct:
 
 - `?` explains what is currently possible.
@@ -417,12 +421,13 @@ All rewrite/destructive/network actions should follow:
 6. Refresh state after success.
 7. Show result, command history entry, and operation-recovery actions.
 
-Current implementation status: selected-revision `jj abandon REV` and parented `jj new` have the
-first mutation previews. Pressing `a` on the log previews `jj abandon REV`; pressing `n` previews
-`jj new PARENT...`, using ordered marks as parents when present and otherwise using the selected
-revision. Enter runs the command, successful runs refresh the graph, command history records the
-resulting operation id, and the recovery footer surfaces undo/redo/operation/history actions. The
-direct `a` binding is a dogfood shortcut until the long-term action-menu prefix exists.
+Current implementation status: selected-revision `jj abandon REV`, parented `jj new`, and
+selected-revision `jj edit REV` have the first mutation previews. Pressing `a` on the log previews
+`jj abandon REV`; pressing `n` previews `jj new PARENT...`, using ordered marks as parents when
+present and otherwise using the selected revision; pressing `e` previews `jj edit REV`. Enter runs
+the command, successful runs refresh the graph, command history records the resulting operation id,
+and the recovery footer surfaces undo/redo/operation/history actions. The direct `a` binding is a
+dogfood shortcut until the long-term action-menu prefix exists.
 
 ### 3.6 Recovery is first-class
 
@@ -638,7 +643,7 @@ pickers.
 Rationale: `n` remains available for `new`; search repeat uses `Ctrl-n/Ctrl-p` rather than stealing
 `n/N`.
 
-### 5.3 Revision graph / main workbench
+### 5.3 Revision graph / main TUI
 
 | Key     | Meaning                                                                                  |
 | ------- | ---------------------------------------------------------------------------------------- |
@@ -674,9 +679,12 @@ Current implementation note: before this prefix menu exists, `a` directly previe
 `jj abandon REV` for the selected log revision. Keep that implementation path command-spec based so
 it can move under `a a` later without rewriting the mutation runner.
 
-Current implementation note: `n` directly previews `jj new PARENT...` from the log. Ordered marks become
-parents when present; otherwise the selected revision is the parent. Search-next remains scoped to
-diff and rendered inspection views.
+Current implementation note: `n` directly previews `jj new PARENT...` from the log. Ordered marks
+become parents when present; otherwise the selected revision is the parent. Search-next remains
+scoped to diff and rendered inspection views.
+
+Current implementation note: `e` directly previews `jj edit REV` from the log. The same key still
+reopens the command prompt when a command-output view is active.
 
 | Key | jj command family               | Notes                                                      |
 | --- | ------------------------------- | ---------------------------------------------------------- |
@@ -809,7 +817,8 @@ jj workspace root
 jj workspace update-stale
 ```
 
-The screen should answer:
+The current implementation covers list, selected-workspace log, selected-workspace status,
+selected-workspace diff, refresh, and update-stale. The screen should answer:
 
 ```text
 What workspaces exist?
@@ -861,7 +870,7 @@ Rules:
 Use a view stack, not hard-coded `H/L` return paths.
 
 ```text
-Workbench / graph
+Main graph
   -> Show/details
   -> Diff
   -> Status
@@ -894,7 +903,7 @@ Navigation contract:
 
 | jj command                          | jk screen/action      | Priority | Notes                                                                              |
 | ----------------------------------- | --------------------- | -------- | ---------------------------------------------------------------------------------- |
-| `jj log`                            | Workbench graph       | P0       | Default screen. Honor `ui.default-command`, `revsets.log`, templates, graph style. |
+| `jj log`                            | Log graph             | P0       | Default screen. Honor `ui.default-command`, `revsets.log`, templates, graph style. |
 | `jj diff`                           | `d`, Diff screen      | P0       | Support `-r`, `--from`, `--to`, filesets, display modes.                           |
 | `jj show`                           | `Enter`, Show/details | P0       | Metadata + diff; View Options.                                                     |
 | `jj status`                         | `s`, Status screen    | P0       | Working copy, conflicts, bookmarks, file list.                                     |
@@ -1184,9 +1193,9 @@ Diff view:
 
 - Preserve selected file/hunk across refresh if path/header still exists.
 - Sticky current-file header.
-- File picker overlay for large diffs. The current implementation spike includes the first `f`
-  file selector for jumping within an active diff; the later target is searchable and shared with
-  the broader fileset selector model.
+- File picker overlay for large diffs. The current implementation includes the first `f` file
+  selector for jumping within an active diff; the later target is searchable and shared with the
+  broader fileset selector model.
 - Search highlights and next/previous match navigation.
 - Next/previous file navigation without reopening the picker.
 - Toggle between patch, stat, summary, name-only, and file-only details.
@@ -1296,8 +1305,14 @@ Prompt keys:
 
 - `Enter`: run `jj describe -m <message> <rev>`.
 - `Ctrl-e`: open editor with current text as seed if supported.
+- `Ctrl-u`: clear the current inline prompt text.
 - `Esc`: cancel.
 - `Ctrl+s`: save when multiline editor is active.
+
+Current implementation status: `m` opens the inline prompt prefilled with the selected revision's full
+description, and `Ctrl-u` clears the prefilled text before preview. The prompt still submits through
+command preview, command history, operation-id capture, log refresh, and recovery footer. It does
+not yet support multiline editing, editor handoff, or a before/after review panel.
 
 `M` opens configured editor directly:
 
@@ -1317,9 +1332,9 @@ Role inference:
 - Else cursor is parent.
 - If cursor is absent: default jj behavior.
 
-Current implementation status: direct `n` implements the marks-or-cursor parent rule and routes through
-command preview, command history, operation-id capture, log refresh, and recovery footer. It does
-not yet support inline messages or the later role-resolver overlay.
+Current implementation status: direct `n` implements the marks-or-cursor parent rule and routes
+through command preview, command history, operation-id capture, log refresh, and recovery footer. It
+does not yet support inline messages or the later role-resolver overlay.
 
 `N`: create new change with inline message.
 
@@ -1332,6 +1347,10 @@ jj edit <rev>
 ```
 
 If revision is immutable or hidden, require stronger preview or route to action menu variant.
+
+Current implementation status: direct `e` implements the selected-revision preview path and routes
+through command preview, command history, operation-id capture, log refresh, and recovery footer. It
+does not yet add immutable-specific warning copy or the stronger `a E` ignore-immutable variant.
 
 ### 9.6 Squash/split/restore/absorb
 
@@ -1678,11 +1697,15 @@ just betamax-log
 just betamax-diff
 ```
 
-The README also says visual README media is generated with `just readme-media`, and generated
-screenshots/GIFs live in the separate
+The README also says visual README media is generated with `just readme-media`. For unreleased
+local work, generated media should stay under `target/dogfood-artifacts/`. Public README and
+crates.io media is published later from the separate
 [`joshka/jk-screenshots`](https://github.com/joshka/jk-screenshots) repository served from
-`https://www.joshka.net/jk-screenshots/`. That setup should grow from "README media helpers" into
-core project infrastructure.
+`https://www.joshka.net/jk-screenshots/`. Website-specific media can live in `jk-website` when the
+site is the only consumer. Keeping generated images and GIFs out of the main source repository is a
+jj ergonomics decision as much as a repository-size decision: Git LFS-heavy media churn is easier to
+manage in a purpose-built media or website repository. That setup should grow from "README media
+helpers" into core project infrastructure.
 
 Every meaningful `jk` workflow should eventually have two Betamax tapes:
 
@@ -1740,7 +1763,13 @@ tapes/
 ```
 
 Validation tapes should be short, deterministic, and assertion-heavy. Media tapes can be slower and
-more readable.
+more readable. Review-media tapes should include readable dwell and, where useful, Betamax
+presentation affordances such as keyboard overlays and captions. For `jk`, captions should read as
+presentation metadata on the surrounding frame, not as terminal content, and must never cover the
+TUI hotbar, footer, prompts, status text, or keyboard overlay. Captions and keyboard overlays should
+occupy separate visual regions so they explain the action without competing with each other. Until
+Betamax can guarantee that layout, `jk` media tapes should prefer keyboard overlays and avoid
+captions.
 
 Expand Betamax coverage for:
 
@@ -1923,10 +1952,10 @@ Every UI-changing PR should attach Betamax artifacts or link CI artifacts.
 Recommended CI artifacts:
 
 ```text
-target/betamax/jk-validation/*.json
-target/betamax/jk-validation/*.png
-target/betamax/jk-media/*.gif
-target/betamax/jk-media/*.mp4, optional
+target/dogfood-artifacts/betamax/validation/*.json
+target/dogfood-artifacts/betamax/validation/*.png
+target/dogfood-artifacts/betamax/media/*.gif
+target/dogfood-artifacts/betamax/media/*.mp4, optional
 ```
 
 PR template addition:
@@ -1958,29 +1987,26 @@ just release-check
 Suggested `justfile` additions:
 
 ```make
+betamax := env_var_or_default("BETAMAX", "betamax")
+
 betamax-validation:
-    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run \
-        tapes/validation/log-navigation.tape
-    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run \
-        tapes/validation/diff-selected-revision.tape
-    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run \
-        tapes/validation/command-mode.tape
+    {{betamax}} run tapes/validation/log-navigation.tape
+    {{betamax}} run tapes/validation/diff-selected-revision.tape
+    {{betamax}} run tapes/validation/command-mode.tape
 
 betamax-media:
-    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run \
-        tapes/media/readme-overview.tape
-    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run \
-        tapes/media/docs-rebase-preview.tape
+    {{betamax}} run tapes/media/readme-overview.tape
+    {{betamax}} run tapes/media/docs-rebase-preview.tape
 
 betamax-update:
     just betamax-validation
     just betamax-media
 ```
 
-The exact command can evolve once Betamax is installed through Homebrew or `cargo-binstall` in CI
-rather than run from a sibling checkout. Betamax currently supports installation through Homebrew
-and `cargo-binstall`. Local development can continue to run tapes through the Betamax checkout,
-including basic smoke experiments with:
+Use the installed `betamax` binary by default, and override `BETAMAX` when a local source checkout
+or wrapper command is needed. Betamax currently supports installation through Homebrew and
+`cargo-binstall`. Local development can still run basic smoke experiments from a Betamax checkout
+with:
 
 ```sh
 cargo run -- run examples/basic.tape
@@ -2003,6 +2029,7 @@ theme pinning for deterministic screenshots
 font/layout stability across CI platforms
 easy per-tape environment setup
 first-class failed-checkpoint screenshot capture
+caption and keyboard-overlay layout that avoids terminal content
 ```
 
 Likely `jk` feature pressure from Betamax:
@@ -2331,10 +2358,14 @@ For each release:
 - Keymap docs regenerated.
 - CLI help regenerated.
 - README updated if status changed.
-- Website workflow screenshots/GIFs updated when UX changes.
+- Website workflow screenshots/GIFs updated when UX changes and only after the behavior is released
+  or release-gated.
 - Betamax validation tapes pass for changed workflows.
 - Betamax media smoke passes for README/site/release demos affected by the change.
-- CHANGELOG describes user-visible changes, keymap changes, config changes, and safety changes.
+- CHANGELOG is written for readers, grouped by workflow or user outcome, and describes
+  user-visible changes, keymap changes, config changes, safety changes, and known limitations.
+- Release notes are LLM-assisted or human-written from a feature audit, not generated from commit
+  messages. Commit history is evidence, not the release-note structure.
 - Release notes include install commands and known limitations.
 - Smoke install via cargo, cargo-binstall, and Homebrew when applicable.
 
@@ -2553,7 +2584,7 @@ for future Codex work.
 ### 24.1 Revised positioning
 
 ```text
-jk is a jj-native terminal workbench: focused screens, jj-shaped commands,
+jk is a jj-native terminal UI: focused screens, jj-shaped commands,
 config-faithful rendering, safe previews, operation recovery, and first-class
 workspaces.
 ```
@@ -2571,7 +2602,7 @@ jk is interactive jj, not a Git dashboard for jj.
 - Note prior-art implementation languages because they show which architecture and ecosystem
   choices each project validates.
 - Treat workspaces as early core scope for daily jj users, not an advanced feature.
-- Treat `jk` as a flag-family workbench: build shared selectors, `V` View Options, Run Options, and
+- Treat `jk` as a flag-family TUI: build shared selectors, `V` View Options, Run Options, and
   generated command/flag manifests before expanding one-off command forms.
 - Reserve standalone `v` for `jj evolog` and use `V` for display, graph, diff, and template
   options.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,7 @@ around reusable flag families instead of one-off command forms.
 
 ## North Star
 
-`jk` is a jj-native terminal workbench: focused screens, jj-shaped commands, config-faithful
+`jk` is a jj-native terminal UI: focused screens, jj-shaped commands, config-faithful
 rendering, safe previews, operation recovery, and first-class workspaces.
 
 The product test is simple: `jk` should feel like interactive jj, not a Git dashboard for jj.
@@ -44,14 +44,14 @@ Make inspection workflows match jj's command model.
   options, and related diff formats.
 - Add standalone `v` for selected-change `evolog` after the shared inspection source model exists.
 - Add first-class diff search, file-list navigation, and two-revision comparison. The current
-  implementation spike now has the first diff file selector (`f`) for jumping within the active
-  diff; searchable file lists and range comparison still need follow-up work.
+  implementation has the first diff file selector (`f`) for jumping within the active diff;
+  searchable file lists and range comparison still need follow-up work.
 - Add docs and [Betamax](https://www.joshka.net/betamax/) tapes for log, diff, show, and status
   flows.
 
 ### 0.5 Command Mode And Workspaces
 
-Add the two features that turn `jk` from an inspection helper into a daily workbench.
+Add the two features that turn `jk` from an inspection helper into a daily jj TUI.
 
 - Add `:` jj command mode with optional `jj` prefix.
 - Add `!` external command mode without shell interpretation by default.
@@ -67,11 +67,14 @@ Introduce mutating workflows only through command preview and recovery.
 
 - Add a reusable Run Options drawer for global options and advanced safety toggles before mutating
   wizards depend on them.
-- Add inline and editor describe flows.
-- Add new, commit, edit, rebase, and abandon flows. The current implementation spike now has direct
-  selected-revision `a` -> `jj abandon REV` and `n` -> `jj new PARENT...` previews. `jj new`
-  already uses ordered marks as parents when present and falls back to the selected revision; the
-  durable action-menu shape still belongs with the broader mutation selector work.
+- Add inline and editor describe flows. The current implementation prefills the inline `m` prompt
+  from the selected revision's full description and supports `Ctrl-u` clear before preview; editor
+  describe and before/after review remain follow-up work.
+- Add new, commit, edit, rebase, and abandon flows. The current implementation has direct
+  selected-revision `a` -> `jj abandon REV`, `n` -> `jj new PARENT...`, and
+  `e` -> `jj edit REV` previews. `jj new` already uses ordered marks as parents when present and
+  falls back to the selected revision; the durable action-menu shape still belongs with the broader
+  mutation selector work.
 - Add rebase destination search and command preview before any graph mutation.
 - Add undo/redo and operation log entry points.
 - Log every mutation in command history.
@@ -125,8 +128,10 @@ Reusable primitives come before broad workflow coverage:
   `--config-file`.
 - Shared selector models must exist before command families grow bespoke prompts for revsets,
   filesets, operations, bookmarks, tags, remotes, or workspaces.
-- Workspaces stay early core scope. They land before broad history-editing polish because
-  multi-workspace state changes how log, status, diff, operation, and sparse workflows are shown.
+- Workspaces stay early core scope. The current implementation covers workspace list,
+  selected-workspace log/status/diff, and stale-workspace updates before broad history-editing
+  polish because multi-workspace state changes how log, status, diff, operation, and sparse
+  workflows are shown.
 - Betamax validation should be organized by flag families as well as command journeys, so one tape
   can prove shared behavior such as `-R` propagation, View Options formats, Run Options safety, or
   selector resolution across multiple commands.
@@ -238,9 +243,9 @@ Make diff inspection useful for large changes without forcing users into another
 
 - Scope: file list, sticky revision/file context, diff search, next/previous file actions,
   two-revision diffs, horizontal overflow controls, edge-case fixtures, and file-only/details mode.
-- Current implementation status: diff views support `[ ]` file movement, `{ }` hunk movement, search,
-  horizontal scroll, sticky/current-file context, diff format View Options, and an `f` file selector
-  that jumps to the chosen file in the active diff.
+- Current implementation status: diff views support `[ ]` file movement, `{ }` hunk movement,
+  search, horizontal scroll, sticky/current-file context, diff format View Options, and an `f` file
+  selector that jumps to the chosen file in the active diff.
 - Acceptance: users can search within a diff, jump between files, inspect name-only/stat/detail
   variants, compare two selected revisions with the shown jj command, recover from empty or failed
   diff loads without leaving the TUI, and use a searchable file list once the shared file selector
@@ -412,10 +417,9 @@ Every major workflow issue should include:
 
 ## Website And Release Visibility
 
-Product-visible `jk` changes should trigger a pass through the companion
-[`jk-website`](https://github.com/joshka/jk-website) repository when they change install
-instructions, released features, key workflows, screenshots, GIFs, command examples, or
-README/crates.io positioning.
+Product-visible `jk` changes should trigger a website pass in `/Users/joshka/local/jk-website`
+when they change install instructions, released features, key workflows, screenshots, GIFs, command
+examples, or README/crates.io positioning.
 
 README, crates.io, website, and release-note media should come from
 [Betamax](https://www.joshka.net/betamax/) tapes. Store generated README and crates.io media in the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,136 @@
+# Using jk
+
+This guide shows the shortest paths through the current `jk` TUI. It is not a complete key
+reference. Press `?` inside `jk` for the full key list for the active screen.
+
+## Start From The Log
+
+Run:
+
+```sh
+jk
+```
+
+Use the log as the place to keep context while inspecting or changing the repository:
+
+- `Enter` opens `jj show` for the selected change.
+- `d` opens `jj diff` for the selected change.
+- `v` opens the selected change's evolog.
+- `s` opens repository status.
+- `Backspace` or `Esc` returns to the previous view.
+- `r` refreshes the active view.
+
+`jk log -T <template>` changes the rendered log template, but the navigation pass still uses `jk`'s
+internal template so movement and selection stay stable.
+
+## Review A Diff
+
+Open a diff from the log with `d`, or start from the command line:
+
+```sh
+jk diff -r <revision>
+jk diff --from <from> --to <to>
+jk diff --stat
+```
+
+Use the smallest set of controls that gets you through review:
+
+- `[` and `]` move between files.
+- `{` and `}` move between hunks.
+- `f` opens the file list.
+- `/`, `n`, and `N` search visible diff text.
+- `h` and `l` fold or unfold the current file.
+- `V` changes diff output format, such as patch, stat, summary, name-only, git, or color-words.
+
+The diff view still renders `jj diff`; `jk` adds navigation, folding, search, current-file context,
+and format switching around that output.
+
+## Preview A Local Mutation
+
+Mutation shortcuts open a preview instead of running immediately:
+
+- `m` previews `jj describe` for the selected revision.
+- `a` previews `jj abandon <revision>`.
+- `n` previews `jj new <parents>` from marks or the selected revision.
+- `e` previews `jj edit <revision>`.
+- `u` previews `jj undo`.
+- `U` previews `jj redo`.
+
+In the preview:
+
+- `Enter` runs the displayed command.
+- `y` copies the displayed command line.
+- `Esc` cancels.
+
+After a confirmed mutation, `jk` refreshes the log and records the result in Command History. When
+`jj` reports a resulting operation id, Command History can open the exact `jj op show` view.
+
+## Run A Direct jj Command
+
+Press `:` to run a direct `jj` command without leaving the TUI:
+
+```text
+:status
+:log -r 'mine()'
+:describe -m "new message" @
+```
+
+Command mode accepts an optional `jj` prefix. It parses argv-like input, does not invoke a shell,
+captures stdout and stderr, and records the result in Command History.
+
+From command output, press `e` to reopen command mode with the previous input.
+
+## Inspect History And Operations
+
+Press `C` for Command History. Use it to inspect what `jk` ran, copy exact commands, and follow
+operation links.
+
+Useful history path:
+
+1. Press `C`.
+1. Press `Enter` to inspect argv, output, status, duration, and operation metadata.
+1. Press `o` to open the recorded operation. If the selected record has no operation id, `jk` opens
+   Operation Log instead.
+
+Press `o` from the log to open Operation Log directly. Operation show and diff views behave like
+other rendered inspection views: search, page, refresh, and return work the same way.
+
+## Inspect Workspaces
+
+Press `W` to list jj workspaces, or start there with `jk workspaces`. From there:
+
+- `l` opens log for the selected workspace.
+- `Enter` or `s` opens status for the selected workspace.
+- `d` opens diff for the selected workspace.
+- `u` runs `jj workspace update-stale` when the selected workspace is stale.
+- `r` refreshes the workspace list.
+
+Missing workspace roots are reported inside `jk` instead of pushing a broken view.
+
+## Command Entry Points
+
+The current root commands are:
+
+```sh
+jk
+jk log [-n <limit>] [-T <template>]
+jk diff -r <revision>
+jk diff --from <from> --to <to>
+jk diff --stat
+jk diff --name-only
+jk diff --git
+jk diff --color-words
+jk show <revision>...
+jk status [fileset]...
+jk -R /path/to/repo -n 20
+```
+
+`jk` also has in-app paths for evolog, workspaces, operation views, command previews, and command
+history.
+
+## Current Limits
+
+- Command History is in-memory for the current `jk` session.
+- Rebase, squash, split, restore, bookmarks, fetch, and push are planned workflows.
+- Direct mutation keys are dogfood shortcuts until the broader action menu exists.
+- Public README, crates.io, and website media still need a release-media refresh.

--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
 set shell := ["bash", "-uc"]
 
+betamax := env_var_or_default("BETAMAX", "betamax")
+
 default:
     @just --list
 
@@ -30,16 +32,19 @@ betamax: betamax-log betamax-diff
 readme-media: readme-log-media readme-diff-media
 
 readme-log-media:
-    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run tapes/readme-log.tape
+    {{betamax}} run tapes/readme-log.tape
 
 readme-diff-media:
-    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run tapes/readme-diff.tape
+    {{betamax}} run tapes/readme-diff.tape
 
 betamax-log:
-    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run tapes/jk-log.tape
+    {{betamax}} run tapes/jk-log.tape
 
 betamax-diff:
-    cargo run --manifest-path ../../betamax/Cargo.toml -p betamax -- run tapes/jk-diff.tape
+    {{betamax}} run tapes/jk-diff.tape
+
+betamax-release-smoke:
+    {{betamax}} run tapes/release-smoke.tape
 
 clippy:
     cargo clippy --workspace --all-targets -- -D warnings

--- a/tapes/jk-diff.tape
+++ b/tapes/jk-diff.tape
@@ -1,5 +1,5 @@
-Output target/betamax/jk-diff.gif
-Output target/betamax/jk-diff-final-state.json
+Output target/dogfood-artifacts/betamax/jk-diff.gif
+Output target/dogfood-artifacts/betamax/jk-diff-final-state.json
 
 Require cargo
 Require jj
@@ -9,10 +9,12 @@ Set Theme "Aardvark Ink"
 Set FontSize 22
 Set Width 1200
 Set Height 720
-Set Margin 12
+Set Padding 0
+Set Margin 20
 Set WindowBar Colorful
 Set BorderRadius 8
 Set CursorBlink false
+Set KeyboardOverlay Input
 Set TypingSpeed 20ms
 Set WaitTimeout 30s
 Env NO_COLOR "1"
@@ -29,61 +31,70 @@ Enter
 Wait+Screen "JK_BUILD_READY"
 Show
 
+Caption "Open a diff from the log when you want to inspect the selected change."
 Type "./target/debug/jk -R . -n 8"
 Enter
 Wait+Screen "jk jj"
 Sleep 500ms
 Type "d"
 Wait+Screen "jk jj diff"
-Sleep 500ms
-Screenshot target/betamax/jk-diff-open.png
-State target/betamax/jk-diff-open.json
+Sleep 1200ms
+Screenshot target/dogfood-artifacts/betamax/jk-diff-open.png
+State target/dogfood-artifacts/betamax/jk-diff-open.json
+
+Caption "Help is available without leaving the diff view."
+Type "?"
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-diff-help.png
+State target/dogfood-artifacts/betamax/jk-diff-help.json
 
 Type "?"
 Sleep 300ms
-Screenshot target/betamax/jk-diff-help.png
-State target/betamax/jk-diff-help.json
-
-Type "?"
-Sleep 300ms
+Caption "Search highlights matching diff text in place."
 Type "/"
 Sleep 200ms
 Type "diff"
 Enter
-Sleep 300ms
-Screenshot target/betamax/jk-diff-search.png
-State target/betamax/jk-diff-search.json
+Sleep 1200ms
+Screenshot target/dogfood-artifacts/betamax/jk-diff-search.png
+State target/dogfood-artifacts/betamax/jk-diff-search.json
 
+Caption "Jump between hunks instead of paging blindly through long patches."
 Type "}"
-Sleep 300ms
-Screenshot target/betamax/jk-diff-next-hunk.png
-State target/betamax/jk-diff-next-hunk.json
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-diff-next-hunk.png
+State target/dogfood-artifacts/betamax/jk-diff-next-hunk.json
 
+Caption "Fold a hunk when its context is no longer relevant."
 Type "-"
-Sleep 300ms
-Screenshot target/betamax/jk-diff-fold-hunk.png
-State target/betamax/jk-diff-fold-hunk.json
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-diff-fold-hunk.png
+State target/dogfood-artifacts/betamax/jk-diff-fold-hunk.json
 
+Caption "Fold a file to reduce a large diff to the parts still in play."
 Type "+"
 Sleep 300ms
 Type "h"
-Sleep 300ms
-Screenshot target/betamax/jk-diff-fold-file.png
-State target/betamax/jk-diff-fold-file.json
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-diff-fold-file.png
+State target/dogfood-artifacts/betamax/jk-diff-fold-file.json
 
+Caption "Horizontal movement keeps long diff lines readable."
 Type "l"
 Sleep 300ms
 Type ">"
-Sleep 300ms
-Screenshot target/betamax/jk-diff-horizontal.png
-State target/betamax/jk-diff-horizontal.json
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-diff-horizontal.png
+State target/dogfood-artifacts/betamax/jk-diff-horizontal.json
 
+Caption "Return to the log when the inspection is done."
 Type "L"
 Wait+Screen "jk jj"
-Sleep 300ms
-Screenshot target/betamax/jk-diff-return-log.png
-State target/betamax/jk-diff-return-log.json
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-diff-return-log.png
+State target/dogfood-artifacts/betamax/jk-diff-return-log.json
 
+Caption ""
 Type "q"
 Hide
 Type "exit"

--- a/tapes/jk-log.tape
+++ b/tapes/jk-log.tape
@@ -1,5 +1,5 @@
-Output target/betamax/jk-log.gif
-Output target/betamax/jk-log-final-state.json
+Output target/dogfood-artifacts/betamax/jk-log.gif
+Output target/dogfood-artifacts/betamax/jk-log-final-state.json
 
 Require cargo
 Require jj
@@ -9,10 +9,12 @@ Set Theme "Aardvark Ink"
 Set FontSize 22
 Set Width 1200
 Set Height 720
-Set Margin 12
+Set Padding 0
+Set Margin 20
 Set WindowBar Colorful
 Set BorderRadius 8
 Set CursorBlink false
+Set KeyboardOverlay Input
 Set TypingSpeed 20ms
 Set WaitTimeout 30s
 Env NO_COLOR "1"
@@ -29,65 +31,75 @@ Enter
 Wait+Screen "JK_BUILD_READY"
 Show
 
+Caption "The home log starts with the working-copy change selected."
 Type "./target/debug/jk -R . -n 3"
 Enter
 Wait+Screen "jk jj"
-Sleep 1s
-Screenshot target/betamax/jk-log-initial.png
-State target/betamax/jk-log-initial.json
+Sleep 1400ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-initial.png
+State target/dogfood-artifacts/betamax/jk-log-initial.json
 
+Caption "L switches to the explicit jj log root view."
 Type "L"
 Wait+Screen "jk jj log"
-Sleep 300ms
-Screenshot target/betamax/jk-log-switched-log.png
-State target/betamax/jk-log-switched-log.json
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-switched-log.png
+State target/dogfood-artifacts/betamax/jk-log-switched-log.json
 
+Caption "H returns to the home view without losing the selected change."
 Type "H"
 Wait+Screen "/jk jj *\\n/"
-Sleep 300ms
-Screenshot target/betamax/jk-log-switched-home.png
-State target/betamax/jk-log-switched-home.json
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-switched-home.png
+State target/dogfood-artifacts/betamax/jk-log-switched-home.json
 
+Caption "j and k move the selected change through the graph."
 Type "j"
-Sleep 300ms
-Screenshot target/betamax/jk-log-selected-second.png
-State target/betamax/jk-log-selected-second.json
+Sleep 800ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-selected-second.png
+State target/dogfood-artifacts/betamax/jk-log-selected-second.json
 
 Type "k"
-Sleep 300ms
-Screenshot target/betamax/jk-log-selected-first-again.png
-State target/betamax/jk-log-selected-first-again.json
+Sleep 800ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-selected-first-again.png
+State target/dogfood-artifacts/betamax/jk-log-selected-first-again.json
 
+Caption "Enter opens the selected change without replacing the log context."
 Enter
-Sleep 300ms
-Screenshot target/betamax/jk-log-expanded.png
-State target/betamax/jk-log-expanded.json
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-expanded.png
+State target/dogfood-artifacts/betamax/jk-log-expanded.json
 
+Caption "Arrow keys collapse and expand long rendered change details."
 Left
-Sleep 300ms
-Screenshot target/betamax/jk-log-collapsed-left.png
-State target/betamax/jk-log-collapsed-left.json
+Sleep 800ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-collapsed-left.png
+State target/dogfood-artifacts/betamax/jk-log-collapsed-left.json
 
 Right
-Sleep 300ms
-Screenshot target/betamax/jk-log-expanded-right.png
-State target/betamax/jk-log-expanded-right.json
+Sleep 800ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-expanded-right.png
+State target/dogfood-artifacts/betamax/jk-log-expanded-right.json
 
+Caption "Refresh re-runs the jj command while preserving the visible context."
 Type "r"
-Sleep 500ms
-Screenshot target/betamax/jk-log-refreshed.png
-State target/betamax/jk-log-refreshed.json
+Sleep 1000ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-refreshed.png
+State target/dogfood-artifacts/betamax/jk-log-refreshed.json
 
+Caption ""
 Type "q"
 Sleep 300ms
 
+Caption "Direct root commands open the same jk surface."
 Type "./target/debug/jk -R . log -n 3"
 Enter
 Wait+Screen "jk jj log"
-Sleep 1s
-Screenshot target/betamax/jk-log-command.png
-State target/betamax/jk-log-command.json
+Sleep 1400ms
+Screenshot target/dogfood-artifacts/betamax/jk-log-command.png
+State target/dogfood-artifacts/betamax/jk-log-command.json
 
+Caption ""
 Type "q"
 Hide
 Type "exit"

--- a/tapes/readme-diff.tape
+++ b/tapes/readme-diff.tape
@@ -1,5 +1,5 @@
-Output ../../jk-screenshots/assets/jk-diff-v3.gif
-Output target/betamax/readme-diff-final-state.json
+Output target/dogfood-artifacts/readme-media/jk-diff-v3.gif
+Output target/dogfood-artifacts/betamax/readme-diff-final-state.json
 
 Require cargo
 Require jj
@@ -9,10 +9,11 @@ Set Theme "Aardvark Ink"
 Set Width 1200
 Set Height 720
 Set Padding 0
-Set Margin 0
+Set Margin 20
 Set WindowBar Colorful
-Set BorderRadius 0
+Set BorderRadius 8
 Set CursorBlink false
+Set KeyboardOverlay Input
 Set TypingSpeed 24ms
 Set WaitTimeout 30s
 Env NO_COLOR "1"
@@ -21,7 +22,7 @@ Hide
 Type "repo=${JK_REPO:-$HOME/local/jk/default}"
 Enter
 Wait
-Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && mkdir -p ../../jk-screenshots/assets target/betamax"
+Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && mkdir -p target/dogfood-artifacts/readme-media target/dogfood-artifacts/betamax"
 Enter
 Wait+Line
 Type "cargo build --manifest-path Cargo.toml -p jk >/tmp/jk-readme-betamax-build.log 2>&1 && echo JK_BUILD_READY"
@@ -35,28 +36,31 @@ Enter
 Wait+Screen "jk jj diff"
 Sleep 1100ms
 Show
-Screenshot ../../jk-screenshots/assets/jk-diff-v3.png
+Screenshot target/dogfood-artifacts/readme-media/jk-diff-v3.png
 
 Hide
+Caption "Help appears as an overlay, keeping the diff in place underneath."
 Type "?"
-Sleep 500ms
-Screenshot ../../jk-screenshots/assets/jk-diff-help-v3.png
+Sleep 1200ms
+Screenshot target/dogfood-artifacts/readme-media/jk-diff-help-v3.png
 
 Type "?"
 Sleep 300ms
 Show
+Caption "Search jumps through rendered diff text without leaving the TUI."
 Type "/"
 Sleep 250ms
 Type "diff"
 Enter
-Sleep 800ms
-Screenshot ../../jk-screenshots/assets/jk-diff-search-v3.png
+Sleep 1400ms
+Screenshot target/dogfood-artifacts/readme-media/jk-diff-search-v3.png
 
+Caption "Hunk and file folding keeps large diffs scannable."
 Type "}"
 Sleep 700ms
 Type "-"
-Sleep 1s
-Screenshot ../../jk-screenshots/assets/jk-diff-folded-hunk-v3.png
+Sleep 1400ms
+Screenshot target/dogfood-artifacts/readme-media/jk-diff-folded-hunk-v3.png
 
 Type "j"
 Sleep 180ms
@@ -73,9 +77,10 @@ Sleep 900ms
 Type "+"
 Sleep 700ms
 Type "h"
-Sleep 1s
-Screenshot ../../jk-screenshots/assets/jk-diff-folded-file-v3.png
+Sleep 1400ms
+Screenshot target/dogfood-artifacts/readme-media/jk-diff-folded-file-v3.png
 
+Caption ""
 Hide
 Type "q"
 Sleep 500ms

--- a/tapes/readme-log.tape
+++ b/tapes/readme-log.tape
@@ -1,5 +1,5 @@
-Output ../../jk-screenshots/assets/jk-log-v3.gif
-Output target/betamax/readme-log-final-state.json
+Output target/dogfood-artifacts/readme-media/jk-log-v3.gif
+Output target/dogfood-artifacts/betamax/readme-log-final-state.json
 
 Require cargo
 Require jj
@@ -9,10 +9,11 @@ Set Theme "Aardvark Ink"
 Set Width 1200
 Set Height 720
 Set Padding 0
-Set Margin 0
+Set Margin 20
 Set WindowBar Colorful
-Set BorderRadius 0
+Set BorderRadius 8
 Set CursorBlink false
+Set KeyboardOverlay Off
 Set TypingSpeed 24ms
 Set WaitTimeout 30s
 Env NO_COLOR "1"
@@ -21,7 +22,7 @@ Hide
 Type "repo=${JK_REPO:-$HOME/local/jk/default}"
 Enter
 Wait
-Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && mkdir -p ../../jk-screenshots/assets target/betamax"
+Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && mkdir -p target/dogfood-artifacts/readme-media target/dogfood-artifacts/betamax"
 Enter
 Wait+Line
 Type "cargo build --manifest-path Cargo.toml -p jk >/tmp/jk-readme-betamax-build.log 2>&1 && echo JK_BUILD_READY"
@@ -35,12 +36,12 @@ Enter
 Wait+Screen "jk jj"
 Sleep 1s
 Show
-Screenshot ../../jk-screenshots/assets/jk-log-v3.png
+Screenshot target/dogfood-artifacts/readme-media/jk-log-v3.png
 
 Hide
 Type "?"
 Sleep 500ms
-Screenshot ../../jk-screenshots/assets/jk-log-help-v3.png
+Screenshot target/dogfood-artifacts/readme-media/jk-log-help-v3.png
 
 Type "?"
 Sleep 300ms
@@ -49,11 +50,11 @@ Type "j"
 Sleep 450ms
 Type "j"
 Sleep 700ms
-Screenshot ../../jk-screenshots/assets/jk-log-selection-v3.png
+Screenshot target/dogfood-artifacts/readme-media/jk-log-selection-v3.png
 
 Enter
 Sleep 700ms
-Screenshot ../../jk-screenshots/assets/jk-log-expanded-v3.png
+Screenshot target/dogfood-artifacts/readme-media/jk-log-expanded-v3.png
 
 Type "d"
 Wait+Screen "jk jj diff"

--- a/tapes/release-smoke.tape
+++ b/tapes/release-smoke.tape
@@ -1,0 +1,129 @@
+Output target/dogfood-artifacts/betamax/release-smoke.gif
+Output target/dogfood-artifacts/betamax/release-smoke-final-state.json
+
+Require cargo
+Require jj
+
+Set Shell "bash"
+Set Theme "Aardvark Ink"
+Set FontSize 22
+Set Width 1200
+Set Height 720
+Set Padding 0
+Set Margin 20
+Set WindowBar Colorful
+Set BorderRadius 8
+Set CursorBlink false
+Set KeyboardOverlay Input
+Set TypingSpeed 20ms
+Set WaitTimeout 30s
+Env NO_COLOR "1"
+
+Hide
+Type "source_repo=${JK_SOURCE_REPO:-$HOME/local/jk/default}"
+Enter
+Wait
+Type "cd \"$source_repo\" && test -f Cargo.toml && mkdir -p target/dogfood-artifacts/betamax && echo JK_SOURCE_READY"
+Enter
+Wait+Screen "JK_SOURCE_READY"
+Type "cargo build --manifest-path Cargo.toml -p jk >/tmp/jk-release-smoke-build.log 2>&1 && echo JK_BUILD_READY"
+Enter
+Wait+Screen "JK_BUILD_READY"
+Type "fixture=$(mktemp -d)"
+Enter
+Wait
+Type "cd \"$fixture\" && jj git init --colocate >/tmp/jk-release-smoke-init.log 2>&1"
+Enter
+Wait
+Type "printf 'one\\n' > file.txt && jj file track file.txt >/dev/null 2>&1 || true"
+Enter
+Wait
+Type "jj describe -m 'Initial workspace' >/dev/null && jj new -m 'Second change' >/dev/null"
+Enter
+Wait
+Type "printf 'two\\n' >> file.txt && bin=\"$source_repo/target/debug/jk\" && echo JK_FIXTURE_READY"
+Enter
+Wait+Screen "JK_FIXTURE_READY"
+Show
+
+Caption "Root status opens the same rendered jk surface used inside jk."
+Type "\"$bin\" -R \"$fixture\" status"
+Enter
+Wait+Screen "file.txt"
+Sleep 1200ms
+State target/dogfood-artifacts/betamax/release-smoke-status.json
+Type "q"
+Sleep 1500ms
+
+Caption "Workspace scope is available as an early, top-level workflow."
+Type "\"$bin\" -R \"$fixture\" workspaces"
+Enter
+Wait+Screen "workspace list"
+Sleep 1200ms
+State target/dogfood-artifacts/betamax/release-smoke-workspaces.json
+Type "q"
+Sleep 1500ms
+
+Caption "Command mode accepts direct jj commands without leaving the TUI."
+Type "\"$bin\" -R \"$fixture\" -n 5"
+Enter
+Wait+Screen "jk jj"
+Sleep 500ms
+Type ":"
+Sleep 200ms
+Type "status"
+Enter
+Wait+Screen "file.txt"
+Sleep 1200ms
+State target/dogfood-artifacts/betamax/release-smoke-command-status.json
+Type "q"
+Sleep 1500ms
+
+Caption "Failed jj commands stay visible as recoverable command output."
+Type "\"$bin\" -R \"$fixture\" -n 5"
+Enter
+Wait+Screen "jk jj"
+Sleep 500ms
+Type ":"
+Sleep 200ms
+Type "not-a-jj-command"
+Enter
+Wait+Screen "not-a-jj-command"
+Sleep 1200ms
+State target/dogfood-artifacts/betamax/release-smoke-command-failure.json
+Type "q"
+Sleep 1500ms
+
+Caption "Mutation shortcuts show a jj command preview before anything runs."
+Type "\"$bin\" -R \"$fixture\" -n 5"
+Enter
+Wait+Screen "jk jj"
+Sleep 500ms
+Type "m"
+Wait+Screen "Describe revision"
+Ctrl+U
+Type "Release smoke message"
+Enter
+Wait+Screen "Confirm command"
+Sleep 1200ms
+State target/dogfood-artifacts/betamax/release-smoke-describe-preview.json
+Enter
+Wait+Screen "Release smoke message"
+Caption "After confirmation, jk refreshes the log with the new description."
+Sleep 1200ms
+State target/dogfood-artifacts/betamax/release-smoke-after-describe.json
+Caption "Command History records the mutation, output, and captured operation."
+Type "C"
+Wait+Screen "Command History"
+Sleep 1200ms
+State target/dogfood-artifacts/betamax/release-smoke-command-history.json
+Caption "The captured operation opens directly for recovery and audit context."
+Type "o"
+Wait+Screen "Changed commits"
+Sleep 1200ms
+State target/dogfood-artifacts/betamax/release-smoke-operation-show.json
+Caption ""
+Type "q"
+Hide
+Type "exit"
+Enter


### PR DESCRIPTION
## Summary

Release the current jk TUI snapshot: jj-native log, show, diff, status, evolog, workspace navigation, command mode, command history, operation recovery, safe mutation previews, and release documentation/media.

This also splits the large app loop into focused support modules so the shipped TUI behavior is reviewable without carrying everything in `main.rs`.

Please preserve the commit history for this PR; the stack is written as the durable implementation record and should not be squash merged.

## Validation

- `just release-check`
- `BETAMAX=/Users/joshka/.cargo/bin/betamax just readme-media`
- `JK_SOURCE_REPO=/path/to/jk BETAMAX=/Users/joshka/.cargo/bin/betamax just betamax-release-smoke`
- `cargo install --path crates/jk --locked --force`
- website companion build: `pnpm build` in `jk-website`

## Media

README and crates.io media are kept in the separate `jk-screenshots` repo. Website-specific media is kept in `jk-website`. Generated media remains out of the main jk repository.
