### PR TITLE
Simplify selected row highlight

### DIFF
--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -594,13 +594,20 @@ mod tests {
         assert_eq!(cell.bg, Color::Rgb(82, 196, 192));
         assert_eq!(
             terminal.backend().buffer()[(23, 1)].bg,
-            Color::Rgb(12, 32, 38)
+            Color::Rgb(82, 196, 192)
         );
         assert_eq!(
-            terminal.backend().buffer()[(35, 1)].bg,
-            Color::Rgb(12, 32, 38)
+            terminal.backend().buffer()[(23, 1)].fg,
+            Color::Rgb(15, 20, 31)
         );
-        assert_eq!(terminal.backend().buffer()[(36, 1)].bg, Color::Reset);
+        assert_eq!(
+            terminal.backend().buffer()[(36, 1)].bg,
+            Color::Rgb(82, 196, 192)
+        );
+        assert_eq!(
+            terminal.backend().buffer()[(36, 1)].fg,
+            Color::Rgb(15, 20, 31)
+        );
         assert!(cell.modifier.contains(ratatui::prelude::Modifier::BOLD));
     }
 
@@ -627,9 +634,10 @@ mod tests {
         assert_eq!(buffer[(0, 1)].bg, Color::Reset);
         assert_eq!(buffer[(0, 2)].bg, Color::Rgb(82, 196, 192));
         assert_eq!(buffer[(0, 2)].fg, Color::Rgb(15, 20, 31));
-        assert_eq!(buffer[(23, 2)].bg, Color::Rgb(12, 32, 38));
-        assert_eq!(buffer[(35, 2)].bg, Color::Rgb(12, 32, 38));
-        assert_eq!(buffer[(36, 2)].bg, Color::Reset);
+        assert_eq!(buffer[(23, 2)].bg, Color::Rgb(82, 196, 192));
+        assert_eq!(buffer[(23, 2)].fg, Color::Rgb(15, 20, 31));
+        assert_eq!(buffer[(36, 2)].bg, Color::Rgb(82, 196, 192));
+        assert_eq!(buffer[(36, 2)].fg, Color::Rgb(15, 20, 31));
     }
 
     #[test]

--- a/crates/jk-tui/src/selected_row.rs
+++ b/crates/jk-tui/src/selected_row.rs
@@ -1,19 +1,15 @@
 //! Selected-row highlighting for rendered log output.
 //!
 //! The highlight is painted directly into the Ratatui buffer after the log body renders. This keeps
-//! the `jj` text intact while making selection visible with a short cyan gradient that fades back
-//! to the terminal background.
+//! the `jj` text intact while making selection visible with one high-contrast row color.
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::prelude::Color;
 
-const SELECTED_ROW_START: RgbColor = RgbColor::new(82, 196, 192);
-const SELECTED_ROW_END: RgbColor = RgbColor::new(12, 32, 38);
-const SELECTED_GRAPH_FG: RgbColor = RgbColor::new(15, 20, 31);
-const SELECTED_ROW_FADE_COLUMNS: usize = 24;
-const SELECTED_ROW_TOTAL_COLUMNS: usize = 36;
-const SUBTLE_SELECTED_ROW_BG: RgbColor = RgbColor::new(34, 40, 44);
+const SELECTED_ROW_BG: Color = Color::Rgb(82, 196, 192);
+const SELECTED_ROW_FG: Color = Color::Rgb(15, 20, 31);
+const SUBTLE_SELECTED_ROW_BG: Color = Color::Rgb(34, 40, 44);
 
 /// Paints the visible selected row background in the content area.
 pub fn paint_selected_row(
@@ -39,12 +35,9 @@ pub fn paint_selected_row(
 
     let y = area.y + visible_line;
     for x in area.left()..area.right() {
-        let column = usize::from(x - area.left());
-        let width = usize::from(area.width);
-        frame.buffer_mut()[(x, y)].set_bg(selected_row_bg(column, width));
+        frame.buffer_mut()[(x, y)].set_bg(SELECTED_ROW_BG);
+        frame.buffer_mut()[(x, y)].set_fg(SELECTED_ROW_FG);
     }
-
-    frame.buffer_mut()[(area.left(), y)].set_fg(SELECTED_GRAPH_FG.into_color());
 }
 
 /// Paints a quiet full-width selected row for non-graph content.
@@ -71,71 +64,8 @@ pub fn paint_subtle_selected_row(
 
     let y = area.y + visible_line;
     for x in area.left()..area.right() {
-        frame.buffer_mut()[(x, y)].set_bg(SUBTLE_SELECTED_ROW_BG.into_color());
+        frame.buffer_mut()[(x, y)].set_bg(SUBTLE_SELECTED_ROW_BG);
     }
-}
-
-/// Returns the background color for one column of the selection highlight.
-fn selected_row_bg(column: usize, width: usize) -> Color {
-    if column >= SELECTED_ROW_TOTAL_COLUMNS {
-        return Color::Reset;
-    }
-
-    selected_row_gradient(column, width).into_color()
-}
-
-/// Interpolates the visible gradient before the tail resets to the terminal.
-fn selected_row_gradient(column: usize, width: usize) -> RgbColor {
-    let fade_width = width
-        .min(SELECTED_ROW_TOTAL_COLUMNS)
-        .min(SELECTED_ROW_FADE_COLUMNS);
-    let steps = fade_width.saturating_sub(1).max(1);
-    SELECTED_ROW_START.interpolate(SELECTED_ROW_END, column.min(steps), steps)
-}
-
-/// Small RGB value used to keep gradient math independent from Ratatui.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct RgbColor {
-    red: u8,
-    green: u8,
-    blue: u8,
-}
-
-impl RgbColor {
-    /// Creates an RGB color from channel values.
-    const fn new(red: u8, green: u8, blue: u8) -> Self {
-        Self { red, green, blue }
-    }
-
-    /// Interpolates between two RGB colors using integer channel math.
-    fn interpolate(self, end: Self, step: usize, steps: usize) -> Self {
-        Self {
-            red: interpolate_channel(self.red, end.red, step, steps),
-            green: interpolate_channel(self.green, end.green, step, steps),
-            blue: interpolate_channel(self.blue, end.blue, step, steps),
-        }
-    }
-
-    /// Converts this color into Ratatui's RGB color type.
-    const fn into_color(self) -> Color {
-        Color::Rgb(self.red, self.green, self.blue)
-    }
-}
-
-/// Interpolates one color channel without using float rounding.
-fn interpolate_channel(start: u8, end: u8, step: usize, steps: usize) -> u8 {
-    let start = usize::from(start);
-    let end = usize::from(end);
-    if start <= end {
-        channel_from_usize(start + ((end - start) * step / steps))
-    } else {
-        channel_from_usize(start - ((start - end) * step / steps))
-    }
-}
-
-/// Converts a calculated channel value into a saturated byte.
-fn channel_from_usize(value: usize) -> u8 {
-    u8::try_from(value).unwrap_or(u8::MAX)
 }
 
 #[cfg(test)]
@@ -143,26 +73,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn selected_row_background_darkens_from_cool_blue_then_resets() {
-        assert_eq!(
-            selected_row_bg(0, 5),
-            Color::Rgb(
-                SELECTED_ROW_START.red,
-                SELECTED_ROW_START.green,
-                SELECTED_ROW_START.blue
-            )
-        );
-        assert_eq!(
-            selected_row_bg(23, 80),
-            Color::Rgb(
-                SELECTED_ROW_END.red,
-                SELECTED_ROW_END.green,
-                SELECTED_ROW_END.blue
-            )
-        );
-        assert_eq!(selected_row_bg(35, 80), selected_row_bg(23, 80));
-        assert_eq!(selected_row_bg(36, 80), Color::Reset);
-        assert_eq!(selected_row_bg(12, 80), Color::Rgb(46, 111, 112));
+    fn selected_row_uses_flat_high_contrast_colors() {
+        let backend = ratatui::backend::TestBackend::new(3, 1);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test backend should initialize");
+
+        let draw_result = terminal.draw(|frame| {
+            paint_selected_row(frame, Rect::new(0, 0, 3, 1), 0, 0);
+        });
+
+        assert!(draw_result.is_ok());
+        assert_eq!(terminal.backend().buffer()[(0, 0)].bg, SELECTED_ROW_BG);
+        assert_eq!(terminal.backend().buffer()[(0, 0)].fg, SELECTED_ROW_FG);
+        assert_eq!(terminal.backend().buffer()[(2, 0)].bg, SELECTED_ROW_BG);
+        assert_eq!(terminal.backend().buffer()[(2, 0)].fg, SELECTED_ROW_FG);
     }
 
     #[test]
@@ -190,11 +113,11 @@ mod tests {
         assert!(draw_result.is_ok());
         assert_eq!(
             terminal.backend().buffer()[(0, 0)].bg,
-            SUBTLE_SELECTED_ROW_BG.into_color()
+            SUBTLE_SELECTED_ROW_BG
         );
         assert_eq!(
             terminal.backend().buffer()[(2, 0)].bg,
-            SUBTLE_SELECTED_ROW_BG.into_color()
+            SUBTLE_SELECTED_ROW_BG
         );
     }
 }


### PR DESCRIPTION
Replace the experimental gradient log selection highlight with a flat high-contrast selected row. The selected log row now uses one cyan-like background across the full row with dark foreground text, and the gradient interpolation helper is removed.\n\nValidation:\n- cargo test -p jk-tui\n- cargo fmt --check\n- cargo check -p jk-tui