### PR TITLE
Fix log graph expansion links

### DIFF
--- a/crates/jk-tui/src/log_state.rs
+++ b/crates/jk-tui/src/log_state.rs
@@ -327,10 +327,7 @@ impl LogState {
             return None;
         }
 
-        self.entries
-            .get(selected + 1)
-            .map(|entry| entry.rendered_line().saturating_sub(1))
-            .or_else(|| last_entry_line(&self.rendered))
+        self.entry_content_end_line(selected)
     }
 
     /// Returns the selected entry's rendered line.
@@ -341,12 +338,40 @@ impl LogState {
     /// Returns the final rendered line that belongs to the selected entry.
     fn selected_entry_end_line(&self) -> Option<usize> {
         let selected = self.selected?;
-        self.entries
-            .get(selected + 1)
-            .map(|entry| entry.rendered_line().saturating_sub(1))
-            .or_else(|| last_entry_line(&self.rendered))
+        self.entry_content_end_line(selected)
     }
 
+    /// Returns the last rendered line that is content for the entry.
+    fn entry_content_end_line(&self, entry_index: usize) -> Option<usize> {
+        let start = self.entries.get(entry_index)?.rendered_line();
+        let end = self
+            .entries
+            .get(entry_index + 1)
+            .map_or_else(|| self.rendered.lines().count(), LogEntry::rendered_line);
+        content_end_line(&self.rendered, start, end)
+    }
+}
+
+/// Finds the final rendered line that belongs to a visible log entry.
+fn content_end_line(rendered: &str, start: usize, end: usize) -> Option<usize> {
+    rendered
+        .lines()
+        .enumerate()
+        .skip(start)
+        .take(end.saturating_sub(start))
+        .filter(|(_, line)| !is_separator_line(line))
+        .map(|(index, _)| index)
+        .last()
+}
+
+/// Returns whether a rendered line is a separator after an entry instead of entry content.
+fn is_separator_line(line: &str) -> bool {
+    strip_ansi(line).trim().is_empty()
+        || is_graph_elision_line(line)
+        || is_graph_connector_line(line)
+}
+
+impl LogState {
     /// Scrolls upward when selection moves above the current viewport.
     fn keep_selected_visible(&mut self) {
         let Some(selected_line) = self.selected_rendered_line() else {
@@ -394,20 +419,45 @@ impl LogState {
     }
 }
 
-/// Finds the final rendered line that belongs to a visible log entry.
-fn last_entry_line(rendered: &str) -> Option<usize> {
-    let mut last_entry_line = None;
-    for (index, line) in rendered.lines().enumerate() {
-        if !is_graph_elision_line(line) {
-            last_entry_line = Some(index);
-        }
-    }
-    last_entry_line
-}
-
 /// Returns whether a rendered line is jj's hidden-revision graph elision.
 fn is_graph_elision_line(line: &str) -> bool {
-    strip_ansi(line).trim() == "~"
+    strip_ansi(line)
+        .trim_start()
+        .chars()
+        .find(|character| !is_graph_prefix(*character))
+        == Some('~')
+}
+
+/// Returns whether a rendered line is a graph connector tail after an entry.
+fn is_graph_connector_line(line: &str) -> bool {
+    let line = strip_ansi(line);
+    let mut seen_graph = false;
+    let mut has_connector = false;
+
+    for character in line.trim_end().chars() {
+        if is_graph_prefix(character) {
+            seen_graph = true;
+            has_connector |= is_graph_connector(character);
+            continue;
+        }
+
+        break;
+    }
+
+    seen_graph && has_connector
+}
+
+/// Returns whether a character can appear before jj's elision marker in a graph line.
+const fn is_graph_prefix(character: char) -> bool {
+    matches!(
+        character,
+        ' ' | '│' | '─' | '├' | '╭' | '╮' | '╯' | '╰' | '╲' | '╱'
+    )
+}
+
+/// Returns whether a graph-prefix character joins or closes lanes.
+const fn is_graph_connector(character: char) -> bool {
+    matches!(character, '─' | '├' | '╭' | '╮' | '╯' | '╰' | '╲' | '╱')
 }
 
 /// Returns whether an entry has detail text worth expanding inline.
@@ -886,6 +936,58 @@ mod tests {
         state.toggle_expanded();
 
         assert_eq!(state.expanded_insertion_line(), Some(1));
+    }
+
+    #[test]
+    fn expanded_insertion_line_keeps_elision_separator_after_expansion() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "◆  aaa\n│  first\n~\n\n○  bbb\n│  second\n",
+            vec![
+                LogEntry::new("aaa", "111", "first\n\nbody")
+                    .with_details("body")
+                    .with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(4),
+            ],
+        ));
+
+        state.toggle_expanded();
+
+        assert_eq!(state.expanded_insertion_line(), Some(1));
+    }
+
+    #[test]
+    fn expanded_insertion_line_keeps_parallel_elision_separator_after_expansion() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "│ ◆  aaa\n│ │  first\n│ ~  (elided revisions)\n│ │ ○  bbb\n│ ├─╯  second\n│ ◆  ccc\n",
+            vec![
+                LogEntry::new("aaa", "111", "first\n\nbody")
+                    .with_details("body")
+                    .with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(3),
+                LogEntry::new("ccc", "333", "third").with_rendered_line(5),
+            ],
+        ));
+
+        state.toggle_expanded();
+
+        assert_eq!(state.expanded_insertion_line(), Some(1));
+    }
+
+    #[test]
+    fn expanded_insertion_line_keeps_connector_separator_after_expansion() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "│ ◆  aaa\n├─╯  first\n│ ○  bbb\n│ │  second\n",
+            vec![
+                LogEntry::new("aaa", "111", "first\n\nbody")
+                    .with_details("body")
+                    .with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(2),
+            ],
+        ));
+
+        state.toggle_expanded();
+
+        assert_eq!(state.expanded_insertion_line(), Some(0));
     }
 
     fn snapshot<const N: usize>(change_ids: [&str; N]) -> LogSnapshot {

--- a/crates/jk-tui/src/rendered_log.rs
+++ b/crates/jk-tui/src/rendered_log.rs
@@ -57,11 +57,8 @@ impl<'a> RenderedLog<'a> {
             return line;
         }
 
-        let inserted_lines = self
-            .body
-            .lines()
-            .nth(details.after_line)
-            .map(expanded_prefix)
+        let lines = self.body.split_inclusive('\n').collect::<Vec<_>>();
+        let inserted_lines = expanded_prefix_at_line(&lines, details.after_line)
             .map(|prefix| expanded_details_line_count(details.text, &prefix, width))
             .unwrap_or_default();
         line + inserted_lines
@@ -74,10 +71,12 @@ impl<'a> RenderedLog<'a> {
             return;
         };
 
-        for (line_index, line) in self.body.split_inclusive('\n').enumerate() {
+        let lines = self.body.split_inclusive('\n').collect::<Vec<_>>();
+        for (line_index, line) in lines.iter().enumerate() {
             rendered.push_str(line);
             if line_index == details.after_line {
-                let prefix = expanded_prefix(line);
+                let prefix = expanded_prefix_at_line(&lines, line_index)
+                    .unwrap_or_else(|| DEFAULT_EXPANDED_PREFIX.to_owned());
                 if !line.ends_with('\n') {
                     rendered.push('\n');
                 }
@@ -149,18 +148,71 @@ fn wrap_options(width: usize) -> Options<'static> {
 }
 
 /// Chooses the graph prefix that should continue into inserted detail lines.
-fn expanded_prefix(line: &str) -> String {
-    let line = strip_ansi(line);
-    if let Some(prefix) = commit_continuation_prefix(&line) {
-        return format!("{prefix}  ");
-    }
+fn expanded_prefix_at_line(lines: &[&str], line_index: usize) -> Option<String> {
+    let line = lines.get(line_index)?;
+    let next_graph_line = lines
+        .iter()
+        .skip(line_index + 1)
+        .copied()
+        .find(|line| !strip_ansi(line).trim().is_empty());
+    Some(expanded_prefix(line, next_graph_line))
+}
 
-    let prefix = body_continuation_prefix(&line);
+/// Chooses the graph prefix that should continue into inserted detail lines.
+fn expanded_prefix(line: &str, next_line: Option<&str>) -> String {
+    let prefix = continuation_prefix(line);
+    let prefix = next_line.map(continuation_prefix).map_or_else(
+        || prefix.clone(),
+        |next_prefix| merge_continuation_prefixes(&prefix, &next_prefix),
+    );
+    let prefix = normalize_continuation_prefix(&prefix);
     if prefix.is_empty() {
         DEFAULT_EXPANDED_PREFIX.to_owned()
     } else {
         prefix
     }
+}
+
+/// Builds the graph continuation prefix implied by one rendered line.
+fn continuation_prefix(line: &str) -> String {
+    let line = strip_ansi(line);
+    commit_continuation_prefix(&line).map_or_else(
+        || body_continuation_prefix(&line),
+        |prefix| format!("{prefix}  "),
+    )
+}
+
+/// Combines continuation prefixes from surrounding graph lines.
+fn merge_continuation_prefixes(previous: &str, next: &str) -> String {
+    let width = previous.chars().count().max(next.chars().count());
+    let mut merged = String::new();
+    let previous = previous.chars().chain(std::iter::repeat(' ')).take(width);
+    let next = next.chars().chain(std::iter::repeat(' ')).take(width);
+    for (previous, next) in previous.zip(next) {
+        merged.push(if previous == '│' || next == '│' {
+            '│'
+        } else {
+            ' '
+        });
+    }
+    merged
+}
+
+/// Keeps only the continuation lanes plus the usual spacing before detail text.
+fn normalize_continuation_prefix(prefix: &str) -> String {
+    let Some(last_lane) = prefix
+        .chars()
+        .enumerate()
+        .filter_map(|(index, character)| (character == '│').then_some(index))
+        .last()
+    else {
+        return String::new();
+    };
+    prefix
+        .chars()
+        .take(last_lane + 1)
+        .chain([' ', ' '])
+        .collect()
 }
 
 /// Builds a continuation prefix from a commit row.
@@ -265,6 +317,79 @@ mod tests {
         assert_eq!(
             rendered,
             "│ ○  aaa\n│ │  first\n│ │  \n│ │  body\n│ │  \n│ ○  bbb\n"
+        );
+    }
+
+    #[test]
+    fn expanded_details_link_next_graph_item_after_connector_line() {
+        let rendered = RenderedLog::new("│ │ ○  aaa\n│ ├─╯  first\n│ ◆  bbb\n")
+            .with_expanded_details(Some(ExpandedDetails::new(1, "body")))
+            .render_with_width(80);
+
+        assert_eq!(
+            rendered,
+            "│ │ ○  aaa\n│ ├─╯  first\n│ │  \n│ │  body\n│ │  \n│ ◆  bbb\n"
+        );
+    }
+
+    #[test]
+    fn expanded_details_link_parallel_graph_item_after_connector_line() {
+        let rendered = RenderedLog::new("│ ◆  aaa\n├─╯  first\n│ ○  bbb\n")
+            .with_expanded_details(Some(ExpandedDetails::new(1, "body")))
+            .render_with_width(80);
+
+        assert_eq!(
+            rendered,
+            "│ ◆  aaa\n├─╯  first\n│ │  \n│ │  body\n│ │  \n│ ○  bbb\n"
+        );
+    }
+
+    #[test]
+    fn expanded_details_keep_connector_separator_after_details() {
+        let rendered = RenderedLog::new("│ ◆  aaa\n├─╯  first\n│ ○  bbb\n")
+            .with_expanded_details(Some(ExpandedDetails::new(0, "body")))
+            .render_with_width(80);
+
+        assert_eq!(
+            rendered,
+            "│ ◆  aaa\n│ │  \n│ │  body\n│ │  \n├─╯  first\n│ ○  bbb\n"
+        );
+    }
+
+    #[test]
+    fn expanded_details_keep_elision_separator_after_details() {
+        let rendered = RenderedLog::new("│ ◆  aaa\n│ │  first\n~\n│ ○  bbb\n")
+            .with_expanded_details(Some(ExpandedDetails::new(1, "body")))
+            .render_with_width(80);
+
+        assert_eq!(
+            rendered,
+            "│ ◆  aaa\n│ │  first\n│ │  \n│ │  body\n│ │  \n~\n│ ○  bbb\n"
+        );
+    }
+
+    #[test]
+    fn expanded_details_keep_parallel_elision_separator_after_details() {
+        let rendered =
+            RenderedLog::new("│ ◆  aaa\n│ │  first\n│ ~  (elided revisions)\n│ │ ○  bbb\n")
+                .with_expanded_details(Some(ExpandedDetails::new(1, "body")))
+                .render_with_width(80);
+
+        assert_eq!(
+            rendered,
+            "│ ◆  aaa\n│ │  first\n│ │  \n│ │  body\n│ │  \n│ ~  (elided revisions)\n│ │ ○  bbb\n"
+        );
+    }
+
+    #[test]
+    fn expanded_details_keep_elision_separator_and_blank_after_details() {
+        let rendered = RenderedLog::new("◆  aaa\n│  first\n~\n\n○  bbb\n")
+            .with_expanded_details(Some(ExpandedDetails::new(1, "body")))
+            .render_with_width(80);
+
+        assert_eq!(
+            rendered,
+            "◆  aaa\n│  first\n│  \n│  body\n│  \n~\n\n○  bbb\n"
         );
     }
 


### PR DESCRIPTION
## Summary

- Keep inline log expansions before trailing graph separator rows such as `~` and connector tails.
- Merge graph continuation lanes from surrounding rows so inserted details stay connected through normal, branch, connector, and elided graph shapes.
- Cover expansion placement and rendering with focused TUI tests.

## Evidence

These PNGs use a short local jj fixture so normal, branch, and elided graph behavior stays visible.

**Expansion graph evidence**

| normal-expansion.png | branch-expansion.png |
|---|---|
| ![normal-expansion.png](https://github.com/joshka/jk/blob/2c06e3ccba7701eeefc053b77a5f17bda521a3c2/normal-expansion.png?raw=true) | ![branch-expansion.png](https://github.com/joshka/jk/blob/2c06e3ccba7701eeefc053b77a5f17bda521a3c2/branch-expansion.png?raw=true) |

| elided-expansion.png |
|---|
| ![elided-expansion.png](https://github.com/joshka/jk/blob/2c06e3ccba7701eeefc053b77a5f17bda521a3c2/elided-expansion.png?raw=true) |

## Validation

- `just fmt-check`
- `cargo test -p jk-tui`
- `just check`
- `just test`
- Betamax fixture evidence tapes:
  - `target/betamax/pr-evidence/normal-expansion.tape`
  - `target/betamax/pr-evidence/branch-expansion.tape`
  - `target/betamax/pr-evidence/elided-expansion.tape`
