### PR TITLE
Shorten revision IDs in log navigation

### DIFF
--- a/crates/jk-cli/src/log.rs
+++ b/crates/jk-cli/src/log.rs
@@ -51,6 +51,7 @@ pub struct JjLog {
     limit: Option<usize>,
     template: LogTemplateSelection,
     custom_template: Option<String>,
+    revset: Option<String>,
 }
 
 impl Default for JjLog {
@@ -61,6 +62,7 @@ impl Default for JjLog {
             limit: None,
             template: LogTemplateSelection::Configured,
             custom_template: None,
+            revset: None,
         }
     }
 }
@@ -167,6 +169,14 @@ impl JjLog {
         options
     }
 
+    /// Sets the revset passed to `jj log -r`.
+    #[must_use]
+    pub fn with_revset(mut self, revset: impl Into<String>) -> Self {
+        self.command = JjLogCommand::Log;
+        self.revset = Some(revset.into());
+        self
+    }
+
     /// Loads a rendered log snapshot and semantic entries from `jj`.
     ///
     /// This method executes `jj` twice: once for the user's rendered log output and once with a
@@ -261,10 +271,20 @@ impl JjLog {
     }
 
     fn command_args(&self) -> Vec<String> {
-        match self.command {
+        let mut args = match self.command {
             JjLogCommand::ConfiguredDefault => Vec::new(),
             JjLogCommand::Log => vec![LOG_COMMAND.to_owned()],
+        };
+
+        if let Some(revset) = &self.revset {
+            if args.is_empty() {
+                args.push(LOG_COMMAND.to_owned());
+            }
+            args.push("-r".to_owned());
+            args.push(revset.to_owned());
         }
+
+        args
     }
 
     fn rendered_template(&self) -> Option<&str> {
@@ -606,6 +626,23 @@ mod tests {
                 LogTemplateSelection::Redacted,
                 LogTemplateSelection::Custom("description".to_owned())
             ]
+        );
+    }
+
+    #[test]
+    fn revset_forces_explicit_log_command() {
+        let source = JjLog::default().with_revset("older::newer");
+        let command_args = source.command_args();
+        let command = source.command(DefaultCommandMode::Rendered, &command_args);
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(command_args, ["log", "-r", "older::newer"]);
+        assert!(
+            args.windows(3)
+                .any(|args| args == ["log", "-r", "older::newer"])
         );
     }
 }

--- a/crates/jk-tui/src/chrome.rs
+++ b/crates/jk-tui/src/chrome.rs
@@ -8,6 +8,9 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::prelude::{Color, Line, Modifier, Span, Style, Text};
 use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 
+const CHROME_STYLE: Style = Style::new().fg(Color::White).bg(Color::Black);
+const CHROME_BADGE_STYLE: Style = Style::new().fg(Color::Black).bg(Color::White);
+
 /// Renders a small mode-specific help overlay centered in the content area.
 pub fn render_help_overlay(frame: &mut Frame<'_>, area: Rect, title: &str, lines: &[String]) {
     if area.is_empty() {
@@ -92,14 +95,14 @@ impl<'a> ViewChrome<'a> {
     /// Renders the title and status rows without touching the content area.
     pub fn render(&self, frame: &mut Frame<'_>, areas: ChromeAreas) {
         let title = Paragraph::new(Line::from(vec![
-            Span::styled("jk", Style::new().fg(Color::Black).bg(Color::White)),
-            Span::raw(" "),
-            Span::styled(self.title, Style::new().add_modifier(Modifier::BOLD)),
-        ]));
+            Span::styled("jk", CHROME_BADGE_STYLE),
+            Span::styled(" ", CHROME_STYLE),
+            Span::styled(self.title, CHROME_STYLE.add_modifier(Modifier::BOLD)),
+        ]))
+        .style(CHROME_STYLE);
         frame.render_widget(title, areas.title);
 
-        let status = Paragraph::new(Line::from(self.status))
-            .style(Style::new().fg(Color::Black).bg(Color::White));
+        let status = Paragraph::new(Line::from(self.status)).style(CHROME_STYLE);
         frame.render_widget(status, areas.status);
     }
 }

--- a/crates/jk-tui/src/keymap.rs
+++ b/crates/jk-tui/src/keymap.rs
@@ -334,7 +334,7 @@ const LOG_BINDINGS: &[KeyBinding] = &[
         .with_aliases(&["page", "pagedown", "pageup"]),
     KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
         .with_family(CommandFamily::Navigation),
-    KeyBinding::new(ActionId::Expand, "right, l", "expand selected change")
+    KeyBinding::new(ActionId::Expand, "right, l", "expand change / drill into ~")
         .with_family(CommandFamily::Navigation),
     KeyBinding::new(ActionId::Collapse, "left, h", "collapse selected change")
         .with_family(CommandFamily::Navigation),
@@ -1053,7 +1053,7 @@ mod tests {
                 "Ctrl-j/k             scroll one line",
                 "b, Ctrl-f/b, PgUp/Dn page down/up",
                 "g/G or Home/End      jump to top/bottom",
-                "right, l             expand selected change",
+                "right, l             expand change / drill into ~",
                 "left, h              collapse selected change",
                 "?, q, Esc            close help",
             ]

--- a/crates/jk-tui/src/keymap.rs
+++ b/crates/jk-tui/src/keymap.rs
@@ -246,10 +246,10 @@ impl KeyBinding {
 }
 
 const LOG_BINDINGS: &[KeyBinding] = &[
-    KeyBinding::new(ActionId::OpenShow, "enter", "open selected-change show")
+    KeyBinding::new(ActionId::OpenShow, "enter", "open change / drill into ~")
         .with_family(CommandFamily::JjShow)
         .with_aliases(&["details", "inspect"])
-        .with_hotbar(4, "enter show"),
+        .with_hotbar(4, "enter open"),
     KeyBinding::new(ActionId::OpenDiff, "d", "open selected-change diff")
         .with_family(CommandFamily::JjDiff)
         .with_hotbar(5, "d diff"),
@@ -896,7 +896,7 @@ mod tests {
     fn log_hotbar_matches_current_status_text() {
         assert_eq!(
             hotbar(BindingContext::Log),
-            "? help  H home  L log  r refresh  enter show  d diff  m describe  v evolog  s status  space mark  o ops  c clear  u undo  j/k move  U redo  n new  a abandon  e edit  V options  q quit"
+            "? help  H home  L log  r refresh  enter open  d diff  m describe  v evolog  s status  space mark  o ops  c clear  u undo  j/k move  U redo  n new  a abandon  e edit  V options  q quit"
         );
     }
 
@@ -955,7 +955,7 @@ mod tests {
         assert!(status.chars().count() <= 104);
         assert!(status.contains("? help"));
         assert!(status.contains("q quit"));
-        assert!(status.contains("enter show"));
+        assert!(status.contains("enter open"));
         assert!(status.contains("d diff"));
         assert!(status.contains("m describe"));
         assert!(status.contains("v evolog"));
@@ -974,7 +974,7 @@ mod tests {
 
         assert_eq!(
             status,
-            "? help  H home  L log  r refresh  enter show  d diff  ...  q quit"
+            "? help  H home  L log  r refresh  enter open  d diff  ...  q quit"
         );
     }
 
@@ -1031,7 +1031,7 @@ mod tests {
         assert_eq!(
             help_lines(BindingContext::Log),
             vec![
-                "enter                open selected-change show",
+                "enter                open change / drill into ~",
                 "d                    open selected-change diff",
                 "v                    open selected-change evolog",
                 "s                    open repository status",

--- a/crates/jk-tui/src/log_state.rs
+++ b/crates/jk-tui/src/log_state.rs
@@ -52,7 +52,8 @@ pub struct LogState {
     title: String,
     rendered: String,
     entries: Vec<LogEntry>,
-    selected: Option<usize>,
+    elisions: Vec<LogElision>,
+    selected: Option<LogSelection>,
     expanded_change_id: Option<String>,
     scroll_offset: usize,
     viewport_height: usize,
@@ -60,15 +61,30 @@ pub struct LogState {
     marks: OrderedRevisionMarks,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LogSelection {
+    Entry(usize),
+    Elision(usize),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LogElision {
+    rendered_line: usize,
+    before_entry: Option<usize>,
+    after_entry: Option<usize>,
+}
+
 impl LogState {
     /// Creates state from a freshly loaded log snapshot.
     pub fn new(snapshot: LogSnapshot) -> Self {
         let (title, rendered, entries) = snapshot.into_parts();
-        let selected = (!entries.is_empty()).then_some(0);
+        let elisions = log_elisions(&rendered, &entries);
+        let selected = first_selection(&entries, &elisions);
         Self {
             title: title_or_default(title),
             rendered,
             entries,
+            elisions,
             selected,
             expanded_change_id: None,
             scroll_offset: 0,
@@ -89,13 +105,15 @@ impl LogState {
         self.rendered = rendered;
         self.entries = entries;
         self.marks.retain_visible(&self.entries);
+        self.elisions = log_elisions(&self.rendered, &self.entries);
         self.selected = selected_change_id
             .and_then(|change_id| {
                 self.entries
                     .iter()
                     .position(|entry| entry.change_id() == change_id)
+                    .map(LogSelection::Entry)
             })
-            .or_else(|| (!self.entries.is_empty()).then_some(0));
+            .or_else(|| first_selection(&self.entries, &self.elisions));
 
         if let Some(expanded_change_id) = &self.expanded_change_id {
             let expanded_still_exists_with_details = self
@@ -122,7 +140,35 @@ impl LogState {
 
     /// Returns the currently selected semantic entry.
     pub fn selected_entry(&self) -> Option<&LogEntry> {
-        self.selected.and_then(|index| self.entries.get(index))
+        let LogSelection::Entry(index) = self.selected? else {
+            return None;
+        };
+        self.entries.get(index)
+    }
+
+    /// Returns the revset that should reveal the selected graph elision.
+    #[must_use]
+    pub fn selected_elision_revset(&self) -> Option<String> {
+        let LogSelection::Elision(index) = self.selected? else {
+            return None;
+        };
+        let elision = self.elisions.get(index)?;
+        match (elision.before_entry, elision.after_entry) {
+            (Some(before), Some(after)) => {
+                let before = self.entries.get(before)?;
+                let after = self.entries.get(after)?;
+                Some(format!("{}::{}", after.change_id(), before.change_id()))
+            }
+            (Some(before), None) => {
+                let before = self.entries.get(before)?;
+                Some(format!("::{}", before.change_id()))
+            }
+            (None, Some(after)) => {
+                let after = self.entries.get(after)?;
+                Some(format!("{}::", after.change_id()))
+            }
+            (None, None) => None,
+        }
     }
 
     /// Returns the first rendered line currently visible in the viewport.
@@ -157,7 +203,10 @@ impl LogState {
             return;
         };
 
-        self.select_index(selected.saturating_sub(1));
+        let Some(index) = self.selectable_index(selected) else {
+            return;
+        };
+        self.select_selectable_index(index.saturating_sub(1));
     }
 
     /// Moves selection to the next semantic entry.
@@ -166,8 +215,11 @@ impl LogState {
             return;
         };
 
-        let last_index = self.entries.len().saturating_sub(1);
-        self.select_index((selected + 1).min(last_index));
+        let Some(index) = self.selectable_index(selected) else {
+            return;
+        };
+        let last_index = self.selectable_len().saturating_sub(1);
+        self.select_selectable_index((index + 1).min(last_index));
     }
 
     /// Moves selection one viewport toward newer visible rendered lines.
@@ -178,11 +230,11 @@ impl LogState {
 
         let target_line = selected_line.saturating_sub(self.viewport_height);
         let target_index = self
-            .entries
+            .selectables()
             .iter()
-            .rposition(|entry| entry.rendered_line() <= target_line)
+            .rposition(|selection| self.selection_rendered_line(*selection) <= target_line)
             .unwrap_or(0);
-        self.select_index(target_index);
+        self.select_selectable_index(target_index);
     }
 
     /// Moves selection one viewport toward older visible rendered lines.
@@ -192,26 +244,27 @@ impl LogState {
         };
 
         let target_line = selected_line.saturating_add(self.viewport_height);
-        let last_index = self.entries.len().saturating_sub(1);
-        let target_index = self
-            .entries
+        let selectables = self.selectables();
+        let last_index = selectables.len().saturating_sub(1);
+        let target_index = selectables
             .iter()
-            .position(|entry| entry.rendered_line() >= target_line)
+            .position(|selection| self.selection_rendered_line(*selection) >= target_line)
             .unwrap_or(last_index);
-        self.select_index(target_index);
+        self.select_selectable_index(target_index);
     }
 
     /// Moves selection to the first semantic entry.
     pub fn select_first(&mut self) {
-        if !self.entries.is_empty() {
-            self.select_index(0);
+        if self.selectable_len() > 0 {
+            self.select_selectable_index(0);
         }
     }
 
     /// Moves selection to the last semantic entry.
     pub fn select_last(&mut self) {
-        if !self.entries.is_empty() {
-            self.select_index(self.entries.len() - 1);
+        let selectable_len = self.selectable_len();
+        if selectable_len > 0 {
+            self.select_selectable_index(selectable_len - 1);
         }
     }
 
@@ -322,7 +375,9 @@ impl LogState {
 
     /// Returns the rendered line after which inline details should be inserted.
     pub fn expanded_insertion_line(&self) -> Option<usize> {
-        let selected = self.selected?;
+        let LogSelection::Entry(selected) = self.selected? else {
+            return None;
+        };
         if !self.selected_is_expanded() {
             return None;
         }
@@ -332,12 +387,15 @@ impl LogState {
 
     /// Returns the selected entry's rendered line.
     pub fn selected_rendered_line(&self) -> Option<usize> {
-        self.selected_entry().map(LogEntry::rendered_line)
+        self.selected
+            .map(|selection| self.selection_rendered_line(selection))
     }
 
     /// Returns the final rendered line that belongs to the selected entry.
     fn selected_entry_end_line(&self) -> Option<usize> {
-        let selected = self.selected?;
+        let LogSelection::Entry(selected) = self.selected? else {
+            return None;
+        };
         self.entry_content_end_line(selected)
     }
 
@@ -350,28 +408,7 @@ impl LogState {
             .map_or_else(|| self.rendered.lines().count(), LogEntry::rendered_line);
         content_end_line(&self.rendered, start, end)
     }
-}
 
-/// Finds the final rendered line that belongs to a visible log entry.
-fn content_end_line(rendered: &str, start: usize, end: usize) -> Option<usize> {
-    rendered
-        .lines()
-        .enumerate()
-        .skip(start)
-        .take(end.saturating_sub(start))
-        .filter(|(_, line)| !is_separator_line(line))
-        .map(|(index, _)| index)
-        .last()
-}
-
-/// Returns whether a rendered line is a separator after an entry instead of entry content.
-fn is_separator_line(line: &str) -> bool {
-    strip_ansi(line).trim().is_empty()
-        || is_graph_elision_line(line)
-        || is_graph_connector_line(line)
-}
-
-impl LogState {
     /// Scrolls upward when selection moves above the current viewport.
     fn keep_selected_visible(&mut self) {
         let Some(selected_line) = self.selected_rendered_line() else {
@@ -385,13 +422,13 @@ impl LogState {
     }
 
     /// Selects an entry and carries expansion forward when movement expects it.
-    fn select_index(&mut self, index: usize) {
-        let Some(_) = self.entries.get(index) else {
+    fn select_selectable_index(&mut self, index: usize) {
+        let Some(selection) = self.selectables().get(index).copied() else {
             return;
         };
 
         let was_expanded = self.selected_is_expanded();
-        self.selected = Some(index);
+        self.selected = Some(selection);
         self.follow_selection = true;
         self.apply_expansion_to_selected(was_expanded);
         self.keep_selected_visible();
@@ -417,6 +454,82 @@ impl LogState {
         let max_scroll_offset = self.rendered.lines().count().saturating_sub(1);
         self.scroll_offset = self.scroll_offset.min(max_scroll_offset);
     }
+
+    fn selectables(&self) -> Vec<LogSelection> {
+        let mut selections = Vec::with_capacity(self.entries.len() + self.elisions.len());
+        selections.extend((0..self.entries.len()).map(LogSelection::Entry));
+        selections.extend((0..self.elisions.len()).map(LogSelection::Elision));
+        selections.sort_by_key(|selection| self.selection_rendered_line(*selection));
+        selections
+    }
+
+    const fn selectable_len(&self) -> usize {
+        self.entries.len() + self.elisions.len()
+    }
+
+    fn selectable_index(&self, selected: LogSelection) -> Option<usize> {
+        self.selectables()
+            .iter()
+            .position(|selection| *selection == selected)
+    }
+
+    fn selection_rendered_line(&self, selection: LogSelection) -> usize {
+        match selection {
+            LogSelection::Entry(index) => self.entries[index].rendered_line(),
+            LogSelection::Elision(index) => self.elisions[index].rendered_line,
+        }
+    }
+}
+
+/// Finds the final rendered line that belongs to a visible log entry.
+fn content_end_line(rendered: &str, start: usize, end: usize) -> Option<usize> {
+    rendered
+        .lines()
+        .enumerate()
+        .skip(start)
+        .take(end.saturating_sub(start))
+        .filter(|(_, line)| !is_separator_line(line))
+        .map(|(index, _)| index)
+        .last()
+}
+
+/// Returns whether a rendered line is a separator after an entry instead of entry content.
+fn is_separator_line(line: &str) -> bool {
+    strip_ansi(line).trim().is_empty()
+        || is_graph_elision_line(line)
+        || is_graph_connector_line(line)
+}
+
+fn first_selection(entries: &[LogEntry], elisions: &[LogElision]) -> Option<LogSelection> {
+    let first_entry = entries
+        .first()
+        .map(|entry| (entry.rendered_line(), LogSelection::Entry(0)));
+    let first_elision = elisions
+        .first()
+        .map(|elision| (elision.rendered_line, LogSelection::Elision(0)));
+
+    [first_entry, first_elision]
+        .into_iter()
+        .flatten()
+        .min_by_key(|(line, _)| *line)
+        .map(|(_, selection)| selection)
+}
+
+fn log_elisions(rendered: &str, entries: &[LogEntry]) -> Vec<LogElision> {
+    rendered
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| is_graph_elision_line(line))
+        .map(|(rendered_line, _)| LogElision {
+            rendered_line,
+            before_entry: entries
+                .iter()
+                .rposition(|entry| entry.rendered_line() < rendered_line),
+            after_entry: entries
+                .iter()
+                .position(|entry| entry.rendered_line() > rendered_line),
+        })
+        .collect()
 }
 
 /// Returns whether a rendered line is jj's hidden-revision graph elision.
@@ -771,11 +884,41 @@ mod tests {
         let mut state = LogState::new(snapshot(["aaa", "bbb"]));
 
         state.select_previous();
-        assert_eq!(state.selected, Some(0));
+        assert_eq!(state.selected, Some(LogSelection::Entry(0)));
 
         state.select_next();
         state.select_next();
-        assert_eq!(state.selected, Some(1));
+        assert_eq!(state.selected, Some(LogSelection::Entry(1)));
+    }
+
+    #[test]
+    fn movement_can_select_graph_elision() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  aaa first\n~  (elided revisions)\n○  bbb second\n",
+            vec![
+                LogEntry::new("aaa", "111", "first").with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(2),
+            ],
+        ));
+
+        state.select_next();
+
+        assert_eq!(state.selected, Some(LogSelection::Elision(0)));
+        assert_eq!(state.selected_entry(), None);
+        assert_eq!(state.selected_rendered_line(), Some(1));
+        assert_eq!(state.selected_elision_revset(), Some("bbb::aaa".to_owned()));
+    }
+
+    #[test]
+    fn trailing_graph_elision_drills_into_ancestors() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  aaa first\n~  (elided revisions)\n",
+            vec![LogEntry::new("aaa", "111", "first").with_rendered_line(0)],
+        ));
+
+        state.select_next();
+
+        assert_eq!(state.selected_elision_revset(), Some("::aaa".to_owned()));
     }
 
     #[test]
@@ -925,7 +1068,7 @@ mod tests {
     #[test]
     fn expanded_insertion_line_skips_trailing_graph_elision() {
         let mut state = LogState::new(LogSnapshot::new(
-            "@  aaa\n│  first\n\u{1b}[38;5;8m~\u{1b}[0m\n",
+            "@  aaa\n│  first\n\u{1b}[38;5;8m~  (elided revisions)\u{1b}[0m\n",
             vec![
                 LogEntry::new("aaa", "111", "first\n\nbody")
                     .with_details("body")

--- a/crates/jk-tui/src/log_state.rs
+++ b/crates/jk-tui/src/log_state.rs
@@ -9,6 +9,8 @@ use jk_core::{LogEntry, LogSnapshot};
 use crate::ansi_text::strip_ansi;
 use crate::chrome::title_or_default;
 
+const REVSET_ID_PREFIX_LEN: usize = 8;
+
 /// Ordered revision marks keyed by stable change id.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct OrderedRevisionMarks {
@@ -146,6 +148,47 @@ impl LogState {
         self.entries.get(index)
     }
 
+    /// Returns the selected entry's revision identifier for follow-up commands.
+    #[must_use]
+    pub fn selected_revision_id(&self) -> Option<&str> {
+        self.selected_entry()
+            .map(|entry| revision_id_prefix(entry.change_id()))
+    }
+
+    /// Returns the visible change before the selected graph elision.
+    #[must_use]
+    pub fn selected_elision_before_change_id(&self) -> Option<&str> {
+        let LogSelection::Elision(index) = self.selected? else {
+            return None;
+        };
+        let elision = self.elisions.get(index)?;
+        let before = elision.before_entry?;
+        self.entries.get(before).map(LogEntry::change_id)
+    }
+
+    /// Selects the first entry rendered after the given visible change.
+    #[must_use]
+    pub fn select_first_entry_after_change_id(&mut self, change_id: &str) -> bool {
+        let Some(index) = self
+            .entries
+            .iter()
+            .position(|entry| entry.change_id() == change_id)
+        else {
+            return false;
+        };
+        let Some(next_index) = index.checked_add(1) else {
+            return false;
+        };
+        if next_index >= self.entries.len() {
+            return false;
+        }
+        self.selected = Some(LogSelection::Entry(next_index));
+        self.follow_selection = true;
+        self.expanded_change_id = None;
+        self.keep_selected_visible();
+        true
+    }
+
     /// Returns the revset that should reveal the selected graph elision.
     #[must_use]
     pub fn selected_elision_revset(&self) -> Option<String> {
@@ -153,21 +196,37 @@ impl LogState {
             return None;
         };
         let elision = self.elisions.get(index)?;
-        match (elision.before_entry, elision.after_entry) {
+        let reveal_revset = match (elision.before_entry, elision.after_entry) {
             (Some(before), Some(after)) => {
                 let before = self.entries.get(before)?;
                 let after = self.entries.get(after)?;
-                Some(format!("{}::{}", after.change_id(), before.change_id()))
+                Some(format!(
+                    "{}::{}",
+                    revision_id_prefix(after.change_id()),
+                    revision_id_prefix(before.change_id())
+                ))
             }
             (Some(before), None) => {
                 let before = self.entries.get(before)?;
-                Some(format!("::{}", before.change_id()))
+                Some(format!("::{}", revision_id_prefix(before.change_id())))
             }
             (None, Some(after)) => {
                 let after = self.entries.get(after)?;
-                Some(format!("{}::", after.change_id()))
+                Some(format!("{}::", revision_id_prefix(after.change_id())))
             }
             (None, None) => None,
+        }?;
+
+        let visible_entries = self
+            .entries
+            .iter()
+            .map(|entry| revision_id_prefix(entry.change_id()))
+            .collect::<Vec<_>>()
+            .join(" | ");
+        if visible_entries.is_empty() {
+            Some(reveal_revset)
+        } else {
+            Some(format!("({reveal_revset}) | {visible_entries}"))
         }
     }
 
@@ -313,6 +372,15 @@ impl LogState {
     /// Returns marked change ids in insertion order.
     pub fn marked_change_ids(&self) -> &[String] {
         self.marks.change_ids()
+    }
+
+    /// Returns marked revision identifiers shortened for follow-up commands.
+    pub fn marked_revision_ids(&self) -> Vec<String> {
+        self.marks
+            .change_ids()
+            .iter()
+            .map(|change_id| revision_id_prefix(change_id).to_owned())
+            .collect()
     }
 
     /// Returns the selected change's zero-based mark index, if marked.
@@ -481,6 +549,12 @@ impl LogState {
     }
 }
 
+fn revision_id_prefix(id: &str) -> &str {
+    id.char_indices()
+        .nth(REVSET_ID_PREFIX_LEN)
+        .map_or(id, |(index, _)| &id[..index])
+}
+
 /// Finds the final rendered line that belongs to a visible log entry.
 fn content_end_line(rendered: &str, start: usize, end: usize) -> Option<usize> {
     rendered
@@ -600,6 +674,17 @@ mod tests {
         state.refresh(snapshot(["ccc", "ddd"]));
 
         assert_eq!(state.selected_entry().map(LogEntry::change_id), Some("ccc"));
+    }
+
+    #[test]
+    fn selected_revision_id_uses_short_change_id() {
+        let state = LogState::new(snapshot(["abcdefghijklmnop"]));
+
+        assert_eq!(state.selected_revision_id(), Some("abcdefgh"));
+        assert_eq!(
+            state.selected_entry().map(LogEntry::change_id),
+            Some("abcdefghijklmnop")
+        );
     }
 
     #[test]
@@ -730,6 +815,26 @@ mod tests {
         assert_eq!(state.marked_change_ids(), ["aaa", "ccc"]);
         assert_eq!(state.mark_index_for_change_id("aaa"), Some(0));
         assert_eq!(state.mark_index_for_change_id("ccc"), Some(1));
+    }
+
+    #[test]
+    fn marked_revision_ids_use_short_change_ids() {
+        let mut state = LogState::new(snapshot([
+            "abcdefghijklmnop",
+            "bbbbbbbbcccccccc",
+            "zyxwvutsrqponmlk",
+        ]));
+
+        state.toggle_selected_mark();
+        state.select_next();
+        state.select_next();
+        state.toggle_selected_mark();
+
+        assert_eq!(
+            state.marked_change_ids(),
+            ["abcdefghijklmnop", "zyxwvutsrqponmlk"]
+        );
+        assert_eq!(state.marked_revision_ids(), ["abcdefgh", "zyxwvuts"]);
     }
 
     #[test]
@@ -906,11 +1011,56 @@ mod tests {
         assert_eq!(state.selected, Some(LogSelection::Elision(0)));
         assert_eq!(state.selected_entry(), None);
         assert_eq!(state.selected_rendered_line(), Some(1));
-        assert_eq!(state.selected_elision_revset(), Some("bbb::aaa".to_owned()));
+        assert_eq!(
+            state.selected_elision_revset(),
+            Some("(bbb::aaa) | aaa | bbb".to_owned())
+        );
     }
 
     #[test]
-    fn trailing_graph_elision_drills_into_ancestors() {
+    fn graph_elision_revset_includes_visible_boundaries() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  current\n~  (elided revisions)\n◆  root\n",
+            vec![
+                LogEntry::new("current", "111", "current").with_rendered_line(0),
+                LogEntry::new("root", "000", "root").with_rendered_line(2),
+            ],
+        ));
+
+        state.select_next();
+
+        assert_eq!(
+            state.selected_elision_revset(),
+            Some("(root::current) | current | root".to_owned())
+        );
+    }
+
+    #[test]
+    fn graph_elision_revset_uses_short_change_ids() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  abcdefghijklmnop current\n~  (elided revisions)\n◆  zyxwvutsrqponmlk root\n",
+            vec![
+                LogEntry::new("abcdefghijklmnop", "1111222233334444", "current")
+                    .with_rendered_line(0),
+                LogEntry::new("zyxwvutsrqponmlk", "0000111122223333", "root").with_rendered_line(2),
+            ],
+        ));
+
+        state.select_next();
+
+        assert_eq!(
+            state.selected_elision_revset(),
+            Some("(zyxwvuts::abcdefgh) | abcdefgh | zyxwvuts".to_owned())
+        );
+    }
+
+    #[test]
+    fn revision_id_prefix_keeps_short_ids() {
+        assert_eq!(revision_id_prefix("abc123"), "abc123");
+    }
+
+    #[test]
+    fn trailing_graph_elision_drills_into_ancestors_with_visible_context() {
         let mut state = LogState::new(LogSnapshot::new(
             "@  aaa first\n~  (elided revisions)\n",
             vec![LogEntry::new("aaa", "111", "first").with_rendered_line(0)],
@@ -918,7 +1068,68 @@ mod tests {
 
         state.select_next();
 
-        assert_eq!(state.selected_elision_revset(), Some("::aaa".to_owned()));
+        assert_eq!(
+            state.selected_elision_revset(),
+            Some("(::aaa) | aaa".to_owned())
+        );
+    }
+
+    #[test]
+    fn trailing_graph_elision_keeps_visible_stack_context() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  current\n○  parent\n◆  main\n~  (elided revisions)\n",
+            vec![
+                LogEntry::new("current", "333", "current").with_rendered_line(0),
+                LogEntry::new("parent", "222", "parent").with_rendered_line(1),
+                LogEntry::new("main", "111", "main").with_rendered_line(2),
+            ],
+        ));
+
+        state.select_next();
+        state.select_next();
+        state.select_next();
+
+        assert_eq!(
+            state.selected_elision_revset(),
+            Some("(::main) | current | parent | main".to_owned())
+        );
+    }
+
+    #[test]
+    fn can_select_first_revealed_entry_after_elision_boundary() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  current\n○  parent\n◆  main\n○  hidden\n◆  root\n",
+            vec![
+                LogEntry::new("current", "333", "current").with_rendered_line(0),
+                LogEntry::new("parent", "222", "parent").with_rendered_line(1),
+                LogEntry::new("main", "111", "main").with_rendered_line(2),
+                LogEntry::new("hidden", "999", "hidden").with_rendered_line(3),
+                LogEntry::new("root", "000", "root").with_rendered_line(4),
+            ],
+        ));
+
+        assert!(state.select_first_entry_after_change_id("main"));
+
+        assert_eq!(
+            state.selected_entry().map(LogEntry::change_id),
+            Some("hidden")
+        );
+        assert_eq!(state.selected_rendered_line(), Some(3));
+    }
+
+    #[test]
+    fn selecting_after_final_entry_reports_no_target() {
+        let mut state = LogState::new(LogSnapshot::new(
+            "@  current\n",
+            vec![LogEntry::new("current", "333", "current").with_rendered_line(0)],
+        ));
+
+        assert!(!state.select_first_entry_after_change_id("current"));
+
+        assert_eq!(
+            state.selected_entry().map(LogEntry::change_id),
+            Some("current")
+        );
     }
 
     #[test]

--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -36,6 +36,9 @@ pub enum ActionResult {
     /// Open the selected change's diff.
     OpenDiff,
 
+    /// Drill into the selected graph elision.
+    DrillElision,
+
     /// Exit the application.
     Quit,
 }
@@ -206,6 +209,12 @@ impl LogView {
         self.state.selected_mark_index()
     }
 
+    /// Returns the revset that reveals the selected graph elision.
+    #[must_use]
+    pub fn selected_elision_revset(&self) -> Option<String> {
+        self.state.selected_elision_revset()
+    }
+
     /// Applies a single input action.
     ///
     /// [`ActionResult::Refresh`] asks the caller to load a new [`LogSnapshot`]. The view does not
@@ -256,6 +265,9 @@ impl LogView {
             | LogAction::FoldAll
             | LogAction::UnfoldAll => ActionResult::Continue,
             LogAction::ToggleExpanded => {
+                if self.selected_elision_revset().is_some() {
+                    return ActionResult::DrillElision;
+                }
                 self.state.toggle_expanded();
                 ActionResult::Continue
             }
@@ -424,6 +436,25 @@ mod tests {
     }
 
     #[test]
+    fn toggle_expanded_on_elision_requests_drill_in() {
+        let mut view = LogView::new(LogSnapshot::new(
+            "@  aaa first\n~  (elided revisions)\n○  bbb second\n",
+            vec![
+                LogEntry::new("aaa", "111", "first").with_rendered_line(0),
+                LogEntry::new("bbb", "222", "second").with_rendered_line(2),
+            ],
+        ));
+
+        let _ = view.apply(LogAction::Next);
+
+        assert_eq!(
+            view.apply(LogAction::ToggleExpanded),
+            ActionResult::DrillElision
+        );
+        assert_eq!(view.selected_elision_revset(), Some("bbb::aaa".to_owned()));
+    }
+
+    #[test]
     fn refresh_errors_replace_status_without_replacing_log() {
         let mut view = LogView::new(snapshot(["aaa"]));
         view.show_error("jj failed");
@@ -485,6 +516,14 @@ mod tests {
         let buffer = terminal.backend().buffer();
         assert!(buffer_line(buffer, 0).contains("jk jj log"));
         assert!(buffer_line(buffer, 3).contains("r refresh"));
+        assert_eq!(buffer[(0, 0)].fg, Color::Black);
+        assert_eq!(buffer[(0, 0)].bg, Color::White);
+        assert_eq!(buffer[(3, 0)].fg, Color::White);
+        assert_eq!(buffer[(3, 0)].bg, Color::Black);
+        assert_eq!(buffer[(47, 0)].bg, Color::Black);
+        assert_eq!(buffer[(0, 3)].fg, Color::White);
+        assert_eq!(buffer[(0, 3)].bg, Color::Black);
+        assert_eq!(buffer[(47, 3)].bg, Color::Black);
     }
 
     #[test]
@@ -510,6 +549,7 @@ mod tests {
         assert!(rendered.contains("a                    preview jj abandon"));
         assert!(rendered.contains("u                    preview jj undo"));
         assert!(rendered.contains("U                    preview jj redo"));
+        assert!(rendered.contains("right, l             expand change / drill into ~"));
         assert!(rendered.contains("?, q, Esc            close help"));
     }
 
@@ -546,7 +586,7 @@ mod tests {
     fn renders_jj_output_with_title_and_status_bars_but_no_border() {
         let mut view = LogView::new(
             LogSnapshot::new(
-                "@  aaaabbbb summary\n│  body\n~\n",
+                "@  aaaabbbb summary\n│  body\n~  (elided revisions)\n",
                 vec![LogEntry::new("aaaabbbb", "11112222", "summary")],
             )
             .with_title("jj log -n 3"),

--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -184,6 +184,24 @@ impl LogView {
             .map(jk_core::LogEntry::change_id)
     }
 
+    /// Returns the selected revision identifier for follow-up commands.
+    #[must_use]
+    pub fn selected_revision_id(&self) -> Option<&str> {
+        self.state.selected_revision_id()
+    }
+
+    /// Returns the visible change before the selected graph elision.
+    #[must_use]
+    pub fn selected_elision_before_change_id(&self) -> Option<&str> {
+        self.state.selected_elision_before_change_id()
+    }
+
+    /// Selects the first entry rendered after the given visible change.
+    #[must_use]
+    pub fn select_first_entry_after_change_id(&mut self, change_id: &str) -> bool {
+        self.state.select_first_entry_after_change_id(change_id)
+    }
+
     /// Returns the selected change's full description for editing commands.
     pub fn selected_description(&self) -> Option<&str> {
         self.state
@@ -201,6 +219,12 @@ impl LogView {
     #[must_use]
     pub fn marked_change_ids(&self) -> &[String] {
         self.state.marked_change_ids()
+    }
+
+    /// Returns marked revision identifiers shortened for follow-up commands.
+    #[must_use]
+    pub fn marked_revision_ids(&self) -> Vec<String> {
+        self.state.marked_revision_ids()
     }
 
     /// Returns the selected change's zero-based mark index, if marked.
@@ -451,7 +475,10 @@ mod tests {
             view.apply(LogAction::ToggleExpanded),
             ActionResult::DrillElision
         );
-        assert_eq!(view.selected_elision_revset(), Some("bbb::aaa".to_owned()));
+        assert_eq!(
+            view.selected_elision_revset(),
+            Some("(bbb::aaa) | aaa | bbb".to_owned())
+        );
     }
 
     #[test]

--- a/crates/jk/src/actions.rs
+++ b/crates/jk/src/actions.rs
@@ -9,7 +9,7 @@ use crate::key::AppKey;
 use crate::state::{AppState, AppView, InputMode};
 use crate::{
     AppLoop, SearchDirection, apply_action, apply_search_action, copy_selected_command,
-    edit_command_output, handle_back, open_abandon_preview, open_command_discovery,
+    edit_command_output, handle_back_with_log_source, open_abandon_preview, open_command_discovery,
     open_command_history, open_command_history_operation, open_diff_file_list, open_edit_preview,
     open_jj_command_mode, open_new_preview, open_operation_log, open_recovery_preview,
     open_view_options, open_workspaces, push_selected_command_history_details,
@@ -48,7 +48,7 @@ pub fn dispatch_app_key(
         AppView::Workspaces { .. } | AppView::CommandHistory { .. } | AppView::OperationLog { .. }
     ) && matches!(key.code, KeyCode::Esc)
     {
-        handle_back(state);
+        handle_back_with_log_source(state, sources.log);
         return DispatchResult::Continue;
     }
 
@@ -56,6 +56,13 @@ pub fn dispatch_app_key(
         dispatch_direct_app_key(state, sources, app_key);
         return DispatchResult::Continue;
     };
+
+    if matches!(action, LogAction::CollapseExpanded)
+        && matches!(key.code, KeyCode::Left)
+        && state.pop_log_drill(sources.log)
+    {
+        return DispatchResult::Continue;
+    }
 
     if matches!(app_key, AppKey::Action(LogAction::ToggleHelp)) {
         open_command_discovery(state);
@@ -83,7 +90,7 @@ pub fn dispatch_app_key(
 fn dispatch_direct_app_key(state: &mut AppState, sources: &mut AppSources<'_>, app_key: AppKey) {
     match app_key {
         AppKey::Back => {
-            handle_back(state);
+            handle_back_with_log_source(state, sources.log);
         }
         AppKey::OpenShow => {
             if matches!(state.views.active(), AppView::OperationLog { .. }) {
@@ -92,6 +99,18 @@ fn dispatch_direct_app_key(state: &mut AppState, sources: &mut AppSources<'_>, a
                 push_selected_workspace_status(state, sources.workspaces);
             } else if matches!(state.views.active(), AppView::CommandHistory { .. }) {
                 push_selected_command_history_details(state);
+            } else if active_log_has_selected_elision(state) {
+                let _ = apply_action(
+                    state,
+                    sources.log,
+                    sources.diff,
+                    sources.evolog,
+                    sources.show,
+                    sources.status,
+                    sources.operation,
+                    sources.workspaces,
+                    LogAction::ToggleExpanded,
+                );
             } else {
                 push_selected_show(state, sources.show);
             }
@@ -170,6 +189,13 @@ fn dispatch_direct_app_key(state: &mut AppState, sources: &mut AppSources<'_>, a
         }
         AppKey::Action(_) | AppKey::Ignore | AppKey::StartSearch => {}
     }
+}
+
+fn active_log_has_selected_elision(state: &AppState) -> bool {
+    let AppView::Log(log) = state.views.active() else {
+        return false;
+    };
+    log.selected_elision_revset().is_some()
 }
 
 fn active_view_supports_search(state: &AppState) -> bool {

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -646,7 +646,7 @@ fn open_describe_message(state: &mut AppState) {
     let AppView::Log(log) = state.views.active_mut() else {
         return;
     };
-    let Some(rev) = log.selected_change_id().map(ToOwned::to_owned) else {
+    let Some(rev) = log.selected_revision_id().map(ToOwned::to_owned) else {
         log.show_error("No revision selected");
         return;
     };
@@ -661,7 +661,7 @@ fn open_abandon_preview(state: &mut AppState, abandon_source: &JjAbandon) {
     let AppView::Log(log) = state.views.active_mut() else {
         return;
     };
-    let Some(rev) = log.selected_change_id().map(ToOwned::to_owned) else {
+    let Some(rev) = log.selected_revision_id().map(ToOwned::to_owned) else {
         log.show_error("No revision selected");
         return;
     };
@@ -696,7 +696,7 @@ fn open_edit_preview(state: &mut AppState, edit_source: &JjEdit) {
     let AppView::Log(log) = state.views.active_mut() else {
         return;
     };
-    let Some(rev) = log.selected_change_id().map(ToOwned::to_owned) else {
+    let Some(rev) = log.selected_revision_id().map(ToOwned::to_owned) else {
         log.show_error("No revision selected");
         return;
     };
@@ -1179,12 +1179,23 @@ fn apply_search_action(state: &mut AppState, direction: SearchDirection) {
 }
 
 /// Closes the active mode, or returns to the previous view when possible.
-fn handle_back(state: &mut AppState) {
+#[cfg(test)]
+pub(crate) fn handle_back(state: &mut AppState) {
     if state.modes.pop().is_some() {
         return;
     }
 
     state.views.pop();
+}
+
+pub(crate) fn handle_back_with_log_source(state: &mut AppState, source: &mut JjLog) {
+    if state.modes.pop().is_some() {
+        return;
+    }
+
+    if !state.pop_log_drill(source) {
+        state.views.pop();
+    }
 }
 
 /// Applies an action to the active view and performs any requested I/O.
@@ -1273,6 +1284,14 @@ fn apply_action(
             state.views.push(view);
             AppLoop::Continue
         }
+        AppTransition::PushLog {
+            view,
+            previous_source,
+        } => {
+            state.push_log_source(previous_source);
+            state.views.push(AppView::Log(view));
+            AppLoop::Continue
+        }
         AppTransition::PopView => {
             state.views.pop();
             AppLoop::Continue
@@ -1318,13 +1337,13 @@ fn apply_log_action(
             switch_log_command(log, history, source, JjLogCommand::ConfiguredDefault);
         }
         ActionResult::SwitchLog => switch_log_command(log, history, source, JjLogCommand::Log),
-        ActionResult::DrillElision => drill_log_elision(log, history, source),
+        ActionResult::DrillElision => return drill_log_elision(log, history, source),
         ActionResult::Quit => return AppTransition::Quit,
         _ => {}
     }
 
     if action == jk_tui::log_view::LogAction::OpenDiff {
-        let Some(change_id) = log.selected_change_id().map(ToOwned::to_owned) else {
+        let Some(change_id) = log.selected_revision_id().map(ToOwned::to_owned) else {
             return AppTransition::Continue;
         };
 
@@ -1353,7 +1372,7 @@ fn push_selected_show(state: &mut AppState, show_source: &JjShow) {
         let AppView::Log(log) = state.views.active_mut() else {
             return;
         };
-        let Some(change_id) = log.selected_change_id().map(ToOwned::to_owned) else {
+        let Some(change_id) = log.selected_revision_id().map(ToOwned::to_owned) else {
             return;
         };
         change_id
@@ -1384,7 +1403,7 @@ fn push_selected_evolog(state: &mut AppState, evolog_source: &JjEvolog) {
         let AppView::Log(log) = state.views.active_mut() else {
             return;
         };
-        let Some(change_id) = log.selected_change_id().map(ToOwned::to_owned) else {
+        let Some(change_id) = log.selected_revision_id().map(ToOwned::to_owned) else {
             return;
         };
         change_id
@@ -1787,6 +1806,10 @@ enum AppLoop {
 pub(crate) enum AppTransition {
     Continue,
     Push(AppView),
+    PushLog {
+        view: LogView,
+        previous_source: JjLog,
+    },
     PopView,
     PushSelectedWorkspaceStatus,
     PushSelectedWorkspaceLog,
@@ -1804,11 +1827,19 @@ fn open_template_selector(modes: &mut ModeStack, source: &JjLog) {
     modes.push(InputMode::LogTemplate { options, selected });
 }
 
-/// Replaces the log with a revset that reveals the selected graph elision.
-fn drill_log_elision(app: &mut LogView, history: &mut CommandHistory, source: &mut JjLog) {
+/// Pushes a narrower log view that reveals the selected graph elision.
+fn drill_log_elision(
+    app: &mut LogView,
+    history: &mut CommandHistory,
+    source: &mut JjLog,
+) -> AppTransition {
     let Some(revset) = app.selected_elision_revset() else {
-        return;
+        return AppTransition::Continue;
     };
+    let elision_before_change_id = app
+        .selected_elision_before_change_id()
+        .map(ToOwned::to_owned);
+    let previous_source = source.clone();
     let next_source = source.clone().with_revset(revset);
     let mut runner = recording_runner(
         history,
@@ -1816,10 +1847,20 @@ fn drill_log_elision(app: &mut LogView, history: &mut CommandHistory, source: &m
     );
     match next_source.load_with_runner(&mut runner) {
         Ok(snapshot) => {
+            let mut view = LogView::new(snapshot);
+            if let Some(change_id) = elision_before_change_id {
+                let _ = view.select_first_entry_after_change_id(&change_id);
+            }
             *source = next_source;
-            app.refresh(snapshot);
+            AppTransition::PushLog {
+                view,
+                previous_source,
+            }
         }
-        Err(error) => app.show_error(error.to_string()),
+        Err(error) => {
+            app.show_error(error.to_string());
+            AppTransition::Continue
+        }
     }
 }
 
@@ -2207,6 +2248,40 @@ mod tests {
 
         assert!(stack.pop());
         assert_eq!(stack.active(), &AppView::Log(previous_log));
+    }
+
+    #[test]
+    fn back_from_drilled_log_restores_previous_log_source() {
+        let mut previous_log = LogView::default();
+        previous_log.show_status("previous log");
+        let mut state = AppState::new(AppView::Log(previous_log.clone()));
+        let previous_source = JjLog::default().with_template(LogTemplateSelection::Detailed);
+        state.push_log_source(previous_source.clone());
+        state.views.push(AppView::Log(LogView::default()));
+        let mut source = JjLog::default().with_template(LogTemplateSelection::Compact);
+
+        handle_back_with_log_source(&mut state, &mut source);
+
+        assert_eq!(state.views.len(), 1);
+        assert_eq!(state.views.active(), &AppView::Log(previous_log));
+        assert_eq!(source.template(), previous_source.template());
+    }
+
+    #[test]
+    fn left_from_drilled_log_restores_previous_log_source() {
+        let mut previous_log = LogView::default();
+        previous_log.show_status("previous log");
+        let mut state = AppState::new(AppView::Log(previous_log.clone()));
+        let previous_source = JjLog::default().with_template(LogTemplateSelection::Detailed);
+        state.push_log_source(previous_source.clone());
+        state.views.push(AppView::Log(LogView::default()));
+        let mut source = JjLog::default().with_template(LogTemplateSelection::Compact);
+
+        assert!(state.pop_log_drill(&mut source));
+
+        assert_eq!(state.views.len(), 1);
+        assert_eq!(state.views.active(), &AppView::Log(previous_log));
+        assert_eq!(source.template(), previous_source.template());
     }
 
     #[test]
@@ -2634,15 +2709,15 @@ mod tests {
 
     #[test]
     fn describe_message_opens_for_selected_revision() {
-        let mut state = AppState::new(log_app_view("abc123"));
+        let mut state = AppState::new(log_app_view("abcdefghijklmnop"));
 
         open_describe_message(&mut state);
 
         assert_eq!(
             state.modes.active(),
             Some(&InputMode::DescribeMessage {
-                rev: "abc123".to_owned(),
-                message: "abc123 summary".to_owned(),
+                rev: "abcdefgh".to_owned(),
+                message: "abcdefghijklmnop summary".to_owned(),
             })
         );
     }
@@ -2754,7 +2829,7 @@ mod tests {
 
     #[test]
     fn abandon_preview_uses_selected_revision() {
-        let mut state = AppState::new(log_app_view("abc123"));
+        let mut state = AppState::new(log_app_view("abcdefghijklmnop"));
 
         open_abandon_preview(&mut state, &JjAbandon::default());
 
@@ -2766,7 +2841,7 @@ mod tests {
         assert_eq!(pending.failure_label, "jj abandon");
         assert_eq!(
             pending.preview.command_line,
-            "jj --no-pager --color always abandon abc123"
+            "jj --no-pager --color always abandon abcdefgh"
         );
         assert_eq!(
             pending.preview.safety,
@@ -2780,7 +2855,7 @@ mod tests {
 
     #[test]
     fn new_preview_uses_selected_revision_as_parent() {
-        let mut state = AppState::new(log_app_view("abc123"));
+        let mut state = AppState::new(log_app_view("abcdefghijklmnop"));
 
         open_new_preview(&mut state, &JjNew::default());
 
@@ -2792,7 +2867,7 @@ mod tests {
         assert_eq!(pending.failure_label, "jj new");
         assert_eq!(
             pending.preview.command_line,
-            "jj --no-pager --color always new abc123"
+            "jj --no-pager --color always new abcdefgh"
         );
         assert_eq!(pending.preview.safety, jk_core::SafetyClass::LocalRewrite);
         assert_eq!(
@@ -2803,7 +2878,11 @@ mod tests {
 
     #[test]
     fn new_preview_uses_ordered_marks_as_parents() {
-        let mut state = AppState::new(log_app_view_with_changes(["aaa", "bbb", "ccc"]));
+        let mut state = AppState::new(log_app_view_with_changes([
+            "abcdefghijklmnop",
+            "bbbbbbbbcccccccc",
+            "zyxwvutsrqponmlk",
+        ]));
         let AppView::Log(log) = state.views.active_mut() else {
             panic!("expected log");
         };
@@ -2819,13 +2898,13 @@ mod tests {
         };
         assert_eq!(
             pending.preview.command_line,
-            "jj --no-pager --color always new aaa ccc"
+            "jj --no-pager --color always new abcdefgh zyxwvuts"
         );
     }
 
     #[test]
     fn edit_preview_uses_selected_revision() {
-        let mut state = AppState::new(log_app_view("abc123"));
+        let mut state = AppState::new(log_app_view("abcdefghijklmnop"));
 
         open_edit_preview(&mut state, &JjEdit::default());
 
@@ -2837,7 +2916,7 @@ mod tests {
         assert_eq!(pending.failure_label, "jj edit");
         assert_eq!(
             pending.preview.command_line,
-            "jj --no-pager --color always edit abc123"
+            "jj --no-pager --color always edit abcdefgh"
         );
         assert_eq!(pending.preview.safety, jk_core::SafetyClass::LocalRewrite);
         assert_eq!(

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -1318,6 +1318,7 @@ fn apply_log_action(
             switch_log_command(log, history, source, JjLogCommand::ConfiguredDefault);
         }
         ActionResult::SwitchLog => switch_log_command(log, history, source, JjLogCommand::Log),
+        ActionResult::DrillElision => drill_log_elision(log, history, source),
         ActionResult::Quit => return AppTransition::Quit,
         _ => {}
     }
@@ -1801,6 +1802,25 @@ fn open_template_selector(modes: &mut ModeStack, source: &JjLog) {
         .position(|template| template == source.template())
         .unwrap_or(0);
     modes.push(InputMode::LogTemplate { options, selected });
+}
+
+/// Replaces the log with a revset that reveals the selected graph elision.
+fn drill_log_elision(app: &mut LogView, history: &mut CommandHistory, source: &mut JjLog) {
+    let Some(revset) = app.selected_elision_revset() else {
+        return;
+    };
+    let next_source = source.clone().with_revset(revset);
+    let mut runner = recording_runner(
+        history,
+        CommandSource::new(SourceView::Log, SourceAction::Refresh),
+    );
+    match next_source.load_with_runner(&mut runner) {
+        Ok(snapshot) => {
+            *source = next_source;
+            app.refresh(snapshot);
+        }
+        Err(error) => app.show_error(error.to_string()),
+    }
 }
 
 /// Restores terminal mode even when the event loop returns through an error.

--- a/crates/jk/src/mutation_preview.rs
+++ b/crates/jk/src/mutation_preview.rs
@@ -74,10 +74,10 @@ impl PendingCommandPreview {
 
 pub fn selected_new_parents(log: &LogView) -> Vec<String> {
     if log.has_marks() {
-        return log.marked_change_ids().to_vec();
+        return log.marked_revision_ids();
     }
 
-    log.selected_change_id()
+    log.selected_revision_id()
         .map(ToOwned::to_owned)
         .into_iter()
         .collect()
@@ -108,7 +108,8 @@ pub fn command_failure_message(command: &str, stderr: &[u8], stdout: &[u8]) -> S
 
 #[cfg(test)]
 mod tests {
-    use jk_core::JjCommandSpec;
+    use jk_core::{JjCommandSpec, LogEntry, LogSnapshot};
+    use jk_tui::log_view::LogAction;
 
     use super::*;
 
@@ -149,6 +150,24 @@ mod tests {
     }
 
     #[test]
+    fn selected_new_parents_use_short_selected_revision() {
+        let log = log_view(["abcdefghijklmnop", "zyxwvutsrqponmlk"]);
+
+        assert_eq!(selected_new_parents(&log), ["abcdefgh"]);
+    }
+
+    #[test]
+    fn selected_new_parents_use_short_marked_revisions() {
+        let mut log = log_view(["abcdefghijklmnop", "bbbbbbbbcccccccc", "zyxwvutsrqponmlk"]);
+        let _ = log.apply(LogAction::ToggleMark);
+        let _ = log.apply(LogAction::Next);
+        let _ = log.apply(LogAction::Next);
+        let _ = log.apply(LogAction::ToggleMark);
+
+        assert_eq!(selected_new_parents(&log), ["abcdefgh", "zyxwvuts"]);
+    }
+
+    #[test]
     fn failure_message_prefers_stderr_then_stdout() {
         assert_eq!(
             command_failure_message("jj abandon", b"bad rev\n", b"ignored\n"),
@@ -162,5 +181,24 @@ mod tests {
             command_failure_message("jj edit", b"", b""),
             "jj edit failed"
         );
+    }
+
+    fn log_view<const N: usize>(change_ids: [&str; N]) -> LogView {
+        let rendered = change_ids
+            .iter()
+            .enumerate()
+            .map(|(index, change_id)| {
+                let marker = if index == 0 { "@" } else { "○" };
+                format!("{marker}  {change_id} summary\n")
+            })
+            .collect::<String>();
+        let entries = change_ids
+            .iter()
+            .enumerate()
+            .map(|(index, change_id)| {
+                LogEntry::new(*change_id, "commit", "summary").with_rendered_line(index)
+            })
+            .collect();
+        LogView::new(LogSnapshot::new(rendered, entries))
     }
 }

--- a/crates/jk/src/state.rs
+++ b/crates/jk/src/state.rs
@@ -1,5 +1,5 @@
 use jk_cli::{
-    DiffQuery, EvologQuery, LogTemplateSelection, OperationQuery, ShowQuery, StatusQuery,
+    DiffQuery, EvologQuery, JjLog, LogTemplateSelection, OperationQuery, ShowQuery, StatusQuery,
     WorkspaceInspectionQuery,
 };
 use jk_core::CommandHistory;
@@ -77,6 +77,7 @@ pub struct AppState {
     pub(crate) views: ViewStack,
     pub(crate) modes: ModeStack,
     pub(crate) history: CommandHistory,
+    log_source_stack: Vec<JjLog>,
 }
 
 impl AppState {
@@ -90,12 +91,36 @@ impl AppState {
             views: ViewStack::new(root),
             modes: ModeStack::default(),
             history,
+            log_source_stack: Vec::new(),
         }
     }
 
     #[cfg(test)]
     pub(crate) const fn command_history(&self) -> &CommandHistory {
         &self.history
+    }
+
+    pub(crate) fn push_log_source(&mut self, source: JjLog) {
+        self.log_source_stack.push(source);
+    }
+
+    pub(crate) fn can_pop_log_drill(&self) -> bool {
+        self.views.active_is_log_with_log_parent() && !self.log_source_stack.is_empty()
+    }
+
+    pub(crate) fn pop_log_drill(&mut self, source: &mut JjLog) -> bool {
+        if !self.can_pop_log_drill() {
+            return false;
+        }
+        let Some(previous_source) = self.log_source_stack.pop() else {
+            return false;
+        };
+        if !self.views.pop() {
+            self.log_source_stack.push(previous_source);
+            return false;
+        }
+        *source = previous_source;
+        true
     }
 }
 
@@ -135,6 +160,17 @@ impl ViewStack {
 
         self.views.pop();
         true
+    }
+
+    fn active_is_log_with_log_parent(&self) -> bool {
+        if self.views.len() < 2 {
+            return false;
+        }
+        matches!(self.views.last(), Some(AppView::Log(_)))
+            && matches!(
+                self.views.get(self.views.len().saturating_sub(2)),
+                Some(AppView::Log(_))
+            )
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Summary

- Shorten selected log revision targets before building navigation commands.
- Keep full change IDs for log selection and mark identity.
- Apply shortened IDs to diff, show, evolog, describe, edit, abandon, new parents, and elision drill-in revsets.

## Tests

- cargo +nightly fmt --all
- just fmt-check
- cargo check --workspace --all-targets
- cargo test --workspace
- cargo install --path crates/jk
