### PR TITLE
Improve contextual help overlays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,53 +73,96 @@ behavior, such as `refresh_keeps_selected_change_when_still_visible`.
 Run focused tests while editing and `just release-check` before
 release-oriented changes.
 
+## Betamax Demo & Media Guidelines
+
+Betamax tapes should show the behavior under review, not setup noise.
+Hide setup work with `Hide`, build or fixture-prep while hidden, and
+clear the terminal before the first visible frame. The first visible
+frame should usually be either one clean command line or the app already
+open when the command itself is not the point of the demo.
+
+Avoid extraneous output unrelated to the behavior being shown. Do not
+record dependency builds, `cd`, fixture setup, cargo output, shell
+prompts from pre-work, cleanup commands, or transient diagnostics unless
+that output is the thing under review. If a tape needs that work, run it
+while hidden and use `Wait+Screen` or `Wait+Line` assertions before
+showing the terminal.
+
+Prefer PNG screenshots for simple UI states, layout checks, and
+before/after comparisons that do not need motion. Use GIFs or videos
+only when animation, navigation, typing, state transitions, or timing
+are part of the behavior being reviewed. For GIFs, also capture one or
+more PNG checkpoints when they make review easier.
+
+Use readable dwell times, but keep them intentional:
+
+- Wait on semantic screen text before sleeping.
+- Use short sleeps, around `300ms`, after closing overlays or returning
+  to the shell.
+- Use medium sleeps, around `600ms` to `1200ms`, after opening a new app
+  view or popup that humans need to read.
+- Use longer sleeps only when the demo intentionally teaches a state or
+  transition, and keep those rare.
+- Clear captions with `Caption ""` before cleanup or any frame that
+  should return to a clean terminal.
+
+Keyboard overlays and captions should clarify the action being shown.
+Avoid showing long setup commands in keyboard overlays; keep setup hidden
+or disable overlays until the user-facing interaction begins.
+
 ## TUI App Layout Guidelines
 
-Default to user comprehension over implementation structure. Screens, overlays,
-hotbars, menus, previews, and other discretionary layout should read like
-user-facing product surfaces, not debug views of internal enums or dispatch
-order.
+Default to user comprehension over implementation structure. Screens,
+overlays, hotbars, menus, previews, and other discretionary layout
+should read like user-facing product surfaces, not debug views of
+internal enums or dispatch order.
 
-- Group actions and information by user task, not implementation type. Prefer
-  broad groups such as Open and inspect, Move and find, Change actions, History
-  and recovery, and Session.
-- Keep labels concrete without repeating the same idea twice. Use a command
-  name when the command is the clearest label, or use an action label when the
-  action is clearer; avoid command-plus-parenthetical forms that restate each
-  other.
-- Align columns globally within a surface. Key, action, object, status, and
-  command columns should share column stops rather than jittering per section.
-- Avoid accidental horizontal spread. Multi-column layouts are useful only when
-  related columns remain visually connected by a deliberate gap.
-- Size overlays and modals to rendered content with minimal padding. Avoid fixed
-  large dialog dimensions when the content is smaller. Scrollable document
-  overlays should size from the full rendered document, not from the current
-  scroll slice, so the box does not resize while scrolling.
-- Use available space before scrolling when it improves scanning. Show all
-  relevant content when the terminal can fit it cleanly, but width-constrained
-  document overlays may keep a stable viewport instead of expanding into a tall
-  sheet. Show scroll indicators only when content is hidden.
+- Group actions and information by user task, not implementation type.
+  Prefer broad groups such as Open and inspect, Move and find, Change
+  actions, History and recovery, and Session.
+- Keep labels concrete without repeating the same idea twice. Use a
+  command name when the command is the clearest label, or use an action
+  label when the action is clearer; avoid command-plus-parenthetical
+  forms that restate each other.
+- Align columns globally within a surface. Key, action, object, status,
+  and command columns should share column stops rather than jittering
+  per section.
+- Avoid accidental horizontal spread. Multi-column layouts are useful
+  only when related columns remain visually connected by a deliberate
+  gap.
+- Size overlays and modals to rendered content with minimal padding.
+  Avoid fixed large dialog dimensions when the content is smaller.
+  Scrollable document overlays should size from the full rendered
+  document, not from the current scroll slice, so the box does not
+  resize while scrolling.
+- Use available space before scrolling when it improves scanning. Show
+  all relevant content when the terminal can fit it cleanly, but
+  width-constrained document overlays may keep a stable viewport instead
+  of expanding into a tall sheet. Show scroll indicators only when
+  content is hidden.
 - Match scrolling to the surface. Document-like content should scroll by
-  rendered line; selection-style movement belongs to actual selectable rows.
-- Do not repeat controls between body, hotbar, footer, and chrome. Chrome should
-  add only information not already carried by the active surface, except when
-  the visible chrome belongs to the underlying screen and remains useful for
-  mode safety.
-- Prefer readable key notation. Use symbols where they reduce noise, such as
-  `↑/↓` and `←/→`, and split overloaded bindings when they represent different
-  actions.
-- Protect keys, action text, object labels, and status text from wrapping and
-  truncation. At narrow widths, fall back to shorter labels or fewer columns
-  before allowing awkward wrapping.
-- Choose column count from content shape, not width alone. A two-column layout
-  should activate only when both columns fit, the gap is readable, vertical
-  scrolling is materially reduced, and the result still scans top-to-bottom.
-- Test layout as data. Unit tests should cover representative sizes and assert
-  width bounds, scroll indicators, column switching, readable compact layouts,
-  and consistent alignment.
-- Use PNG or terminal visual proof for polish and gestalt. Mechanical failures
-  such as overflow, stale scroll indicators, bad column switching, and unwanted
-  truncation belong in tests.
+  rendered line; selection-style movement belongs to actual selectable
+  rows.
+- Do not repeat controls between body, hotbar, footer, and chrome.
+  Chrome should add only information not already carried by the active
+  surface, except when the visible chrome belongs to the underlying
+  screen and remains useful for mode safety.
+- Prefer readable key notation. Use symbols where they reduce noise,
+  such as `↑/↓` and `←/→`, and split overloaded bindings when they
+  represent different actions.
+- Protect keys, action text, object labels, and status text from
+  wrapping and truncation. At narrow widths, fall back to shorter labels
+  or fewer columns before allowing awkward wrapping.
+- Choose column count from content shape, not width alone. A two-column
+  layout should activate only when both columns fit, the gap is readable,
+  vertical scrolling is materially reduced, and the result still scans
+  top-to-bottom.
+- Test layout as data. Unit tests should cover representative sizes and
+  assert width bounds, scroll indicators, column switching, readable
+  compact layouts, and consistent alignment.
+- Use PNG or terminal visual proof for polish and gestalt. Mechanical
+  failures such as overflow, stale scroll indicators, bad column
+  switching, and unwanted truncation belong in tests.
 
 ## Commit & Pull Request Guidelines
 

--- a/crates/jk-tui/src/chrome.rs
+++ b/crates/jk-tui/src/chrome.rs
@@ -17,23 +17,207 @@ pub fn render_help_overlay(frame: &mut Frame<'_>, area: Rect, title: &str, lines
         return;
     }
 
-    let overlay = centered_rect(area, 72, lines.len().saturating_add(4));
+    let overlay = centered_rect(
+        area,
+        overlay_width(title, lines, area.width),
+        overlay_height(title, lines),
+    );
     frame.render_widget(Clear, overlay);
 
-    let text = Text::from(
-        std::iter::once(Line::from(Span::styled(
-            title,
-            Style::new().add_modifier(Modifier::BOLD),
-        )))
-        .chain(std::iter::once(Line::from("")))
-        .chain(lines.iter().map(|line| Line::from(line.as_str())))
-        .collect::<Vec<_>>(),
-    );
+    let command_discovery = title == "Command discovery";
+    let display_title = if command_discovery { "Help" } else { title };
+    let mut text_lines = Vec::new();
+    if !command_discovery {
+        text_lines.push(Line::from(Span::styled(
+            display_title,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        )));
+        text_lines.push(Line::from(""));
+    }
+    text_lines.extend(lines.iter().map(|line| overlay_line(line)));
+    let text = Text::from(text_lines);
+    let mut block = Block::bordered();
+    if command_discovery {
+        block = block.title(Span::styled(
+            display_title,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ));
+    }
     let paragraph = Paragraph::new(text)
-        .block(Block::bordered())
+        .block(block)
         .style(Style::new().fg(Color::White).bg(Color::Black))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, overlay);
+}
+
+fn overlay_width(title: &str, lines: &[String], area_width: u16) -> usize {
+    const COMMAND_DISCOVERY_MAX_WIDTH: usize = 132;
+
+    if title == "Command discovery" {
+        let content_width = lines
+            .iter()
+            .map(|line| visible_width(line))
+            .chain(std::iter::once(visible_width("Help")))
+            .max()
+            .unwrap_or(0);
+        let area_width = usize::from(area_width);
+        return content_width
+            .saturating_add(4)
+            .clamp(56, COMMAND_DISCOVERY_MAX_WIDTH)
+            .min(area_width);
+    }
+
+    let content_width = lines
+        .iter()
+        .map(|line| visible_width(line))
+        .chain(std::iter::once(visible_width(title)))
+        .max()
+        .unwrap_or(0);
+    content_width.saturating_add(4).clamp(56, 96)
+}
+
+fn overlay_height(title: &str, lines: &[String]) -> usize {
+    if title == "Command discovery" {
+        return lines.len().saturating_add(2);
+    }
+
+    lines.len().saturating_add(4)
+}
+
+fn overlay_line(line: &str) -> Line<'_> {
+    if line.ends_with(':') {
+        return Line::from(Span::styled(
+            line,
+            Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    if let Some(line) = command_row_line(line) {
+        return line;
+    }
+
+    if line.starts_with("Type ")
+        || line == "actions, and aliases."
+        || line.starts_with("Examples:")
+        || line.contains(" closes")
+        || line.starts_with("showing ")
+        || line.trim_start().starts_with("key ")
+    {
+        return Line::from(Span::styled(line, Style::new().fg(Color::Gray)));
+    }
+
+    if line.starts_with('>') {
+        return Line::from(Span::styled(
+            line,
+            Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    Line::from(line)
+}
+
+fn command_row_line(line: &str) -> Option<Line<'_>> {
+    if !line.starts_with("  ") || line.trim_start().starts_with("no matching") {
+        return None;
+    }
+
+    let mut spans = Vec::new();
+    let mut cursor = 0;
+    while let Some(prefix_start) = find_cell_prefix(line, cursor) {
+        if prefix_start > cursor {
+            spans.push(Span::raw(&line[cursor..prefix_start]));
+        }
+
+        let key_start = skip_spaces(line, prefix_start);
+        let separator_start = find_space_run(line, key_start, 2)?;
+        let separator_end = skip_spaces(line, separator_start);
+        let key = &line[key_start..separator_start];
+        if key.trim().is_empty() {
+            return None;
+        }
+
+        spans.push(Span::raw(&line[prefix_start..key_start]));
+        spans.push(Span::styled(
+            key,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(&line[separator_start..separator_end]));
+
+        let next_prefix = find_next_cell_prefix(line, separator_end);
+        let action_end = next_prefix.unwrap_or(line.len());
+        spans.push(Span::styled(
+            &line[separator_end..action_end],
+            Style::new().fg(Color::White),
+        ));
+
+        cursor = action_end;
+        if next_prefix.is_none() {
+            break;
+        }
+    }
+
+    if cursor < line.len() {
+        spans.push(Span::raw(&line[cursor..]));
+    }
+
+    Some(Line::from(spans))
+}
+
+fn find_next_cell_prefix(line: &str, start: usize) -> Option<usize> {
+    let mut cursor = start;
+    while let Some(prefix_start) = find_cell_prefix(line, cursor) {
+        let key_start = skip_spaces(line, prefix_start);
+        if find_space_run(line, key_start, 2).is_some() {
+            return Some(prefix_start);
+        }
+        cursor = key_start.saturating_add(1);
+    }
+    None
+}
+
+fn find_cell_prefix(line: &str, start: usize) -> Option<usize> {
+    let mut cursor = start;
+    while let Some(space_start) = find_space_run(line, cursor, 2) {
+        let key_start = skip_spaces(line, space_start);
+        if key_start < line.len() {
+            return Some(space_start);
+        }
+        cursor = key_start;
+    }
+    None
+}
+
+fn find_space_run(line: &str, start: usize, min_len: usize) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut cursor = start;
+    while cursor < bytes.len() {
+        if bytes[cursor] != b' ' {
+            cursor += 1;
+            continue;
+        }
+
+        let run_start = cursor;
+        while cursor < bytes.len() && bytes[cursor] == b' ' {
+            cursor += 1;
+        }
+        if cursor.saturating_sub(run_start) >= min_len {
+            return Some(run_start);
+        }
+    }
+    None
+}
+
+fn skip_spaces(line: &str, start: usize) -> usize {
+    let bytes = line.as_bytes();
+    let mut cursor = start;
+    while cursor < bytes.len() && bytes[cursor] == b' ' {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn visible_width(text: &str) -> usize {
+    text.chars().count()
 }
 
 fn centered_rect(area: Rect, preferred_width: usize, preferred_height: usize) -> Rect {

--- a/crates/jk-tui/src/diff_view.rs
+++ b/crates/jk-tui/src/diff_view.rs
@@ -559,7 +559,7 @@ mod tests {
     fn help_action_shows_diff_specific_keys() {
         let mut view = DiffView::new(snapshot("aaa", "Modified regular file src/a.rs:\n alpha\n"));
         let _ = view.apply(DiffAction::ToggleHelp);
-        let backend = TestBackend::new(72, 18);
+        let backend = TestBackend::new(72, 32);
         let mut terminal = match Terminal::new(backend) {
             Ok(terminal) => terminal,
             Err(error) => match error {},
@@ -570,9 +570,11 @@ mod tests {
 
         let rendered = buffer_to_string(terminal.backend().buffer());
         assert!(rendered.contains("Diff keys"));
-        assert!(rendered.contains("f                    open file list"));
-        assert!(rendered.contains("[ / ]                previous/next file"));
-        assert!(rendered.contains("/, n, N              search, next, previous"));
+        assert!(rendered.contains("Open and inspect:"));
+        assert!(rendered.contains("open file list"));
+        assert!(rendered.contains("previous/next file"));
+        assert!(rendered.contains("Move and find:"));
+        assert!(rendered.contains("search, next, previous"));
     }
 
     #[test]

--- a/crates/jk-tui/src/keymap.rs
+++ b/crates/jk-tui/src/keymap.rs
@@ -24,8 +24,10 @@ pub enum BindingContext {
 enum ActionId {
     Move,
     LineScroll,
-    Page,
-    FirstLast,
+    PageDown,
+    PageUp,
+    JumpTop,
+    JumpBottom,
     Mark,
     ClearMarks,
     Expand,
@@ -65,13 +67,84 @@ enum ActionId {
     Quit,
 }
 
+const fn default_help_group(action: ActionId) -> HelpGroup {
+    match action {
+        ActionId::Move
+        | ActionId::LineScroll
+        | ActionId::PageDown
+        | ActionId::PageUp
+        | ActionId::JumpTop
+        | ActionId::JumpBottom
+        | ActionId::Expand
+        | ActionId::Collapse
+        | ActionId::HorizontalScroll
+        | ActionId::Search
+        | ActionId::ReturnToLog
+        | ActionId::ReturnBack => HelpGroup::Navigation,
+        ActionId::OpenShow
+        | ActionId::OpenDiff
+        | ActionId::OpenLog
+        | ActionId::OpenEvolog
+        | ActionId::OpenStatus
+        | ActionId::SwitchLogCommand
+        | ActionId::ViewOptions
+        | ActionId::OpenFileList
+        | ActionId::File
+        | ActionId::Hunk
+        | ActionId::FoldFile
+        | ActionId::FoldAll
+        | ActionId::FoldHunk => HelpGroup::Views,
+        ActionId::OpenDescribe
+        | ActionId::NewChange
+        | ActionId::EditChange
+        | ActionId::Abandon
+        | ActionId::Mark
+        | ActionId::ClearMarks => HelpGroup::Mutations,
+        ActionId::OpenCommandHistory
+        | ActionId::OpenCommandDetails
+        | ActionId::CopyCommand
+        | ActionId::OpenOperation
+        | ActionId::OpenOperationLog
+        | ActionId::Undo
+        | ActionId::Redo => HelpGroup::Recovery,
+        ActionId::CommandMode
+        | ActionId::Refresh
+        | ActionId::UpdateStale
+        | ActionId::CloseHelp
+        | ActionId::Quit => HelpGroup::Session,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HelpGroup {
+    Navigation,
+    Views,
+    Mutations,
+    Recovery,
+    Session,
+}
+
+impl HelpGroup {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Navigation => "Move and find",
+            Self::Views => "Open and inspect",
+            Self::Mutations => "Change actions",
+            Self::Recovery => "History and recovery",
+            Self::Session => "Session",
+        }
+    }
+}
+
 impl ActionId {
     const fn label(self) -> &'static str {
         match self {
             Self::Move => "Move selection",
             Self::LineScroll => "Scroll line",
-            Self::Page => "Page",
-            Self::FirstLast => "Jump to edge",
+            Self::PageDown => "Page down",
+            Self::PageUp => "Page up",
+            Self::JumpTop => "Jump to top",
+            Self::JumpBottom => "Jump to bottom",
             Self::Mark => "Mark revision",
             Self::ClearMarks => "Clear marks",
             Self::Expand => "Expand change",
@@ -108,12 +181,12 @@ impl ActionId {
             Self::ReturnToLog => "Return to log",
             Self::ReturnBack => "Return back",
             Self::CloseHelp => "Close help",
-            Self::Quit => "Quit",
+            Self::Quit => "Quit / exit",
         }
     }
 }
 
-/// Command or interaction family used by searchable discovery.
+/// Command or interaction family used by contextual help.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CommandFamily {
     /// Commands and actions related to `jj log`.
@@ -156,7 +229,7 @@ pub enum CommandFamily {
     ViewOptions,
     /// User-entered `jj` command mode.
     CommandMode,
-    /// Help and discovery controls.
+    /// Help controls.
     Help,
     /// Quitting the application.
     Quit,
@@ -196,6 +269,7 @@ struct KeyBinding {
     action: ActionId,
     keys: &'static str,
     help: &'static str,
+    help_group: HelpGroup,
     command_family: Option<CommandFamily>,
     aliases: &'static [&'static str],
     hotbar: Option<&'static str>,
@@ -210,6 +284,7 @@ impl KeyBinding {
             action,
             keys,
             help,
+            help_group: default_help_group(action),
             command_family: None,
             aliases: &[],
             hotbar: None,
@@ -240,8 +315,8 @@ impl KeyBinding {
         self
     }
 
-    fn help_line(self) -> String {
-        format!("{:<21}{}", self.keys, self.help)
+    fn help_line(self, key_width: usize) -> String {
+        format!("  {:<key_width$} {}", self.keys, self.help)
     }
 }
 
@@ -323,22 +398,27 @@ const LOG_BINDINGS: &[KeyBinding] = &[
         .with_family(CommandFamily::JjLog)
         .with_aliases(&["home", "current screen"])
         .with_hotbar(2, "H home  L log"),
-    KeyBinding::new(ActionId::Move, "j/k or arrows", "move selection")
+    KeyBinding::new(ActionId::Move, "↑/↓, j/k", "move selection")
         .with_family(CommandFamily::Navigation)
         .with_aliases(&["selection", "current row"])
         .with_hotbar(13, "j/k move"),
     KeyBinding::new(ActionId::LineScroll, "Ctrl-j/k", "scroll one line")
         .with_family(CommandFamily::Navigation),
-    KeyBinding::new(ActionId::Page, "b, Ctrl-f/b, PgUp/Dn", "page down/up")
+    KeyBinding::new(ActionId::PageDown, "PgDn, Ctrl-f", "page down")
         .with_family(CommandFamily::Navigation)
         .with_aliases(&["page", "pagedown", "pageup"]),
-    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+    KeyBinding::new(ActionId::PageUp, "PgUp, Ctrl-b", "page up")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["page", "pagedown", "pageup"]),
+    KeyBinding::new(ActionId::JumpTop, "Home, g", "jump to top")
         .with_family(CommandFamily::Navigation),
-    KeyBinding::new(ActionId::Expand, "right, l", "expand change / drill into ~")
+    KeyBinding::new(ActionId::JumpBottom, "End, G", "jump to bottom")
         .with_family(CommandFamily::Navigation),
-    KeyBinding::new(ActionId::Collapse, "left, h", "collapse selected change")
+    KeyBinding::new(ActionId::Expand, "→, l", "expand change / drill into ~")
         .with_family(CommandFamily::Navigation),
-    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+    KeyBinding::new(ActionId::Collapse, "←, h", "collapse selected change")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::CloseHelp, "?, Esc", "close help")
         .with_family(CommandFamily::Help)
         .with_hotbar(1, "? help"),
     KeyBinding::new(ActionId::Quit, "q", "quit")
@@ -382,20 +462,24 @@ const DIFF_BINDINGS: &[KeyBinding] = &[
     KeyBinding::new(ActionId::Refresh, "r", "refresh")
         .with_family(CommandFamily::Refresh)
         .with_hotbar(3, "r refresh"),
-    KeyBinding::new(ActionId::Move, "j/k or arrows", "scroll one line")
+    KeyBinding::new(ActionId::Move, "↑/↓, j/k", "scroll one line")
         .with_family(CommandFamily::Navigation)
         .with_hotbar(4, "j/k line"),
     KeyBinding::new(ActionId::LineScroll, "Ctrl-j/k", "scroll one line")
         .with_family(CommandFamily::Navigation),
-    KeyBinding::new(ActionId::Page, "space / b, Ctrl-f/b", "page down/up")
+    KeyBinding::new(ActionId::PageDown, "Space, PgDn, Ctrl-f", "page down")
         .with_family(CommandFamily::Navigation)
-        .with_hotbar(6, "space/b page"),
-    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+        .with_hotbar(6, "space page"),
+    KeyBinding::new(ActionId::PageUp, "PgUp, Ctrl-b", "page up")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::JumpTop, "Home, g", "jump to top")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::JumpBottom, "End, G", "jump to bottom")
         .with_family(CommandFamily::Navigation),
     KeyBinding::new(ActionId::ReturnToLog, "H / L", "go back")
         .with_family(CommandFamily::JjLog)
         .with_aliases(&["back"]),
-    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+    KeyBinding::new(ActionId::CloseHelp, "?, Esc", "close help")
         .with_family(CommandFamily::Help)
         .with_hotbar(1, "? help"),
     KeyBinding::new(ActionId::Quit, "q", "quit")
@@ -421,20 +505,24 @@ const INSPECTION_BINDINGS: &[KeyBinding] = &[
     KeyBinding::new(ActionId::Refresh, "r", "refresh")
         .with_family(CommandFamily::Refresh)
         .with_hotbar(3, "r refresh"),
-    KeyBinding::new(ActionId::Move, "j/k or arrows", "scroll one line")
+    KeyBinding::new(ActionId::Move, "↑/↓, j/k", "scroll one line")
         .with_family(CommandFamily::Navigation)
         .with_hotbar(4, "j/k line"),
     KeyBinding::new(ActionId::LineScroll, "Ctrl-j/k", "scroll one line")
         .with_family(CommandFamily::Navigation),
-    KeyBinding::new(ActionId::Page, "space / b, Ctrl-f/b", "page down/up")
+    KeyBinding::new(ActionId::PageDown, "Space, PgDn, Ctrl-f", "page down")
         .with_family(CommandFamily::Navigation)
-        .with_hotbar(5, "space/b page"),
-    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+        .with_hotbar(5, "space page"),
+    KeyBinding::new(ActionId::PageUp, "PgUp, Ctrl-b", "page up")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::JumpTop, "Home, g", "jump to top")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::JumpBottom, "End, G", "jump to bottom")
         .with_family(CommandFamily::Navigation),
     KeyBinding::new(ActionId::ReturnToLog, "H / L", "go back")
         .with_family(CommandFamily::JjLog)
         .with_aliases(&["back"]),
-    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+    KeyBinding::new(ActionId::CloseHelp, "?, Esc", "close help")
         .with_family(CommandFamily::Help)
         .with_hotbar(1, "? help"),
     KeyBinding::new(ActionId::Quit, "q", "quit")
@@ -482,7 +570,7 @@ const WORKSPACES_BINDINGS: &[KeyBinding] = &[
         .with_family(CommandFamily::Refresh)
         .with_aliases(&["reload", "workspace"])
         .with_hotbar(2, "r refresh"),
-    KeyBinding::new(ActionId::Move, "j/k or arrows", "move selection")
+    KeyBinding::new(ActionId::Move, "↑/↓, j/k", "move selection")
         .with_family(CommandFamily::Navigation)
         .with_aliases(&["selection", "workspace", "current row"])
         .with_hotbar(5, "j/k move"),
@@ -496,7 +584,7 @@ const WORKSPACES_BINDINGS: &[KeyBinding] = &[
     .with_family(CommandFamily::Navigation)
     .with_aliases(&["back", "return", "previous"])
     .with_hotbar(9, "Esc back"),
-    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+    KeyBinding::new(ActionId::CloseHelp, "?, Esc", "close help")
         .with_family(CommandFamily::Help)
         .with_hotbar(1, "? help"),
     KeyBinding::new(ActionId::Quit, "q", "quit")
@@ -535,15 +623,20 @@ const COMMAND_HISTORY_BINDINGS: &[KeyBinding] = &[
     KeyBinding::new(ActionId::CommandMode, ":", "run jj command")
         .with_family(CommandFamily::CommandMode)
         .with_aliases(&["command", "prompt", "colon", "jj"]),
-    KeyBinding::new(ActionId::Move, "j/k or arrows", "move selection")
+    KeyBinding::new(ActionId::Move, "↑/↓, j/k", "move selection")
         .with_family(CommandFamily::Navigation)
         .with_aliases(&["selection", "command", "current row"])
         .with_hotbar(3, "j/k move"),
-    KeyBinding::new(ActionId::Page, "space / b, Ctrl-f/b", "page down/up")
+    KeyBinding::new(ActionId::PageDown, "Space, PgDn, Ctrl-f", "page down")
         .with_family(CommandFamily::Navigation)
         .with_aliases(&["page", "pagedown", "pageup"])
-        .with_hotbar(4, "space/b page"),
-    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+        .with_hotbar(4, "space page"),
+    KeyBinding::new(ActionId::PageUp, "PgUp, Ctrl-b", "page up")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["page", "pagedown", "pageup"]),
+    KeyBinding::new(ActionId::JumpTop, "Home, g", "jump to top")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::JumpBottom, "End, G", "jump to bottom")
         .with_family(CommandFamily::Navigation),
     KeyBinding::new(
         ActionId::ReturnBack,
@@ -553,7 +646,7 @@ const COMMAND_HISTORY_BINDINGS: &[KeyBinding] = &[
     .with_family(CommandFamily::Navigation)
     .with_aliases(&["back", "return", "previous"])
     .with_hotbar(8, "Esc back"),
-    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+    KeyBinding::new(ActionId::CloseHelp, "?, Esc", "close help")
         .with_family(CommandFamily::Help)
         .with_hotbar(1, "? help"),
     KeyBinding::new(ActionId::Quit, "q", "quit")
@@ -578,15 +671,20 @@ const OPERATION_LOG_BINDINGS: &[KeyBinding] = &[
     KeyBinding::new(ActionId::CommandMode, ":", "run jj command")
         .with_family(CommandFamily::CommandMode)
         .with_aliases(&["command", "prompt", "colon", "jj"]),
-    KeyBinding::new(ActionId::Move, "j/k or arrows", "move selection")
+    KeyBinding::new(ActionId::Move, "↑/↓, j/k", "move selection")
         .with_family(CommandFamily::Navigation)
         .with_aliases(&["selection", "operation", "current row"])
         .with_hotbar(4, "j/k move"),
-    KeyBinding::new(ActionId::Page, "space / b, Ctrl-f/b", "page down/up")
+    KeyBinding::new(ActionId::PageDown, "Space, PgDn, Ctrl-f", "page down")
         .with_family(CommandFamily::Navigation)
         .with_aliases(&["page", "pagedown", "pageup"])
-        .with_hotbar(5, "space/b page"),
-    KeyBinding::new(ActionId::FirstLast, "g/G or Home/End", "jump to top/bottom")
+        .with_hotbar(5, "space page"),
+    KeyBinding::new(ActionId::PageUp, "PgUp, Ctrl-b", "page up")
+        .with_family(CommandFamily::Navigation)
+        .with_aliases(&["page", "pagedown", "pageup"]),
+    KeyBinding::new(ActionId::JumpTop, "Home, g", "jump to top")
+        .with_family(CommandFamily::Navigation),
+    KeyBinding::new(ActionId::JumpBottom, "End, G", "jump to bottom")
         .with_family(CommandFamily::Navigation),
     KeyBinding::new(
         ActionId::ReturnBack,
@@ -596,7 +694,7 @@ const OPERATION_LOG_BINDINGS: &[KeyBinding] = &[
     .with_family(CommandFamily::Navigation)
     .with_aliases(&["back", "return", "previous"])
     .with_hotbar(7, "Esc back"),
-    KeyBinding::new(ActionId::CloseHelp, "?, q, Esc", "close help")
+    KeyBinding::new(ActionId::CloseHelp, "?, Esc", "close help")
         .with_family(CommandFamily::Help)
         .with_hotbar(1, "? help"),
     KeyBinding::new(ActionId::Quit, "q", "quit")
@@ -750,58 +848,78 @@ pub const fn help_title(context: BindingContext) -> &'static str {
 
 /// Returns generated help lines for the current binding context.
 pub fn help_lines(context: BindingContext) -> Vec<String> {
-    bindings(context)
+    let visible = bindings(context)
         .iter()
         .filter(|binding| binding.show_in_help)
-        .map(|binding| binding.help_line())
-        .collect()
+        .copied()
+        .collect::<Vec<_>>();
+    let key_width = visible
+        .iter()
+        .map(|binding| visible_width(binding.keys))
+        .max()
+        .unwrap_or(0);
+    let mut lines = vec![
+        "Contextual help for the current screen.".to_owned(),
+        String::new(),
+    ];
+
+    let mut first_group = true;
+    for group in help_groups_for_context(context) {
+        let group_bindings = visible
+            .iter()
+            .filter(|binding| binding.help_group == *group)
+            .collect::<Vec<_>>();
+        if group_bindings.is_empty() {
+            continue;
+        }
+
+        if !first_group {
+            lines.push(String::new());
+        }
+        first_group = false;
+        lines.push(format!("{}:", group.label()));
+        lines.extend(
+            group_bindings
+                .into_iter()
+                .map(|binding| binding.help_line(key_width)),
+        );
+    }
+
+    lines
 }
 
-/// A searchable command-discovery row derived from visible keymap metadata.
+/// A contextual help row derived from visible keymap metadata.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DiscoveryRow {
+    action_id: ActionId,
     /// Key text shown in the first column.
     pub keys: &'static str,
     /// Short action label shown in the second column.
     pub action: &'static str,
-    /// Help text used for filtering and future detail displays.
+    /// Help text used for legacy help and future detail displays.
     pub help: &'static str,
     /// Screen context where the row applies.
     pub context: BindingContext,
     /// Optional command or interaction family.
     pub command_family: Option<CommandFamily>,
+    help_group: HelpGroup,
     aliases: &'static [&'static str],
 }
 
 impl DiscoveryRow {
-    /// Returns the context label used for rendering and filtering.
+    /// Returns the context label used for rendering.
     #[must_use]
     pub const fn context_label(self) -> &'static str {
         context_label(self.context)
     }
 
-    /// Returns the command family label used for rendering and filtering.
+    /// Returns the command family label used for rendering.
     #[must_use]
     pub const fn command_family_label(self) -> Option<&'static str> {
         match self.command_family {
             Some(family) => Some(family.label()),
             None => None,
         }
-    }
-
-    fn matches_token(self, token: &str) -> bool {
-        let token = token.to_lowercase();
-        self.keys.to_lowercase().contains(&token)
-            || self.action.to_lowercase().contains(&token)
-            || self.help.to_lowercase().contains(&token)
-            || self.context_label().to_lowercase().contains(&token)
-            || self
-                .command_family_label()
-                .is_some_and(|family| family.to_lowercase().contains(&token))
-            || self
-                .aliases
-                .iter()
-                .any(|alias| alias.to_lowercase().contains(&token))
     }
 }
 
@@ -812,58 +930,298 @@ pub fn discovery_rows(context: BindingContext) -> Vec<DiscoveryRow> {
         .iter()
         .filter(|binding| binding.show_in_discovery)
         .map(|binding| DiscoveryRow {
+            action_id: binding.action,
             keys: binding.keys,
             action: binding.action.label(),
             help: binding.help,
             context,
             command_family: binding.command_family,
+            help_group: binding.help_group,
             aliases: binding.aliases,
         })
         .collect()
 }
 
-/// Returns context rows whose searchable fields match every query token.
+/// Number of command rows shown in the discovery popup before scrolling.
+pub const DISCOVERY_VISIBLE_ROWS: usize = 12;
+
+const DISCOVERY_DEFAULT_WIDTH: usize = 80;
+const DISCOVERY_COLUMN_GUTTER: usize = 6;
+const DISCOVERY_TWO_COLUMN_WIDTH: usize = 80;
+const DISCOVERY_WIDE_VISIBLE_ROWS: usize = 34;
+
+/// Formats command-discovery popup lines for the current context and scroll offset.
 #[must_use]
-pub fn filter_discovery_rows(context: BindingContext, query: &str) -> Vec<DiscoveryRow> {
-    let tokens = query.split_whitespace().collect::<Vec<_>>();
-    discovery_rows(context)
-        .into_iter()
-        .filter(|row| tokens.iter().all(|token| row.matches_token(token)))
-        .collect()
+pub fn discovery_lines(context: BindingContext, _query: &str, scroll_offset: usize) -> Vec<String> {
+    discovery_lines_for_width(context, "", scroll_offset, DISCOVERY_DEFAULT_WIDTH)
 }
 
-/// Formats command-discovery popup lines for the current query and selected row.
+/// Formats command-discovery popup lines for the current context, scroll offset, and width.
 #[must_use]
-pub fn discovery_lines(context: BindingContext, query: &str, selected: usize) -> Vec<String> {
-    let rows = filter_discovery_rows(context, query);
-    let selected = selected.min(rows.len().saturating_sub(1));
-    let mut lines = vec![format!("? {query}")];
+pub fn discovery_lines_for_width(
+    context: BindingContext,
+    _query: &str,
+    scroll_offset: usize,
+    width: usize,
+) -> Vec<String> {
+    discovery_lines_for_width_and_rows(
+        context,
+        "",
+        scroll_offset,
+        width,
+        default_discovery_visible_rows(width),
+    )
+}
 
-    if rows.is_empty() {
-        lines.push("  no matching commands".to_owned());
-    } else {
-        lines.extend(rows.into_iter().enumerate().map(|(index, row)| {
-            let marker = if index == selected { ">" } else { " " };
-            let family = row.command_family_label().unwrap_or("");
-            format!(
-                "{marker} {:<18} {:<24} {:<10} {}",
-                row.keys,
-                row.action,
-                row.context_label(),
-                family
-            )
-        }));
-    }
-
-    lines.push(String::new());
-    lines.push("type to filter   j/k or arrows move   enter/esc close".to_owned());
+/// Formats command-discovery popup lines for the current context, width, and body-row budget.
+#[must_use]
+pub fn discovery_lines_for_width_and_rows(
+    context: BindingContext,
+    _query: &str,
+    scroll_offset: usize,
+    width: usize,
+    visible_rows: usize,
+) -> Vec<String> {
+    let rows = discovery_rows(context);
+    let body_lines = discovery_body_lines(context, &rows, width);
+    let body_line_count = body_lines.len();
+    let visible_body_lines = discovery_visible_body_lines(visible_rows);
+    let (start, end) = visible_discovery_range(body_line_count, scroll_offset, visible_body_lines);
+    let mut lines = body_lines[start..end].to_vec();
+    lines.extend(discovery_footer_lines(width, start, end, body_line_count));
     lines
 }
 
-/// Returns the number of visible discovery rows for clamping selection state.
+fn discovery_body_lines(
+    context: BindingContext,
+    rows: &[DiscoveryRow],
+    width: usize,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    let spaced_groups = discovery_uses_group_spacing(width);
+    let key_width = discovery_key_width_for_width(rows, width);
+    let column_width = discovery_global_column_width(rows, key_width);
+    let column_count = discovery_column_count(width, column_width);
+    for group in help_groups_for_context(context) {
+        let group_rows = rows
+            .iter()
+            .filter(|row| row.help_group == *group)
+            .copied()
+            .collect::<Vec<_>>();
+        if group_rows.is_empty() {
+            continue;
+        }
+
+        if spaced_groups && !lines.is_empty() {
+            lines.push(String::new());
+        }
+        lines.push(format!("{}:", group.label()));
+        lines.extend(
+            group_rows.chunks(column_count).map(|chunk| {
+                discovery_row_line(chunk, column_count, column_width, key_width, width)
+            }),
+        );
+    }
+    lines
+}
+
+const fn discovery_uses_group_spacing(width: usize) -> bool {
+    width >= 120
+}
+
+const fn discovery_column_count(width: usize, column_width: usize) -> usize {
+    if width >= DISCOVERY_TWO_COLUMN_WIDTH
+        && column_width
+            .saturating_mul(2)
+            .saturating_add(DISCOVERY_COLUMN_GUTTER)
+            <= width
+    {
+        2
+    } else {
+        1
+    }
+}
+
+fn discovery_global_column_width(rows: &[DiscoveryRow], key_width: usize) -> usize {
+    rows.iter()
+        .map(|row| discovery_cell_width(*row, key_width))
+        .max()
+        .unwrap_or(0)
+}
+
+fn discovery_row_line(
+    rows: &[DiscoveryRow],
+    column_count: usize,
+    column_width: usize,
+    key_width: usize,
+    width: usize,
+) -> String {
+    rows.iter()
+        .enumerate()
+        .map(|(index, row)| {
+            let cell = discovery_cell(*row, key_width, width);
+            if index + 1 == column_count || index + 1 == rows.len() {
+                cell
+            } else {
+                format!("{cell:<column_width$}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(&" ".repeat(DISCOVERY_COLUMN_GUTTER))
+}
+
+fn discovery_cell(row: DiscoveryRow, key_width: usize, width: usize) -> String {
+    let full_action = discovery_action_label(row);
+    let compact_action = row.action.to_owned();
+    let full = discovery_cell_with_action(row, key_width, &full_action);
+    if visible_width(&full) <= width {
+        return full;
+    }
+
+    discovery_cell_with_action(row, key_width, &compact_action)
+}
+
+fn discovery_cell_with_action(row: DiscoveryRow, key_width: usize, action: &str) -> String {
+    format!("  {:<key_width$}  {action}", row.keys)
+}
+
+fn discovery_key_width(rows: &[DiscoveryRow]) -> usize {
+    rows.iter()
+        .map(|row| visible_width(row.keys))
+        .max()
+        .unwrap_or(0)
+}
+
+fn discovery_key_width_for_width(rows: &[DiscoveryRow], width: usize) -> usize {
+    let key_width = discovery_key_width(rows);
+    if width >= DISCOVERY_TWO_COLUMN_WIDTH {
+        return key_width;
+    }
+
+    key_width.min(12)
+}
+
+fn discovery_cell_width(row: DiscoveryRow, key_width: usize) -> usize {
+    4_usize
+        .saturating_add(key_width)
+        .saturating_add(visible_width(&discovery_action_label(row)))
+}
+
+fn discovery_action_label(row: DiscoveryRow) -> String {
+    // Prefer one clear label per row. A concrete jj command teaches the command shape better than
+    // repeating it as `jj describe (Describe revision)`; app-only actions keep the human action
+    // label.
+    discovery_command_display_label(row)
+        .map_or_else(|| row.action.to_owned(), std::borrow::ToOwned::to_owned)
+}
+
+fn discovery_command_display_label(row: DiscoveryRow) -> Option<&'static str> {
+    match (row.command_family, row.action_id) {
+        (Some(CommandFamily::JjOperation), ActionId::OpenOperationLog) => Some("jj op log"),
+        (Some(CommandFamily::JjOperation), ActionId::OpenShow) => Some("jj op show"),
+        (Some(CommandFamily::JjOperation), ActionId::OpenDiff) => Some("jj op diff"),
+        (Some(CommandFamily::JjOperation), ActionId::Undo) => Some("jj undo"),
+        (Some(CommandFamily::JjOperation), ActionId::Redo) => Some("jj redo"),
+        (Some(CommandFamily::JjOperation), ActionId::Abandon) => Some("jj abandon"),
+        (Some(CommandFamily::JjOperation) | None, _) => None,
+        (Some(family), _) => {
+            let label = family.label();
+            if label.starts_with("jj ") {
+                Some(label)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn discovery_footer_lines(width: usize, start: usize, end: usize, row_count: usize) -> Vec<String> {
+    let position = discovery_position_line(start, end, row_count);
+    if row_count <= end.saturating_sub(start) {
+        return Vec::new();
+    }
+
+    let scroll_controls = "j/k scroll";
+    let full = format!("{position}   {scroll_controls}");
+    if visible_width(&full) <= width {
+        return vec![full];
+    }
+
+    vec![position, scroll_controls.to_owned()]
+}
+
+fn visible_discovery_range(
+    row_count: usize,
+    selected: usize,
+    visible_rows: usize,
+) -> (usize, usize) {
+    if row_count <= visible_rows {
+        return (0, row_count);
+    }
+
+    let start = selected.min(discovery_scroll_limit_for_len(row_count, visible_rows));
+    (start, start + visible_rows)
+}
+
+fn discovery_position_line(start: usize, end: usize, row_count: usize) -> String {
+    let more_above = start > 0;
+    let more_below = end < row_count;
+    let affordance = match (more_above, more_below) {
+        (true, true) => "more above/below",
+        (true, false) => "more above",
+        (false, true) => "more below",
+        (false, false) => "",
+    };
+    if affordance.is_empty() {
+        format!(
+            "showing lines {}-{} of {}",
+            start.saturating_add(1),
+            end,
+            row_count
+        )
+    } else {
+        format!(
+            "showing lines {}-{} of {}  {affordance}",
+            start.saturating_add(1),
+            end,
+            row_count
+        )
+    }
+}
+
+/// Returns the number of visible help rows for clamping scroll state.
 #[must_use]
-pub fn filtered_discovery_len(context: BindingContext, query: &str) -> usize {
-    filter_discovery_rows(context, query).len()
+pub fn discovery_len(context: BindingContext, query: &str) -> usize {
+    let _ = query;
+    discovery_rows(context).len()
+}
+
+/// Returns the highest scroll offset for the contextual help overlay.
+#[must_use]
+pub fn discovery_scroll_limit(context: BindingContext, query: &str) -> usize {
+    let _ = query;
+    let rows = discovery_rows(context);
+    let body_line_count = discovery_body_lines(context, &rows, 40).len();
+    discovery_scroll_limit_for_len(
+        body_line_count,
+        discovery_visible_body_lines(DISCOVERY_VISIBLE_ROWS),
+    )
+}
+
+const fn default_discovery_visible_rows(width: usize) -> usize {
+    if width >= DISCOVERY_TWO_COLUMN_WIDTH {
+        DISCOVERY_WIDE_VISIBLE_ROWS
+    } else {
+        DISCOVERY_VISIBLE_ROWS
+    }
+}
+
+const fn discovery_visible_body_lines(visible_rows: usize) -> usize {
+    visible_rows
+}
+
+const fn discovery_scroll_limit_for_len(row_count: usize, visible_rows: usize) -> usize {
+    row_count.saturating_sub(visible_rows)
 }
 
 const fn bindings(context: BindingContext) -> &'static [KeyBinding] {
@@ -888,9 +1246,50 @@ const fn context_label(context: BindingContext) -> &'static str {
     }
 }
 
+const fn help_groups_for_context(context: BindingContext) -> &'static [HelpGroup] {
+    match context {
+        BindingContext::Log => &[
+            HelpGroup::Views,
+            HelpGroup::Navigation,
+            HelpGroup::Mutations,
+            HelpGroup::Recovery,
+            HelpGroup::Session,
+        ],
+        BindingContext::Diff
+        | BindingContext::Inspection
+        | BindingContext::Workspaces
+        | BindingContext::OperationLog => &[
+            HelpGroup::Views,
+            HelpGroup::Navigation,
+            HelpGroup::Recovery,
+            HelpGroup::Session,
+        ],
+        BindingContext::CommandHistory => &[
+            HelpGroup::Recovery,
+            HelpGroup::Navigation,
+            HelpGroup::Session,
+        ],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_help_header(lines: &[String]) {
+        assert_eq!(lines[0], "Contextual help for the current screen.");
+    }
+
+    fn assert_ordered_lines(lines: &[String], expected: &[&str]) {
+        let mut start = 0;
+        for expected_line in expected {
+            let relative_index = lines[start..]
+                .iter()
+                .position(|line| line == expected_line)
+                .unwrap_or_else(|| panic!("missing ordered line {expected_line:?} in {lines:?}"));
+            start += relative_index + 1;
+        }
+    }
 
     #[test]
     fn log_hotbar_matches_current_status_text() {
@@ -904,7 +1303,7 @@ mod tests {
     fn diff_hotbar_matches_current_status_text() {
         assert_eq!(
             hotbar(BindingContext::Diff),
-            "? help  V options  r refresh  j/k line  f files  space/b page  q quit"
+            "? help  V options  r refresh  j/k line  f files  space page  q quit"
         );
     }
 
@@ -912,7 +1311,7 @@ mod tests {
     fn inspection_hotbar_matches_current_status_text() {
         assert_eq!(
             hotbar(BindingContext::Inspection),
-            "? help  V options  r refresh  j/k line  space/b page  q quit"
+            "? help  V options  r refresh  j/k line  space page  q quit"
         );
     }
 
@@ -920,7 +1319,7 @@ mod tests {
     fn command_history_hotbar_matches_current_status_text() {
         assert_eq!(
             hotbar(BindingContext::CommandHistory),
-            "? help  enter details  j/k move  space/b page  r refresh  o operation  y copy  Esc back  q quit"
+            "? help  enter details  j/k move  space page  r refresh  o operation  y copy  Esc back  q quit"
         );
     }
 
@@ -928,7 +1327,7 @@ mod tests {
     fn operation_log_hotbar_matches_current_status_text() {
         assert_eq!(
             hotbar(BindingContext::OperationLog),
-            "? help  enter show  d diff  j/k move  space/b page  r refresh  Esc back  q quit"
+            "? help  enter show  d diff  j/k move  space page  r refresh  Esc back  q quit"
         );
     }
 
@@ -1027,142 +1426,126 @@ mod tests {
     }
 
     #[test]
-    fn log_help_lines_match_current_overlay() {
-        assert_eq!(
-            help_lines(BindingContext::Log),
-            vec![
-                "enter                open change / drill into ~",
-                "d                    open selected-change diff",
-                "v                    open selected-change evolog",
-                "s                    open repository status",
-                "o                    open operation log",
-                "m                    describe selected revision",
-                "n                    preview jj new",
-                "e                    preview jj edit",
-                "a                    preview jj abandon",
-                "u                    preview jj undo",
-                "U                    preview jj redo",
-                "space                mark/unmark selected revision",
-                "c                    clear revision marks when marks exist",
-                "C                    open command history",
-                ":                    run jj command",
-                "V                    open view options",
-                "r                    refresh",
-                "H / L                home command / jj log",
-                "j/k or arrows        move selection",
-                "Ctrl-j/k             scroll one line",
-                "b, Ctrl-f/b, PgUp/Dn page down/up",
-                "g/G or Home/End      jump to top/bottom",
-                "right, l             expand change / drill into ~",
-                "left, h              collapse selected change",
-                "?, q, Esc            close help",
-            ]
+    fn log_help_lines_group_contextual_commands() {
+        let lines = help_lines(BindingContext::Log);
+
+        assert_help_header(&lines);
+        assert_ordered_lines(
+            &lines,
+            &[
+                "Open and inspect:",
+                "  enter        open change / drill into ~",
+                "Move and find:",
+                "  ↑/↓, j/k     move selection",
+                "  PgDn, Ctrl-f page down",
+                "  PgUp, Ctrl-b page up",
+                "  →, l         expand change / drill into ~",
+                "Change actions:",
+                "  m            describe selected revision",
+                "  space        mark/unmark selected revision",
+                "History and recovery:",
+                "  o            open operation log",
+                "Session:",
+                "  ?, Esc       close help",
+            ],
         );
     }
 
     #[test]
-    fn diff_help_lines_match_current_overlay() {
-        assert_eq!(
-            help_lines(BindingContext::Diff),
-            vec![
-                "f                    open file list",
-                "[ / ]                previous/next file",
-                "{ / }                previous/next hunk",
-                "h / l                fold/unfold current file",
-                "Ctrl-left/right      fold/unfold all files",
-                "- / +                fold/unfold current hunk",
-                "< / >                horizontal scroll",
-                "/, n, N              search, next, previous",
-                "C                    open command history",
-                ":                    run jj command",
-                "V                    open view options",
-                "r                    refresh",
-                "j/k or arrows        scroll one line",
-                "Ctrl-j/k             scroll one line",
-                "space / b, Ctrl-f/b  page down/up",
-                "g/G or Home/End      jump to top/bottom",
-                "H / L                go back",
-                "?, q, Esc            close help",
-            ]
+    fn diff_help_lines_group_file_search_and_navigation_commands() {
+        let lines = help_lines(BindingContext::Diff);
+
+        assert_help_header(&lines);
+        assert_ordered_lines(
+            &lines,
+            &[
+                "Open and inspect:",
+                "  f                   open file list",
+                "  V                   open view options",
+                "Move and find:",
+                "  < / >               horizontal scroll",
+                "  /, n, N             search, next, previous",
+                "Session:",
+                "  ?, Esc              close help",
+            ],
         );
     }
 
     #[test]
-    fn inspection_help_lines_match_current_overlay() {
-        assert_eq!(
-            help_lines(BindingContext::Inspection),
-            vec![
-                "/, n, N              search, next, previous",
-                "C                    open command history",
-                ":                    run jj command",
-                "V                    open view options",
-                "r                    refresh",
-                "j/k or arrows        scroll one line",
-                "Ctrl-j/k             scroll one line",
-                "space / b, Ctrl-f/b  page down/up",
-                "g/G or Home/End      jump to top/bottom",
-                "H / L                go back",
-                "?, q, Esc            close help",
-            ]
+    fn inspection_help_lines_lead_with_search() {
+        let lines = help_lines(BindingContext::Inspection);
+
+        assert_help_header(&lines);
+        assert_ordered_lines(
+            &lines,
+            &[
+                "Open and inspect:",
+                "  V                   open view options",
+                "Move and find:",
+                "  /, n, N             search, next, previous",
+                "  H / L               go back",
+                "Session:",
+                "  ?, Esc              close help",
+            ],
         );
     }
 
     #[test]
-    fn workspaces_help_lines_match_current_overlay() {
-        assert_eq!(
-            help_lines(BindingContext::Workspaces),
-            vec![
-                "l                    open selected workspace log",
-                "enter, s             open selected workspace status",
-                "d                    open selected workspace diff",
-                "u                    update selected stale workspace",
-                "C                    open command history",
-                ":                    run jj command",
-                "V                    open view options",
-                "r                    refresh workspaces",
-                "j/k or arrows        move selection",
-                "Ctrl-j/k             scroll one line",
-                "Backspace, Esc, H/L  return to previous view",
-                "?, q, Esc            close help",
-            ]
+    fn workspaces_help_lines_keep_workspace_actions_together() {
+        let lines = help_lines(BindingContext::Workspaces);
+
+        assert_help_header(&lines);
+        assert_ordered_lines(
+            &lines,
+            &[
+                "Open and inspect:",
+                "  l                   open selected workspace log",
+                "Move and find:",
+                "  Backspace, Esc, H/L return to previous view",
+                "History and recovery:",
+                "  C                   open command history",
+                "Session:",
+                "  u                   update selected stale workspace",
+            ],
         );
     }
 
     #[test]
-    fn command_history_help_lines_match_current_overlay() {
-        assert_eq!(
-            help_lines(BindingContext::CommandHistory),
-            vec![
-                "enter                open command details",
-                "o                    open operation or operation log",
-                "y                    copy selected command",
-                "r                    refresh history",
-                "C                    refresh command history",
-                ":                    run jj command",
-                "j/k or arrows        move selection",
-                "space / b, Ctrl-f/b  page down/up",
-                "g/G or Home/End      jump to top/bottom",
-                "Backspace, Esc       return to previous view",
-                "?, q, Esc            close help",
-            ]
+    fn command_history_help_lines_group_history_and_recovery() {
+        let lines = help_lines(BindingContext::CommandHistory);
+
+        assert_help_header(&lines);
+        assert_ordered_lines(
+            &lines,
+            &[
+                "History and recovery:",
+                "  enter               open command details",
+                "  o                   open operation or operation log",
+                "Move and find:",
+                "  Backspace, Esc      return to previous view",
+                "Session:",
+                "  :                   run jj command",
+            ],
         );
     }
 
     #[test]
-    fn operation_log_help_lines_match_current_overlay() {
-        assert_eq!(
-            help_lines(BindingContext::OperationLog),
-            vec![
-                "enter                open selected operation show",
-                "d                    open selected operation diff",
-                "r                    refresh operation log",
-                ":                    run jj command",
-                "j/k or arrows        move selection",
-                "space / b, Ctrl-f/b  page down/up",
-                "g/G or Home/End      jump to top/bottom",
-                "Backspace, Esc       return to previous view",
-                "?, q, Esc            close help",
-            ]
+    fn operation_log_help_lines_keep_operation_routes_visible() {
+        let lines = help_lines(BindingContext::OperationLog);
+
+        assert_help_header(&lines);
+        assert_ordered_lines(
+            &lines,
+            &[
+                "Open and inspect:",
+                "  enter               open selected operation show",
+                "  d                   open selected operation diff",
+                "Move and find:",
+                "  Backspace, Esc      return to previous view",
+                "Session:",
+                "  r                   refresh operation log",
+                "  :                   run jj command",
+            ],
         );
     }
 
@@ -1184,102 +1567,65 @@ mod tests {
         }
     }
 
-    #[test]
-    fn discovery_filter_matches_all_tokens_case_insensitively() {
-        let rows = filter_discovery_rows(BindingContext::Log, "JJ SHOW");
-
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].keys, "enter");
-        assert_eq!(rows[0].action, "Open show");
-    }
-
-    #[test]
-    fn discovery_filter_searches_view_options_aliases() {
-        let rows = filter_discovery_rows(BindingContext::Log, "template log");
-
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].keys, "V");
-        assert_eq!(rows[0].command_family_label(), Some("view options"));
-
-        let rows = filter_discovery_rows(BindingContext::Log, "view options");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].keys, "V");
+    fn discovery_row_for_key(rows: &[DiscoveryRow], key: &str) -> DiscoveryRow {
+        rows.iter()
+            .find(|row| row.keys == key)
+            .map_or_else(|| panic!("missing discovery row for key {key}"), |row| *row)
     }
 
     #[test]
     fn log_discovery_finds_mark_and_clear_bindings() {
-        let mark_rows = filter_discovery_rows(BindingContext::Log, "space mark");
-        assert_eq!(mark_rows.len(), 1);
-        assert_eq!(mark_rows[0].keys, "space");
-        assert_eq!(mark_rows[0].command_family_label(), Some("mark"));
+        let rows = discovery_rows(BindingContext::Log);
+        let mark_row = discovery_row_for_key(&rows, "space");
+        assert_eq!(mark_row.command_family_label(), Some("mark"));
 
-        let clear_rows = filter_discovery_rows(BindingContext::Log, "clear marks");
-        assert_eq!(clear_rows.len(), 1);
-        assert_eq!(clear_rows[0].keys, "c");
+        let clear_row = discovery_row_for_key(&rows, "c");
+        assert_eq!(clear_row.action, "Clear marks");
     }
 
     #[test]
-    fn log_discovery_finds_evolog_binding() {
-        for query in [
-            "v",
-            "evolog",
-            "jj evolog",
-            "evolution history",
-            "selected change",
-        ] {
-            let rows = filter_discovery_rows(BindingContext::Log, query);
-            let evolog_row = rows
-                .iter()
-                .find(|row| row.keys == "v")
-                .copied()
-                .unwrap_or_else(|| panic!("missing evolog row for query {query:?}"));
+    fn log_discovery_keeps_evolog_binding() {
+        let rows = discovery_rows(BindingContext::Log);
+        let evolog_row = discovery_row_for_key(&rows, "v");
 
-            assert_eq!(evolog_row.action, "Open evolog");
-            assert_eq!(evolog_row.command_family_label(), Some("jj evolog"));
-        }
+        assert_eq!(evolog_row.action, "Open evolog");
+        assert_eq!(evolog_row.command_family_label(), Some("jj evolog"));
     }
 
     #[test]
-    fn workspaces_discovery_finds_workspace_actions() {
-        let log_rows = filter_discovery_rows(BindingContext::Workspaces, "workspace log");
-        assert_eq!(log_rows.len(), 1);
-        assert_eq!(log_rows[0].keys, "l");
-        assert_eq!(log_rows[0].command_family_label(), Some("jj log"));
+    fn workspaces_discovery_keeps_workspace_actions() {
+        let rows = discovery_rows(BindingContext::Workspaces);
 
-        let status_rows = filter_discovery_rows(BindingContext::Workspaces, "workspace status");
-        assert_eq!(status_rows.len(), 1);
-        assert_eq!(status_rows[0].keys, "enter, s");
-        assert_eq!(status_rows[0].command_family_label(), Some("jj status"));
+        let log_row = discovery_row_for_key(&rows, "l");
+        assert_eq!(log_row.command_family_label(), Some("jj log"));
 
-        let back_rows = filter_discovery_rows(BindingContext::Workspaces, "back previous");
-        assert_eq!(back_rows.len(), 1);
-        assert_eq!(back_rows[0].keys, "Backspace, Esc, H/L");
-        assert_eq!(back_rows[0].context_label(), "workspaces");
+        let status_row = discovery_row_for_key(&rows, "enter, s");
+        assert_eq!(status_row.command_family_label(), Some("jj status"));
 
-        let update_rows = filter_discovery_rows(BindingContext::Workspaces, "update stale");
-        assert_eq!(update_rows.len(), 1);
-        assert_eq!(update_rows[0].keys, "u");
-        assert_eq!(update_rows[0].command_family_label(), Some("jj workspace"));
+        let back_row = discovery_row_for_key(&rows, "Backspace, Esc, H/L");
+        assert_eq!(back_row.context_label(), "workspaces");
+
+        let update_row = discovery_row_for_key(&rows, "u");
+        assert_eq!(update_row.command_family_label(), Some("jj workspace"));
     }
 
     #[test]
-    fn discovery_finds_command_history_entry_point() {
+    fn discovery_keeps_command_history_entry_point() {
         for context in [
             BindingContext::Log,
             BindingContext::Diff,
             BindingContext::Inspection,
             BindingContext::Workspaces,
         ] {
-            let rows = filter_discovery_rows(context, "command history");
+            let rows = discovery_rows(context);
+            let row = discovery_row_for_key(&rows, "C");
 
-            assert_eq!(rows.len(), 1, "{context:?}");
-            assert_eq!(rows[0].keys, "C");
-            assert_eq!(rows[0].command_family_label(), Some("history"));
+            assert_eq!(row.command_family_label(), Some("history"), "{context:?}");
         }
     }
 
     #[test]
-    fn discovery_finds_colon_command_mode() {
+    fn discovery_keeps_colon_command_mode() {
         for context in [
             BindingContext::Log,
             BindingContext::Diff,
@@ -1288,63 +1634,173 @@ mod tests {
             BindingContext::CommandHistory,
             BindingContext::OperationLog,
         ] {
-            let rows = filter_discovery_rows(context, "colon prompt");
+            let rows = discovery_rows(context);
+            let row = discovery_row_for_key(&rows, ":");
 
-            assert_eq!(rows.len(), 1, "{context:?}");
-            assert_eq!(rows[0].keys, ":");
-            assert_eq!(rows[0].action, "Run jj command");
-            assert_eq!(rows[0].command_family_label(), Some("jj command"));
+            assert_eq!(row.action, "Run jj command");
+            assert_eq!(row.command_family_label(), Some("jj command"));
         }
     }
 
     #[test]
-    fn command_history_discovery_finds_operation_route() {
-        for query in ["operation", "op log", "recovery selected command"] {
-            let rows = filter_discovery_rows(BindingContext::CommandHistory, query);
+    fn command_history_discovery_keeps_operation_route() {
+        let rows = discovery_rows(BindingContext::CommandHistory);
+        let row = discovery_row_for_key(&rows, "o");
 
-            assert_eq!(rows.len(), 1, "{query}");
-            assert_eq!(rows[0].keys, "o");
-            assert_eq!(rows[0].action, "Open operation");
-            assert_eq!(rows[0].command_family_label(), Some("jj operation"));
+        assert_eq!(row.action, "Open operation");
+        assert_eq!(row.command_family_label(), Some("jj operation"));
+    }
+
+    #[test]
+    fn operation_log_discovery_keeps_show_diff_and_refresh() {
+        let rows = discovery_rows(BindingContext::OperationLog);
+
+        let show_row = discovery_row_for_key(&rows, "enter");
+        assert_eq!(show_row.command_family_label(), Some("jj operation"));
+
+        let diff_row = discovery_row_for_key(&rows, "d");
+        assert_eq!(diff_row.command_family_label(), Some("jj operation"));
+
+        let refresh_row = discovery_row_for_key(&rows, "r");
+        assert_eq!(refresh_row.command_family_label(), Some("refresh"));
+    }
+
+    #[test]
+    fn discovery_lines_use_inline_context_and_scroll_affordance() {
+        let lines = discovery_lines(BindingContext::Log, "", 0);
+
+        assert!(!lines.iter().any(|line| line.contains("family")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("enter") && line.contains("jj show"))
+        );
+        assert!(!lines.iter().any(|line| line.contains('>')));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains('d') && line.contains("jj diff"))
+        );
+        assert!(!lines.iter().any(|line| line.starts_with("showing lines")));
+        assert!(!lines.iter().any(String::is_empty));
+    }
+
+    #[test]
+    fn discovery_lines_use_aligned_columns_when_wide() {
+        let lines = discovery_lines_for_width(BindingContext::Log, "", 0, 120);
+
+        let view_line = lines
+            .iter()
+            .find(|line| line.contains("jj show") && line.contains("jj diff"))
+            .unwrap_or_else(|| panic!("missing two-column view line in {lines:?}"));
+
+        assert!(view_line.contains("enter"));
+        assert!(view_line.contains('d'));
+        assert!(visible_width(view_line) <= 120);
+    }
+
+    #[test]
+    fn discovery_lines_do_not_truncate_keys_or_instructions() {
+        let lines = discovery_lines_for_width(BindingContext::Log, "", 0, DISCOVERY_DEFAULT_WIDTH);
+
+        assert!(lines.iter().any(|line| line.contains("PgDn, Ctrl-f")));
+        assert!(lines.iter().any(|line| line.contains("PgUp, Ctrl-b")));
+        assert!(lines.iter().any(|line| line.contains("jj log")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains('q') && line.contains("Quit / exit"))
+        );
+        assert!(!lines.iter().any(|line| line.contains("...")));
+    }
+
+    #[test]
+    fn discovery_lines_compress_chrome_in_compact_width() {
+        let lines = discovery_lines_for_width(BindingContext::Log, "", 0, 40);
+
+        assert_eq!(lines.first().map(String::as_str), Some("Open and inspect:"));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.starts_with("showing lines 1-"))
+        );
+        assert!(lines.iter().any(|line| line.contains("j/k scroll")));
+        assert!(lines.iter().any(|line| line.contains("↑/↓, j/k")));
+        assert!(!lines.iter().any(|line| line.contains("...")));
+    }
+
+    #[test]
+    fn discovery_lines_fit_common_terminal_widths() {
+        for context in [
+            BindingContext::Log,
+            BindingContext::Diff,
+            BindingContext::Inspection,
+            BindingContext::Workspaces,
+            BindingContext::CommandHistory,
+            BindingContext::OperationLog,
+        ] {
+            for width in [40, 60, 80, 100, 120, 130] {
+                for visible_rows in [8, 12, 20, 34] {
+                    let lines =
+                        discovery_lines_for_width_and_rows(context, "", 0, width, visible_rows);
+
+                    for line in &lines {
+                        assert!(
+                            visible_width(line) <= width,
+                            "{context:?} width {width} rows {visible_rows}: {line:?} in {lines:?}"
+                        );
+                    }
+                }
+            }
         }
     }
 
     #[test]
-    fn operation_log_discovery_finds_show_diff_and_refresh() {
-        let show_rows = filter_discovery_rows(BindingContext::OperationLog, "operation show");
-        assert_eq!(show_rows.len(), 1);
-        assert_eq!(show_rows[0].keys, "enter");
-        assert_eq!(show_rows[0].command_family_label(), Some("jj operation"));
+    fn discovery_lines_adapt_columns_to_width_and_height() {
+        let compact = discovery_lines_for_width_and_rows(BindingContext::Log, "", 0, 40, 12);
+        assert!(
+            !compact
+                .iter()
+                .any(|line| line.contains("jj show") && line.contains("jj diff"))
+        );
+        assert!(!compact.iter().any(String::is_empty));
+        assert!(compact.iter().any(|line| line.contains("more below")));
 
-        let diff_rows = filter_discovery_rows(BindingContext::OperationLog, "operation diff");
-        assert_eq!(diff_rows.len(), 1);
-        assert_eq!(diff_rows[0].keys, "d");
-        assert_eq!(diff_rows[0].command_family_label(), Some("jj operation"));
+        let wide_short = discovery_lines_for_width_and_rows(BindingContext::Log, "", 0, 120, 12);
+        assert!(
+            wide_short
+                .iter()
+                .any(|line| line.contains("jj show") && line.contains("jj diff"))
+        );
+        assert!(wide_short.iter().any(|line| line.contains("more below")));
 
-        let refresh_rows = filter_discovery_rows(BindingContext::OperationLog, "operation reload");
-        assert_eq!(refresh_rows.len(), 1);
-        assert_eq!(refresh_rows[0].keys, "r");
-        assert_eq!(refresh_rows[0].command_family_label(), Some("refresh"));
+        let wide_tall = discovery_lines_for_width_and_rows(BindingContext::Log, "", 0, 120, 34);
+        assert!(
+            wide_tall
+                .iter()
+                .any(|line| line.contains("jj show") && line.contains("jj diff"))
+        );
+        assert!(
+            !wide_tall
+                .iter()
+                .any(|line| line.starts_with("showing lines"))
+        );
+        assert!(wide_tall.iter().any(String::is_empty));
     }
 
     #[test]
-    fn discovery_filter_keeps_binding_order_without_scoring() {
-        let rows = filter_discovery_rows(BindingContext::Diff, "fold");
-        let keys = rows.iter().map(|row| row.keys).collect::<Vec<_>>();
+    fn discovery_lines_scroll_by_rendered_line_when_wide() {
+        let top_lines = discovery_lines_for_width_and_rows(BindingContext::Log, "", 0, 120, 12);
+        let scrolled_lines =
+            discovery_lines_for_width_and_rows(BindingContext::Log, "", 1, 120, 12);
 
-        assert_eq!(keys, vec!["h / l", "Ctrl-left/right", "- / +"]);
-    }
-
-    #[test]
-    fn discovery_lines_render_empty_state_for_no_results() {
-        assert_eq!(
-            discovery_lines(BindingContext::Inspection, "definitely-not-present", 99),
-            vec![
-                "? definitely-not-present",
-                "  no matching commands",
-                "",
-                "type to filter   j/k or arrows move   enter/esc close",
-            ]
+        assert_eq!(top_lines[0], "Open and inspect:");
+        assert_eq!(scrolled_lines[0], top_lines[1]);
+        assert!(
+            scrolled_lines
+                .iter()
+                .any(|line| line.starts_with("showing lines 2-13 of ")
+                    && line.contains("more above/below"))
         );
     }
 }

--- a/crates/jk-tui/src/lib.rs
+++ b/crates/jk-tui/src/lib.rs
@@ -22,10 +22,11 @@ mod rendered_log;
 mod rendered_state;
 mod selected_row;
 
-/// Searchable command-discovery metadata and popup formatting.
+/// Contextual command-help metadata and popup formatting.
 pub mod command_discovery {
     pub use crate::keymap::{
-        BindingContext, CommandFamily, DiscoveryRow, discovery_lines, discovery_rows,
-        filter_discovery_rows, filtered_discovery_len,
+        BindingContext, CommandFamily, DiscoveryRow, discovery_len, discovery_lines,
+        discovery_lines_for_width, discovery_lines_for_width_and_rows, discovery_rows,
+        discovery_scroll_limit,
     };
 }

--- a/crates/jk-tui/src/log_view.rs
+++ b/crates/jk-tui/src/log_view.rs
@@ -557,7 +557,7 @@ mod tests {
     fn help_action_shows_log_specific_keys() {
         let mut view = LogView::new(snapshot(["aaa"]));
         let _ = view.apply(LogAction::ToggleHelp);
-        let backend = TestBackend::new(72, 32);
+        let backend = TestBackend::new(72, 56);
         let mut terminal = match Terminal::new(backend) {
             Ok(terminal) => terminal,
             Err(error) => match error {},
@@ -568,16 +568,17 @@ mod tests {
 
         let rendered = buffer_to_string(terminal.backend().buffer());
         assert!(rendered.contains("Log keys"));
-        assert!(rendered.contains("d                    open selected-change diff"));
-        assert!(rendered.contains("m                    describe selected revision"));
-        assert!(rendered.contains("s                    open repository status"));
-        assert!(rendered.contains("n                    preview jj new"));
-        assert!(rendered.contains("e                    preview jj edit"));
-        assert!(rendered.contains("a                    preview jj abandon"));
-        assert!(rendered.contains("u                    preview jj undo"));
-        assert!(rendered.contains("U                    preview jj redo"));
-        assert!(rendered.contains("right, l             expand change / drill into ~"));
-        assert!(rendered.contains("?, q, Esc            close help"));
+        assert!(rendered.contains("Contextual help for the current screen."));
+        assert!(rendered.contains("Open and inspect:"));
+        assert!(rendered.contains("open selected-change diff"));
+        assert!(rendered.contains("Change actions:"));
+        assert!(rendered.contains("describe selected revision"));
+        assert!(rendered.contains("preview jj abandon"));
+        assert!(rendered.contains("expand change / drill into ~"));
+        assert!(rendered.contains("History and recovery:"));
+        assert!(rendered.contains("preview jj undo"));
+        assert!(rendered.contains("Session:"));
+        assert!(rendered.contains("close help"));
     }
 
     #[test]

--- a/crates/jk-tui/src/rendered_view.rs
+++ b/crates/jk-tui/src/rendered_view.rs
@@ -311,7 +311,8 @@ mod tests {
 
         let rendered = buffer_to_string(terminal.backend().buffer());
         assert!(rendered.contains("Inspection keys"));
-        assert!(rendered.contains("/, n, N              search, next, previous"));
+        assert!(rendered.contains("Move and find:"));
+        assert!(rendered.contains("search, next, previous"));
     }
 
     fn snapshot(target: &str, rendered: &str) -> InspectionSnapshot {

--- a/crates/jk-tui/src/workspaces_view.rs
+++ b/crates/jk-tui/src/workspaces_view.rs
@@ -663,7 +663,7 @@ mod tests {
     fn help_overlay_uses_workspace_bindings() {
         let mut view = WorkspacesView::new(snapshot([row("default", true)]));
         let _ = view.apply(WorkspacesAction::ToggleHelp);
-        let backend = TestBackend::new(72, 16);
+        let backend = TestBackend::new(72, 32);
         let mut terminal = match Terminal::new(backend) {
             Ok(terminal) => terminal,
             Err(error) => match error {},
@@ -674,8 +674,10 @@ mod tests {
 
         let rendered = buffer_to_string(terminal.backend().buffer());
         assert!(rendered.contains("Workspaces keys"));
-        assert!(rendered.contains("enter, s             open selected workspace status"));
-        assert!(rendered.contains("u                    update selected stale workspace"));
+        assert!(rendered.contains("Open and inspect:"));
+        assert!(rendered.contains("open selected workspace status"));
+        assert!(rendered.contains("Session:"));
+        assert!(rendered.contains("update selected stale workspace"));
     }
 
     fn snapshot<const N: usize>(rows: [WorkspaceViewRow; N]) -> WorkspaceViewSnapshot {

--- a/crates/jk/src/key.rs
+++ b/crates/jk/src/key.rs
@@ -172,7 +172,6 @@ const fn action_for_character_key(character: char) -> Option<AppKey> {
         '/' => Some(AppKey::StartSearch),
         'n' => Some(AppKey::SearchNext),
         'N' => Some(AppKey::SearchPrevious),
-        'b' => Some(AppKey::Action(LogAction::PagePrevious)),
         'k' => Some(AppKey::Action(LogAction::Previous)),
         'j' => Some(AppKey::Action(LogAction::Next)),
         'g' => Some(AppKey::Action(LogAction::First)),
@@ -495,7 +494,7 @@ mod tests {
         );
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE)),
-            AppKey::Action(LogAction::PagePrevious)
+            AppKey::Ignore
         );
         assert_eq!(
             AppKey::from_crossterm(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL)),

--- a/crates/jk/src/main.rs
+++ b/crates/jk/src/main.rs
@@ -30,7 +30,7 @@ use jk_cli::{
     WorkspaceInspectionQuery,
 };
 use jk_core::{CommandHistory, CommandSource, SourceAction, SourceView};
-use jk_tui::command_discovery::{BindingContext, filtered_discovery_len};
+use jk_tui::command_discovery::{BindingContext, discovery_scroll_limit};
 use jk_tui::command_history_view::{CommandHistoryAction, CommandHistoryActionResult};
 #[cfg(test)]
 use jk_tui::command_history_view::{CommandHistorySnapshot, CommandHistoryView};
@@ -77,10 +77,7 @@ pub(crate) use command_history::{
 };
 use command_mode::{command_mode_snapshot, command_mode_spec, parse_jj_command_args};
 use key::AppKey;
-use menus::{
-    MenuDirection, ViewOptionRow, clamp_command_discovery_selection, view_option_rows,
-    wrapped_selection,
-};
+use menus::{MenuDirection, ViewOptionRow, view_option_rows, wrapped_selection};
 #[cfg(test)]
 use menus::{diff_file_list_lines, view_options_lines};
 use mutation_preview::{PendingCommandPreview, selected_new_parents};
@@ -397,27 +394,7 @@ fn handle_command_discovery_mode(state: &mut AppState, key: KeyEvent) -> InputMo
             code: KeyCode::Backspace,
             ..
         } => {
-            let should_close = match state.modes.active_mut() {
-                Some(InputMode::CommandDiscovery {
-                    query, selected, ..
-                }) if query.is_empty() => {
-                    *selected = 0;
-                    true
-                }
-                Some(InputMode::CommandDiscovery {
-                    context,
-                    query,
-                    selected,
-                }) => {
-                    query.pop();
-                    clamp_command_discovery_selection(*context, query, selected);
-                    false
-                }
-                _ => false,
-            };
-            if should_close {
-                state.modes.pop();
-            }
+            state.modes.pop();
             InputModeResult::Handled
         }
         KeyEvent {
@@ -428,7 +405,7 @@ fn handle_command_discovery_mode(state: &mut AppState, key: KeyEvent) -> InputMo
             modifiers: KeyModifiers::NONE,
             ..
         } => {
-            move_command_discovery_selection(state, MenuDirection::Previous);
+            move_command_discovery_scroll(state, MenuDirection::Previous);
             InputModeResult::Handled
         }
         KeyEvent {
@@ -440,23 +417,14 @@ fn handle_command_discovery_mode(state: &mut AppState, key: KeyEvent) -> InputMo
             modifiers: KeyModifiers::NONE,
             ..
         } => {
-            move_command_discovery_selection(state, MenuDirection::Next);
+            move_command_discovery_scroll(state, MenuDirection::Next);
             InputModeResult::Handled
         }
         KeyEvent {
-            code: KeyCode::Char(character),
+            code: KeyCode::Char(_),
             modifiers,
             ..
         } if !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
-            if let Some(InputMode::CommandDiscovery {
-                context,
-                query,
-                selected,
-            }) = state.modes.active_mut()
-            {
-                query.push(character);
-                clamp_command_discovery_selection(*context, query, selected);
-            }
             InputModeResult::Handled
         }
         _ => InputModeResult::Handled,
@@ -929,7 +897,7 @@ fn open_command_discovery(state: &mut AppState) {
     state.modes.push(InputMode::CommandDiscovery {
         context,
         query: String::new(),
-        selected: 0,
+        scroll_offset: 0,
     });
 }
 
@@ -974,22 +942,20 @@ fn active_binding_context(state: &AppState) -> BindingContext {
     }
 }
 
-fn move_command_discovery_selection(state: &mut AppState, direction: MenuDirection) {
+fn move_command_discovery_scroll(state: &mut AppState, direction: MenuDirection) {
     let Some(InputMode::CommandDiscovery {
         context,
         query,
-        selected,
+        scroll_offset,
     }) = state.modes.active_mut()
     else {
         return;
     };
-    let row_count = filtered_discovery_len(*context, query);
-    if row_count == 0 {
-        *selected = 0;
-        return;
-    }
-
-    *selected = wrapped_selection(*selected, row_count, direction);
+    let max_scroll = discovery_scroll_limit(*context, query);
+    *scroll_offset = match direction {
+        MenuDirection::Previous => scroll_offset.saturating_sub(1),
+        MenuDirection::Next => scroll_offset.saturating_add(1).min(max_scroll),
+    };
 }
 
 fn move_view_options_selection(state: &mut AppState, direction: MenuDirection) {
@@ -2591,18 +2557,18 @@ mod tests {
             Some(&InputMode::CommandDiscovery {
                 context: BindingContext::Diff,
                 query: String::new(),
-                selected: 0,
+                scroll_offset: 0,
             })
         );
     }
 
     #[test]
-    fn command_discovery_filters_and_clamps_selection() {
+    fn command_discovery_ignores_typed_text() {
         let mut state = AppState::new(AppView::Log(LogView::default()));
         state.modes.push(InputMode::CommandDiscovery {
             context: BindingContext::Log,
-            query: "jj sho".to_owned(),
-            selected: 12,
+            query: String::new(),
+            scroll_offset: 12,
         });
         let mut source = JjLog::default();
 
@@ -2620,41 +2586,54 @@ mod tests {
             state.modes.active(),
             Some(&InputMode::CommandDiscovery {
                 context: BindingContext::Log,
-                query: "jj show".to_owned(),
-                selected: 0,
+                query: String::new(),
+                scroll_offset: 12,
             })
         );
     }
 
     #[test]
-    fn command_discovery_navigation_wraps_between_edges() {
+    fn command_discovery_navigation_scrolls_without_wrapping() {
         let mut state = AppState::new(AppView::Log(LogView::default()));
         state.modes.push(InputMode::CommandDiscovery {
             context: BindingContext::Log,
             query: String::new(),
-            selected: 0,
+            scroll_offset: 0,
         });
-        let row_count = filtered_discovery_len(BindingContext::Log, "");
+        let max_scroll = discovery_scroll_limit(BindingContext::Log, "");
 
-        move_command_discovery_selection(&mut state, MenuDirection::Previous);
+        move_command_discovery_scroll(&mut state, MenuDirection::Previous);
 
         assert_eq!(
             state.modes.active(),
             Some(&InputMode::CommandDiscovery {
                 context: BindingContext::Log,
                 query: String::new(),
-                selected: row_count - 1,
+                scroll_offset: 0,
             })
         );
 
-        move_command_discovery_selection(&mut state, MenuDirection::Next);
+        move_command_discovery_scroll(&mut state, MenuDirection::Next);
 
         assert_eq!(
             state.modes.active(),
             Some(&InputMode::CommandDiscovery {
                 context: BindingContext::Log,
                 query: String::new(),
-                selected: 0,
+                scroll_offset: 1,
+            })
+        );
+
+        for _ in 0..100 {
+            move_command_discovery_scroll(&mut state, MenuDirection::Next);
+        }
+
+        assert_eq!(
+            state.modes.active(),
+            Some(&InputMode::CommandDiscovery {
+                context: BindingContext::Log,
+                query: String::new(),
+                scroll_offset: max_scroll,
             })
         );
     }
@@ -2666,7 +2645,7 @@ mod tests {
         state.modes.push(InputMode::CommandDiscovery {
             context: BindingContext::Diff,
             query: "refresh".to_owned(),
-            selected: 0,
+            scroll_offset: 0,
         });
         let mut source = JjLog::default();
 
@@ -2690,7 +2669,7 @@ mod tests {
         state.modes.push(InputMode::CommandDiscovery {
             context: BindingContext::Log,
             query: String::new(),
-            selected: 0,
+            scroll_offset: 0,
         });
         let mut source = JjLog::default();
 

--- a/crates/jk/src/menus.rs
+++ b/crates/jk/src/menus.rs
@@ -1,5 +1,5 @@
 use jk_cli::{DiffFormat, LogTemplateSelection};
-use jk_tui::command_discovery::{BindingContext, filtered_discovery_len};
+use jk_tui::command_discovery::BindingContext;
 use jk_tui::diff_view::DiffView;
 
 #[derive(Clone, Copy)]
@@ -34,19 +34,6 @@ pub fn wrapped_selection(selected: usize, row_count: usize, direction: MenuDirec
     match direction {
         MenuDirection::Previous => selected.checked_sub(1).unwrap_or(row_count - 1),
         MenuDirection::Next => (selected + 1) % row_count,
-    }
-}
-
-pub fn clamp_command_discovery_selection(
-    context: BindingContext,
-    query: &str,
-    selected: &mut usize,
-) {
-    let row_count = filtered_discovery_len(context, query);
-    if row_count == 0 {
-        *selected = 0;
-    } else {
-        *selected = (*selected).min(row_count - 1);
     }
 }
 

--- a/crates/jk/src/rendering.rs
+++ b/crates/jk/src/rendering.rs
@@ -1,6 +1,7 @@
 use jk_cli::LogTemplateSelection;
-use jk_tui::command_discovery::discovery_lines;
+use jk_tui::command_discovery::{BindingContext, discovery_lines_for_width_and_rows};
 use jk_tui::command_preview_view::CommandPreviewView;
+use ratatui::prelude::{Color, Line, Modifier, Span, Style};
 
 use crate::command_mode::jj_command_lines;
 use crate::menus::{diff_file_list_lines, template_selector_lines, view_options_lines};
@@ -26,10 +27,10 @@ pub fn render_app(
             Some(InputMode::CommandDiscovery {
                 context,
                 query,
-                selected,
+                scroll_offset,
             }) => {
-                let lines = discovery_lines(*context, query, *selected);
-                log.render_with_selector(frame, "Command discovery", &lines);
+                log.render(frame);
+                render_command_discovery_overlay(frame, *context, query, *scroll_offset);
             }
             Some(InputMode::JjCommand { input, error }) => {
                 log.render(frame);
@@ -65,10 +66,10 @@ pub fn render_app(
             Some(InputMode::CommandDiscovery {
                 context,
                 query,
-                selected,
+                scroll_offset,
             }) => {
-                let lines = discovery_lines(*context, query, *selected);
-                view.render_with_overlay(frame, "Command discovery", &lines);
+                view.render(frame);
+                render_command_discovery_overlay(frame, *context, query, *scroll_offset);
             }
             Some(InputMode::JjCommand { input, error }) => {
                 let lines = jj_command_lines(input, error.as_deref());
@@ -88,11 +89,10 @@ pub fn render_app(
             Some(InputMode::CommandDiscovery {
                 context,
                 query,
-                selected,
+                scroll_offset,
             }) => {
-                let lines = discovery_lines(*context, query, *selected);
                 view.render(frame);
-                render_mode_overlay(frame, "Command discovery", &lines);
+                render_command_discovery_overlay(frame, *context, query, *scroll_offset);
             }
             Some(InputMode::JjCommand { input, error }) => {
                 view.render(frame);
@@ -105,11 +105,10 @@ pub fn render_app(
             Some(InputMode::CommandDiscovery {
                 context,
                 query,
-                selected,
+                scroll_offset,
             }) => {
-                let lines = discovery_lines(*context, query, *selected);
                 view.render(frame);
-                render_mode_overlay(frame, "Command discovery", &lines);
+                render_command_discovery_overlay(frame, *context, query, *scroll_offset);
             }
             Some(InputMode::JjCommand { input, error }) => {
                 view.render(frame);
@@ -127,11 +126,10 @@ pub fn render_app(
             Some(InputMode::CommandDiscovery {
                 context,
                 query,
-                selected,
+                scroll_offset,
             }) => {
-                let lines = discovery_lines(*context, query, *selected);
                 view.render(frame);
-                render_mode_overlay(frame, "Command discovery", &lines);
+                render_command_discovery_overlay(frame, *context, query, *scroll_offset);
             }
             Some(InputMode::JjCommand { input, error }) => {
                 view.render(frame);
@@ -168,10 +166,10 @@ fn render_inspection(
         Some(InputMode::CommandDiscovery {
             context,
             query,
-            selected,
+            scroll_offset,
         }) => {
-            let lines = discovery_lines(*context, query, *selected);
-            view.render_with_overlay(frame, "Command discovery", &lines);
+            view.render(frame);
+            render_command_discovery_overlay(frame, *context, query, *scroll_offset);
         }
         Some(InputMode::JjCommand { input, error }) => {
             let lines = jj_command_lines(input, error.as_deref());
@@ -181,9 +179,91 @@ fn render_inspection(
     }
 }
 
-fn render_mode_overlay(frame: &mut ratatui::Frame<'_>, title: &str, lines: &[String]) {
+fn render_command_discovery_overlay(
+    frame: &mut ratatui::Frame<'_>,
+    context: BindingContext,
+    query: &str,
+    scroll_offset: usize,
+) {
+    let content_width = command_discovery_format_width(frame);
+    let visible_rows = command_discovery_visible_rows(content_width, frame.area().height);
+    let lines = discovery_lines_for_width_and_rows(
+        context,
+        query,
+        scroll_offset,
+        content_width,
+        visible_rows,
+    );
+    // Size from the full rendered document, not the current scroll slice, so the Help box does not
+    // jump wider/narrower as different lines scroll into view.
+    let sizing_lines =
+        discovery_lines_for_width_and_rows(context, query, 0, content_width, usize::MAX);
+    // The overlay body lists close and quit explicitly. Hiding the underlying hotbar prevents
+    // duplicated controls from competing with the help content.
+    clear_overlay_status_row(frame);
+    render_mode_overlay_with_sizing(frame, "Command discovery", &lines, &sizing_lines);
+}
+
+fn clear_overlay_status_row(frame: &mut ratatui::Frame<'_>) {
     use ratatui::layout::Rect;
-    use ratatui::prelude::{Color, Line, Modifier, Span, Style, Text};
+    use ratatui::widgets::Clear;
+
+    let area = frame.area();
+    if area.is_empty() {
+        return;
+    }
+
+    let status_row = Rect {
+        x: area.x,
+        y: area.y.saturating_add(area.height.saturating_sub(1)),
+        width: area.width,
+        height: 1,
+    };
+    frame.render_widget(Clear, status_row);
+}
+
+fn command_discovery_format_width(frame: &ratatui::Frame<'_>) -> usize {
+    let area_width = usize::from(frame.area().width);
+    if area_width < 120 {
+        return area_width.saturating_sub(2);
+    }
+
+    area_width
+        .saturating_mul(9)
+        .saturating_div(10)
+        .min(132)
+        .saturating_sub(2)
+}
+
+const fn command_discovery_visible_rows(content_width: usize, area_height: u16) -> usize {
+    // Narrow Help reads like a document. Keep a stable viewport even in tall terminals so scrolling
+    // remains predictable instead of expanding into a long sheet that changes the user's spatial
+    // model.
+    if content_width < 80 {
+        return 12;
+    }
+
+    if area_height >= 40 {
+        34
+    } else if area_height >= 28 {
+        25
+    } else {
+        12
+    }
+}
+
+fn render_mode_overlay(frame: &mut ratatui::Frame<'_>, title: &str, lines: &[String]) {
+    render_mode_overlay_with_sizing(frame, title, lines, lines);
+}
+
+fn render_mode_overlay_with_sizing(
+    frame: &mut ratatui::Frame<'_>,
+    title: &str,
+    lines: &[String],
+    sizing_lines: &[String],
+) {
+    use ratatui::layout::Rect;
+    use ratatui::prelude::Text;
     use ratatui::widgets::{Block, Clear, Paragraph, Wrap};
 
     let area = frame.area();
@@ -197,8 +277,10 @@ fn render_mode_overlay(frame: &mut ratatui::Frame<'_>, title: &str, lines: &[Str
         width: area.width,
         height: area.height.saturating_sub(2),
     };
-    let width = 72_u16.min(content.width);
-    let height = u16::try_from(lines.len().saturating_add(4))
+    let width = u16::try_from(overlay_width(title, sizing_lines, content.width))
+        .unwrap_or(u16::MAX)
+        .min(content.width);
+    let height = u16::try_from(overlay_height(title, lines))
         .unwrap_or(u16::MAX)
         .min(content.height);
     let overlay = Rect {
@@ -209,18 +291,194 @@ fn render_mode_overlay(frame: &mut ratatui::Frame<'_>, title: &str, lines: &[Str
     };
     frame.render_widget(Clear, overlay);
 
-    let text = Text::from(
-        std::iter::once(Line::from(Span::styled(
-            title,
-            Style::new().add_modifier(Modifier::BOLD),
-        )))
-        .chain(std::iter::once(Line::from("")))
-        .chain(lines.iter().map(|line| Line::from(line.as_str())))
-        .collect::<Vec<_>>(),
-    );
+    let command_discovery = title == "Command discovery";
+    let display_title = if command_discovery { "Help" } else { title };
+    let mut text_lines = Vec::new();
+    if !command_discovery {
+        text_lines.push(Line::from(Span::styled(
+            display_title,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        )));
+        text_lines.push(Line::from(""));
+    }
+    text_lines.extend(lines.iter().map(|line| overlay_line(line)));
+    let text = Text::from(text_lines);
+    let mut block = Block::bordered();
+    if command_discovery {
+        block = block.title(Span::styled(
+            display_title,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ));
+    }
     let paragraph = Paragraph::new(text)
-        .block(Block::bordered())
+        .block(block)
         .style(Style::new().fg(Color::White).bg(Color::Black))
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, overlay);
+}
+
+fn overlay_width(title: &str, lines: &[String], area_width: u16) -> usize {
+    const COMMAND_DISCOVERY_MAX_WIDTH: usize = 132;
+
+    if title == "Command discovery" {
+        let content_width = lines
+            .iter()
+            .map(|line| line.chars().count())
+            .chain(std::iter::once("Help".chars().count()))
+            .max()
+            .unwrap_or(0);
+        let area_width = usize::from(area_width);
+        return content_width
+            .saturating_add(4)
+            .clamp(56, COMMAND_DISCOVERY_MAX_WIDTH)
+            .min(area_width);
+    }
+
+    let content_width = lines
+        .iter()
+        .map(|line| line.chars().count())
+        .chain(std::iter::once(title.chars().count()))
+        .max()
+        .unwrap_or(0);
+    content_width.saturating_add(4).clamp(56, 96)
+}
+
+fn overlay_height(title: &str, lines: &[String]) -> usize {
+    if title == "Command discovery" {
+        return lines.len().saturating_add(2);
+    }
+
+    lines.len().saturating_add(4)
+}
+
+fn overlay_line(line: &str) -> Line<'_> {
+    if line.ends_with(':') {
+        return Line::from(Span::styled(
+            line,
+            Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    if let Some(line) = command_row_line(line) {
+        return line;
+    }
+
+    if line.starts_with("Type ")
+        || line == "actions, and aliases."
+        || line.starts_with("Examples:")
+        || line.contains(" closes")
+        || line.starts_with("showing ")
+        || line.trim_start().starts_with("key ")
+    {
+        return Line::from(Span::styled(line, Style::new().fg(Color::Gray)));
+    }
+
+    if line.starts_with('>') {
+        return Line::from(Span::styled(
+            line,
+            Style::new().fg(Color::Green).add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    Line::from(line)
+}
+
+fn command_row_line(line: &str) -> Option<Line<'_>> {
+    if !line.starts_with("  ") || line.trim_start().starts_with("no matching") {
+        return None;
+    }
+
+    let mut spans = Vec::new();
+    let mut cursor = 0;
+    while let Some(prefix_start) = find_cell_prefix(line, cursor) {
+        if prefix_start > cursor {
+            spans.push(Span::raw(&line[cursor..prefix_start]));
+        }
+
+        let key_start = skip_spaces(line, prefix_start);
+        let separator_start = find_space_run(line, key_start, 2)?;
+        let separator_end = skip_spaces(line, separator_start);
+        let key = &line[key_start..separator_start];
+        if key.trim().is_empty() {
+            return None;
+        }
+
+        spans.push(Span::raw(&line[prefix_start..key_start]));
+        spans.push(Span::styled(
+            key,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(&line[separator_start..separator_end]));
+
+        let next_prefix = find_next_cell_prefix(line, separator_end);
+        let action_end = next_prefix.unwrap_or(line.len());
+        spans.push(Span::styled(
+            &line[separator_end..action_end],
+            Style::new().fg(Color::White),
+        ));
+
+        cursor = action_end;
+        if next_prefix.is_none() {
+            break;
+        }
+    }
+
+    if cursor < line.len() {
+        spans.push(Span::raw(&line[cursor..]));
+    }
+
+    Some(Line::from(spans))
+}
+
+fn find_next_cell_prefix(line: &str, start: usize) -> Option<usize> {
+    let mut cursor = start;
+    while let Some(prefix_start) = find_cell_prefix(line, cursor) {
+        let key_start = skip_spaces(line, prefix_start);
+        if find_space_run(line, key_start, 2).is_some() {
+            return Some(prefix_start);
+        }
+        cursor = key_start.saturating_add(1);
+    }
+    None
+}
+
+fn find_cell_prefix(line: &str, start: usize) -> Option<usize> {
+    let mut cursor = start;
+    while let Some(space_start) = find_space_run(line, cursor, 2) {
+        let key_start = skip_spaces(line, space_start);
+        if key_start < line.len() {
+            return Some(space_start);
+        }
+        cursor = key_start;
+    }
+    None
+}
+
+fn find_space_run(line: &str, start: usize, min_len: usize) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut cursor = start;
+    while cursor < bytes.len() {
+        if bytes[cursor] != b' ' {
+            cursor += 1;
+            continue;
+        }
+
+        let run_start = cursor;
+        while cursor < bytes.len() && bytes[cursor] == b' ' {
+            cursor += 1;
+        }
+        if cursor.saturating_sub(run_start) >= min_len {
+            return Some(run_start);
+        }
+    }
+    None
+}
+
+fn skip_spaces(line: &str, start: usize) -> usize {
+    let bytes = line.as_bytes();
+    let mut cursor = start;
+    while cursor < bytes.len() && bytes[cursor] == b' ' {
+        cursor += 1;
+    }
+    cursor
 }

--- a/crates/jk/src/state.rs
+++ b/crates/jk/src/state.rs
@@ -222,7 +222,7 @@ pub enum InputMode {
     CommandDiscovery {
         context: BindingContext,
         query: String,
-        selected: usize,
+        scroll_offset: usize,
     },
     DescribeMessage {
         rev: String,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,7 +55,8 @@ Add the two features that turn `jk` from an inspection helper into a daily jj TU
 
 - Add `:` jj command mode with optional `jj` prefix.
 - Add `!` external command mode without shell interpretation by default.
-- Add searchable contextual help so users can find actions by key, name, and jj command family.
+- Add contextual help and searchable command discovery so users can scan current actions and find
+  commands by key, name, and jj command family outside the Help overlay.
 - Record command history with argv, output, status, duration, and resulting operation.
 - Add `W` workspace screen backed by `jj workspace list`.
 - Add workspace actions for status, diff, update-stale, add, and forget.
@@ -186,13 +187,14 @@ Make `?` and the future hotbar generate from the same binding registry.
 - Acceptance: adding or remapping a key updates contextual help without hand-editing text.
 - Tests: key conflict tests and generated help snapshots.
 
-### Add Searchable Command Discovery
+### Add Contextual Help And Command Discovery
 
-Make help and command discovery searchable without replacing `:` command mode.
+Make Help scannable and make command discovery searchable without replacing `:` command mode.
 
-- Scope: help overlay, action registry metadata, command family tags, and filter input.
-- Acceptance: users can filter actions by key, action name, current screen, and jj command family.
-- Tests: action metadata tests, filter tests, and Betamax searchable-help tape.
+- Scope: help overlay, action registry metadata, command family tags, and command-mode suggestions.
+- Acceptance: Help answers "what can I do here?" at a glance, and users can search actions by key,
+  action name, current screen, and jj command family outside the Help overlay.
+- Tests: action metadata tests, command-discovery tests, and Betamax help tapes.
 
 ### Add Independent Scrolling And Ordered Marks
 

--- a/tapes/help-overlay-scroll-compact.tape
+++ b/tapes/help-overlay-scroll-compact.tape
@@ -1,0 +1,61 @@
+Output target/dogfood-artifacts/betamax/help-overlay-scroll-compact.gif
+Output target/dogfood-artifacts/betamax/help-overlay-scroll-compact-final-state.json
+
+Require cargo
+Require jj
+
+Set Shell "bash"
+Set Theme "Aardvark Ink"
+Set FontSize 22
+Set Width 720
+Set Height 640
+Set Padding 0
+Set Margin 20
+Set WindowBar Colorful
+Set BorderRadius 8
+Set CursorBlink false
+Set KeyboardOverlay Input
+Set TypingSpeed 20ms
+Set WaitTimeout 30s
+Env NO_COLOR "1"
+
+Hide
+Type "repo=${JK_REPO:-/Users/joshka/local/jk/help-overlays}"
+Enter
+Wait
+Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && echo JK_REPO_READY"
+Enter
+Wait+Screen "JK_REPO_READY"
+Type "cargo build --manifest-path Cargo.toml -p jk >/tmp/jk-help-overlay-scroll-compact-build.log 2>&1 && echo JK_BUILD_READY"
+Enter
+Wait+Screen "JK_BUILD_READY"
+Show
+
+Caption "Compact terminal: Help remains a scrolling reference."
+Type "./target/debug/jk -R . -n 8"
+Enter
+Wait+Screen "jk jj"
+Sleep 800ms
+Type "?"
+Wait+Screen "Open and inspect:"
+Sleep 800ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-compact-00-open.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-compact-00-open.json
+
+Caption "A single Down moves the help body up by one rendered line."
+Down
+Sleep 500ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-compact-01-down.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-compact-01-down.json
+Down
+Sleep 500ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-compact-02-down.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-compact-02-down.json
+
+Caption ""
+Escape
+Sleep 300ms
+Type "q"
+Hide
+Type "exit"
+Enter

--- a/tapes/help-overlay-scroll-narrow-tall.tape
+++ b/tapes/help-overlay-scroll-narrow-tall.tape
@@ -1,0 +1,57 @@
+Output target/dogfood-artifacts/betamax/help-overlay-scroll-narrow-tall.gif
+Output target/dogfood-artifacts/betamax/help-overlay-scroll-narrow-tall-final-state.json
+
+Require cargo
+Require jj
+
+Set Shell "bash"
+Set Theme "Aardvark Ink"
+Set FontSize 22
+Set Width 720
+Set Height 1050
+Set Padding 0
+Set Margin 20
+Set WindowBar Colorful
+Set BorderRadius 8
+Set CursorBlink false
+Set KeyboardOverlay Input
+Set TypingSpeed 20ms
+Set WaitTimeout 30s
+Env NO_COLOR "1"
+
+Hide
+Type "repo=${JK_REPO:-/Users/joshka/local/jk/help-overlays}"
+Enter
+Wait
+Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && echo JK_REPO_READY"
+Enter
+Wait+Screen "JK_REPO_READY"
+Type "cargo build --manifest-path Cargo.toml -p jk >/tmp/jk-help-overlay-scroll-narrow-tall-build.log 2>&1 && echo JK_BUILD_READY"
+Enter
+Wait+Screen "JK_BUILD_READY"
+Show
+
+Caption "Narrow but tall terminal: Help keeps a stable scrolling viewport."
+Type "./target/debug/jk -R . -n 8"
+Enter
+Wait+Screen "jk jj"
+Sleep 800ms
+Type "?"
+Wait+Screen "Open and inspect:"
+Sleep 800ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-narrow-tall-00-open.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-narrow-tall-00-open.json
+
+Caption "Down still scrolls one line instead of expanding to all content."
+Down
+Sleep 500ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-narrow-tall-01-down.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-narrow-tall-01-down.json
+
+Caption ""
+Escape
+Sleep 300ms
+Type "q"
+Hide
+Type "exit"
+Enter

--- a/tapes/help-overlay-scroll-wide.tape
+++ b/tapes/help-overlay-scroll-wide.tape
@@ -1,0 +1,57 @@
+Output target/dogfood-artifacts/betamax/help-overlay-scroll-wide.gif
+Output target/dogfood-artifacts/betamax/help-overlay-scroll-wide-final-state.json
+
+Require cargo
+Require jj
+
+Set Shell "bash"
+Set Theme "Aardvark Ink"
+Set FontSize 22
+Set Width 2850
+Set Height 1250
+Set Padding 0
+Set Margin 20
+Set WindowBar Colorful
+Set BorderRadius 8
+Set CursorBlink false
+Set KeyboardOverlay Input
+Set TypingSpeed 20ms
+Set WaitTimeout 30s
+Env NO_COLOR "1"
+
+Hide
+Type "repo=${JK_REPO:-/Users/joshka/local/jk/help-overlays}"
+Enter
+Wait
+Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && echo JK_REPO_READY"
+Enter
+Wait+Screen "JK_REPO_READY"
+Type "cargo build --manifest-path Cargo.toml -p jk >/tmp/jk-help-overlay-scroll-wide-build.log 2>&1 && echo JK_BUILD_READY"
+Enter
+Wait+Screen "JK_BUILD_READY"
+Show
+
+Caption "Wide terminal around 200x50 cells: Help uses aligned columns."
+Type "./target/debug/jk -R . -n 8"
+Enter
+Wait+Screen "jk jj"
+Sleep 800ms
+Type "?"
+Wait+Screen "Open and inspect:"
+Sleep 800ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-wide-00-open.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-wide-00-open.json
+
+Caption "Down leaves the fitted help stable when every command is visible."
+Down
+Sleep 500ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-wide-01-down.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-wide-01-down.json
+
+Caption ""
+Escape
+Sleep 300ms
+Type "q"
+Hide
+Type "exit"
+Enter

--- a/tapes/help-overlay-scroll.tape
+++ b/tapes/help-overlay-scroll.tape
@@ -1,0 +1,75 @@
+Output target/dogfood-artifacts/betamax/help-overlay-scroll.gif
+Output target/dogfood-artifacts/betamax/help-overlay-scroll-final-state.json
+
+Require cargo
+Require jj
+
+Set Shell "bash"
+Set Theme "Aardvark Ink"
+Set FontSize 22
+Set Width 1200
+Set Height 720
+Set Padding 0
+Set Margin 20
+Set WindowBar Colorful
+Set BorderRadius 8
+Set CursorBlink false
+Set KeyboardOverlay Input
+Set TypingSpeed 20ms
+Set WaitTimeout 30s
+Env NO_COLOR "1"
+
+Hide
+Type "repo=${JK_REPO:-/Users/joshka/local/jk/help-overlays}"
+Enter
+Wait
+Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && echo JK_REPO_READY"
+Enter
+Wait+Screen "JK_REPO_READY"
+Type "cargo build --manifest-path Cargo.toml -p jk >/tmp/jk-help-overlay-scroll-build.log 2>&1 && echo JK_BUILD_READY"
+Enter
+Wait+Screen "JK_BUILD_READY"
+Show
+
+Caption "Help opens as a contextual reference."
+Type "./target/debug/jk -R . -n 8"
+Enter
+Wait+Screen "jk jj"
+Sleep 800ms
+Type "?"
+Wait+Screen "Open and inspect:"
+Sleep 800ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-00-open.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-00-open.json
+
+Caption "Down should scroll the help content predictably."
+Down
+Sleep 500ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-01-down.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-01-down.json
+Down
+Sleep 500ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-02-down.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-02-down.json
+Down
+Sleep 500ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-03-down.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-03-down.json
+
+Caption "Up should reverse that scroll without jumping columns."
+Up
+Sleep 500ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-04-up.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-04-up.json
+Up
+Sleep 500ms
+Screenshot target/dogfood-artifacts/betamax/help-overlay-scroll-05-up.png
+State target/dogfood-artifacts/betamax/help-overlay-scroll-05-up.json
+
+Caption ""
+Escape
+Sleep 300ms
+Type "q"
+Hide
+Type "exit"
+Enter

--- a/tapes/help-overlays.tape
+++ b/tapes/help-overlays.tape
@@ -1,0 +1,102 @@
+Output target/dogfood-artifacts/betamax/help-overlays.gif
+Output target/dogfood-artifacts/betamax/help-overlays-final-state.json
+
+Require cargo
+Require jj
+
+Set Shell "bash"
+Set Theme "Aardvark Ink"
+Set FontSize 22
+Set Width 1200
+Set Height 720
+Set Padding 0
+Set Margin 20
+Set WindowBar Colorful
+Set BorderRadius 8
+Set CursorBlink false
+Set KeyboardOverlay Input
+Set TypingSpeed 20ms
+Set WaitTimeout 30s
+Env NO_COLOR "1"
+
+Hide
+Type "repo=${JK_REPO:-/Users/joshka/local/jk/help-overlays}"
+Enter
+Wait
+Type "cd \"$repo\" && test -f Cargo.toml && test -d .jj && echo JK_REPO_READY"
+Enter
+Wait+Screen "JK_REPO_READY"
+Type "cargo build --manifest-path Cargo.toml -p jk >/tmp/jk-help-overlays-build.log 2>&1 && echo JK_BUILD_READY"
+Enter
+Wait+Screen "JK_BUILD_READY"
+Show
+
+Caption "Press ? to open contextual help for the current screen."
+Type "./target/debug/jk -R . -n 8"
+Enter
+Wait+Screen "jk jj"
+Sleep 800ms
+Type "?"
+Wait+Screen "Open and inspect:"
+Sleep 1200ms
+Screenshot target/dogfood-artifacts/betamax/help-overlays-log.png
+State target/dogfood-artifacts/betamax/help-overlays-log.json
+
+Caption "Diff help groups file movement, folding, search, and return controls."
+Type "d"
+Wait+Screen "jk jj diff"
+Sleep 600ms
+Type "?"
+Wait+Screen "Move and find:"
+Sleep 1200ms
+Screenshot target/dogfood-artifacts/betamax/help-overlays-diff.png
+State target/dogfood-artifacts/betamax/help-overlays-diff.json
+Escape
+Sleep 300ms
+
+Caption "Workspace help keeps workspace-specific actions together."
+Type "W"
+Wait+Screen "jk jj workspace"
+Sleep 600ms
+Type "?"
+Wait+Screen "Open log"
+Sleep 1200ms
+Screenshot target/dogfood-artifacts/betamax/help-overlays-workspaces.png
+State target/dogfood-artifacts/betamax/help-overlays-workspaces.json
+Escape
+Sleep 300ms
+
+Caption "Command history help centers the retained command workflow."
+Type "C"
+Wait+Screen "Command History"
+Sleep 600ms
+Type "?"
+Wait+Screen "Open command details"
+Sleep 1200ms
+Screenshot target/dogfood-artifacts/betamax/help-overlays-command-history.png
+State target/dogfood-artifacts/betamax/help-overlays-command-history.json
+Escape
+Sleep 300ms
+Escape
+Sleep 300ms
+Type "L"
+Wait+Screen "jk jj"
+Sleep 300ms
+
+Caption "Operation log help keeps recovery and operation inspection visible."
+Type "o"
+Wait+Screen "op log"
+Sleep 600ms
+Type "?"
+Wait+Screen "Open show"
+Sleep 1200ms
+Screenshot target/dogfood-artifacts/betamax/help-overlays-operation-log.png
+State target/dogfood-artifacts/betamax/help-overlays-operation-log.json
+
+Caption ""
+Escape
+Sleep 300ms
+Type "q"
+Hide
+Type "exit"
+Enter


### PR DESCRIPTION
## Summary

- Rework contextual help into searchable, grouped command discovery overlays.
- Make command discovery scroll as a static help document, with aligned two-column layout when width allows and compact single-column rendering on small terminals.
- Add Betamax tapes for affected help screens, scroll behavior, compact width, and wide layout; document demo cleanup, PNG, and dwell-time guidance in AGENTS.md.

## Validation

- `just fmt-check`
- `just test`
- `just clippy`
- `betamax validate tapes/help-overlays.tape tapes/help-overlay-scroll.tape tapes/help-overlay-scroll-compact.tape tapes/help-overlay-scroll-wide.tape`
- `markdownlint-cli2 AGENTS.md`
- `betamax run tapes/help-overlay-scroll-wide.tape && betamax run tapes/help-overlay-scroll.tape && betamax run tapes/help-overlay-scroll-compact.tape`
- `cargo install --path crates/jk`

## Visual proof

Fresh local PNGs were captured with cache-busting filenames:

- Wide open: `/Users/joshka/local/jk/help-overlays/target/dogfood-artifacts/betamax/help-overlay-scroll-wide-00-open-20260624012332.png`
- Wide after Down: `/Users/joshka/local/jk/help-overlays/target/dogfood-artifacts/betamax/help-overlay-scroll-wide-01-down-20260624012332.png`
- Normal open: `/Users/joshka/local/jk/help-overlays/target/dogfood-artifacts/betamax/help-overlay-scroll-00-open-20260624012332.png`
- Compact open: `/Users/joshka/local/jk/help-overlays/target/dogfood-artifacts/betamax/help-overlay-scroll-compact-00-open-20260624012332.png`
